### PR TITLE
feat: パスキー認証ページのスキップ処理と機体画像URL取得の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Output directory
+output/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.19-alpine
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY *.go ./
+
+RUN go build -o scraper .
+
+ENTRYPOINT ["./scraper"]

--- a/csv_export.go
+++ b/csv_export.go
@@ -12,7 +12,7 @@ func exportAllScoresCSV(ds DatedScores, w io.Writer) error {
 	csvw := csv.NewWriter(w)
 	defer csvw.Flush()
 
-	header := []string{"試合日時", "プレイヤーNo.", "地域", "プレイヤー名", "勝利判定", "スコア", "撃墜数", "被撃墜数", "与ダメージ", "被ダメージ", "EXダメージ"}
+	header := []string{"試合日時", "プレイヤーNo.", "地域", "プレイヤー名", "勝利判定", "機体画像URL", "スコア", "撃墜数", "被撃墜数", "与ダメージ", "被ダメージ", "EXダメージ"}
 	if err := csvw.Write(header); err != nil {
 		return err
 	}
@@ -24,6 +24,7 @@ func exportAllScoresCSV(ds DatedScores, w io.Writer) error {
 			d.PlayerScore.City,
 			d.PlayerScore.Name,
 			d.PlayerScore.Win,
+			d.PlayerScore.MsImage,
 			strconv.Itoa(d.PlayerScore.Point),
 			strconv.Itoa(d.PlayerScore.Kills),
 			strconv.Itoa(d.PlayerScore.Deaths),

--- a/login.go
+++ b/login.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strings"
 )
 
 // Note:
@@ -140,14 +141,117 @@ func (c *client) login() error {
 		log.Fatal(err)
 	}
 
-	// Request to auth page
-	auth_page, err := c.httpClient.Get(l.RedirectUrl)
-	if err != nil {
-		log.Fatal(err)
+	// パスキーページへのリダイレクトの場合、passkey/info APIを呼んでスキップする
+	if strings.Contains(l.RedirectUrl, "passkey") {
+		err = c.skipPasskey(l)
+	} else {
+		// パスキーページでない場合は従来通り
+		auth_page, err := c.httpClient.Get(l.RedirectUrl)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer auth_page.Body.Close()
 	}
-	defer auth_page.Body.Close()
 
 	return err
+}
+
+// Note: パスキー設定ページが表示された場合に「あとで」ボタン相当の処理を行い、OAuth認証を完了する
+// passkey/info APIにログインCookieをJSON形式で渡し、レスポンスのbtn-next URLにアクセスする
+func (c *client) skipPasskey(l loginResponce) error {
+	parsedURL, err := url.Parse(l.RedirectUrl)
+	if err != nil {
+		return err
+	}
+	q := parsedURL.Query()
+
+	// ブラウザのJSと同様に、cookieクエリパラメータにログインCookieをJSON形式で渡す
+	cookieJSON := map[string]string{"language": "ja"}
+	if l.Cookie.Login.Name != "" {
+		cookieJSON[l.Cookie.Login.Name] = l.Cookie.Login.Value
+	}
+	if l.Cookie.LoginCheck.Name != "" {
+		cookieJSON[l.Cookie.LoginCheck.Name] = l.Cookie.LoginCheck.Value
+	}
+	if l.Cookie.Common.Name != "" {
+		cookieJSON[l.Cookie.Common.Name] = l.Cookie.Common.Value
+	}
+	if l.Cookie.Mnw.Name != "" {
+		cookieJSON[l.Cookie.Mnw.Name] = l.Cookie.Mnw.Value
+	}
+	if l.Cookie.Retention.Name != "" {
+		cookieJSON[l.Cookie.Retention.Name] = l.Cookie.Retention.Value
+	}
+	if l.Cookie.RetentionTmp.Name != "" {
+		cookieJSON[l.Cookie.RetentionTmp.Name] = l.Cookie.RetentionTmp.Value
+	}
+	cookieBytes, _ := json.Marshal(cookieJSON)
+
+	// passkey/info APIを呼ぶ（「あとで」ボタンと同じリクエスト）
+	params := url.Values{}
+	params.Set("client_id", q.Get("client_id"))
+	params.Set("backto", q.Get("backto"))
+	params.Set("redirect_uri", q.Get("redirect_uri"))
+	params.Set("customize_id", q.Get("customize_id"))
+	params.Set("code", q.Get("code"))
+	params.Set("language", "ja")
+	params.Set("cookie", string(cookieBytes))
+
+	passkeyInfoURL := "https://account-api.bandainamcoid.com/v3/passkey/info?" + params.Encode()
+	skipResp, err := c.httpClient.Get(passkeyInfoURL)
+	if err != nil {
+		return err
+	}
+	defer skipResp.Body.Close()
+
+	var passkeyResp map[string]interface{}
+	if err := json.NewDecoder(skipResp.Body).Decode(&passkeyResp); err != nil {
+		return err
+	}
+
+	// data.btn.btn-next.urlから「あとで」ボタンのリダイレクト先を取得
+	redirectURL := ""
+	if data, ok := passkeyResp["data"].(map[string]interface{}); ok {
+		if btn, ok := data["btn"].(map[string]interface{}); ok {
+			if btnNext, ok := btn["btn-next"].(map[string]interface{}); ok {
+				if u, ok := btnNext["url"].(string); ok {
+					redirectURL = u
+				}
+			}
+		}
+	}
+
+	if redirectURL == "" {
+		log.Fatal("passkey/info APIからリダイレクトURLを取得できませんでした")
+	}
+
+	// passkeyInfoProd Cookieをセット（ブラウザのcookie_processingと同等）
+	if cookie, ok := passkeyResp["cookie"].(map[string]interface{}); ok {
+		if pi, ok := cookie["passkey_info"].(map[string]interface{}); ok {
+			if name, ok := pi["name"].(string); ok {
+				if value, ok := pi["value"].(string); ok {
+					accountURL, _ := url.Parse("https://account.bandainamcoid.com/")
+					c.httpClient.Jar.SetCookies(accountURL, []*http.Cookie{{Name: name, Value: value}})
+				}
+			}
+		}
+	}
+
+	// ログインCookieを.bandainamcoid.comドメインにもセット（OAuth URLに送信されるように）
+	bnidURL, _ := url.Parse("https://www.bandainamcoid.com/")
+	c.httpClient.Jar.SetCookies(bnidURL, []*http.Cookie{
+		{Name: l.Cookie.Common.Name, Value: l.Cookie.Common.Value, Domain: ".bandainamcoid.com", Path: "/"},
+		{Name: l.Cookie.Mnw.Name, Value: l.Cookie.Mnw.Value, Domain: ".bandainamcoid.com", Path: "/"},
+	})
+
+	// OAuth URLにアクセスしてvsmobileのセッションを確立
+	authPage, err := c.httpClient.Get(redirectURL)
+	if err != nil {
+		return err
+	}
+	defer authPage.Body.Close()
+
+	return nil
 }
 
 func NewCookieJar(username, password string) (http.CookieJar, error) {

--- a/scraper.go
+++ b/scraper.go
@@ -21,6 +21,7 @@ type PlayerScore struct {
 	City           string
 	Name           string
 	Win            string
+	MsImage        string
 	Point          int
 	Kills          int
 	Deaths         int
@@ -144,9 +145,11 @@ func Scraiping(username, password string) DatedScores {
 		selector_right_value := "div.w55 > dl > dd"
 		selector_city := "div.w80.ta-r > p.col-stand"
 		selector_name := "p.mb-ss.fz-m > span.name"
+		selector_ms_image := "img.item-icon-img"
 
 		cities := e.ChildTexts(selector_city)
 		names := e.ChildTexts(selector_name)
+		msImages := e.ChildAttrs(selector_ms_image, "src")
 		left_value := e.ChildTexts(selector_left_value)   //スコア・撃墜・被撃墜
 		right_value := e.ChildTexts(selector_right_value) //与ダメ・被ダメ・EXダメ
 
@@ -166,6 +169,10 @@ func Scraiping(username, password string) DatedScores {
 			city := cities[i]                                  //地域
 			name := names[i]                                   //プレイヤー名
 			win := wins[i]                                     //勝ち負け
+			msImage := ""                                      //機体画像URL
+			if i < len(msImages) {
+				msImage = msImages[i]
+			}
 			point := parseNumber(left_value[0+offL])           // スコアポイント
 			kills := parseNumber(left_value[1+offL])              // 撃墜
 			deaths := parseNumber(left_value[2+offL])            // 被撃墜
@@ -180,6 +187,7 @@ func Scraiping(username, password string) DatedScores {
 					city,
 					name,
 					win,
+					msImage,
 					point,
 					kills,
 					deaths,
@@ -212,6 +220,7 @@ func (ds DatedScores) getscores(t time.Time, format func(time.Time) time.Time) P
 				v.PlayerScore.City,
 				v.PlayerScore.Name,
 				v.PlayerScore.Win,
+				v.PlayerScore.MsImage,
 				v.PlayerScore.Point,
 				v.PlayerScore.Kills,
 				v.PlayerScore.Deaths,


### PR DESCRIPTION
  ## Summary
  - バンダイナムコIDのパスキー設定ページ追加に伴い、ログイン処理が動作しなくなっていた問題を修正
  - passkey/info APIを呼び出してパスキーページをスキップする `skipPasskey` メソッドを追加
  - 戦績詳細ページから機体画像URLを取得してCSVに出力する機能を追加
  - Docker環境でのビルド・実行用のDockerfileを追加

  ## Test plan
  - [x] Docker環境でビルドが通ることを確認
  - [x] ログイン → パスキースキップ → 戦績ページへのアクセスが成功することを確認
  - [x] CSVに戦績データが出力されることを確認
  - [x] 機体画像URLがCSVに含まれていることを確認

  🤖 Generated with [Claude Code](https://claude.com/claude-code)