### PR TITLE
feat: CSV重複排除と既存戦歴のスクレイピングスキップ

### DIFF
--- a/csv_export.go
+++ b/csv_export.go
@@ -5,7 +5,45 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"time"
 )
+
+// getLatestDatetime は既存CSVファイルから最新の試合日時を取得する。
+// ファイルが存在しない場合はゼロ値のtimeを返す。
+func getLatestDatetime(path string) (time.Time, error) {
+	var latest time.Time
+	layout := "2006-01-02 15:04"
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return latest, nil
+		}
+		return latest, err
+	}
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	records, err := r.ReadAll()
+	if err != nil {
+		return latest, err
+	}
+
+	for i, row := range records {
+		if i == 0 || len(row) == 0 {
+			continue // ヘッダースキップ
+		}
+		t, err := time.Parse(layout, row[0])
+		if err != nil {
+			continue
+		}
+		if t.After(latest) {
+			latest = t
+		}
+	}
+
+	return latest, nil
+}
 
 // exportAllScoresCSV writes all DatedScore entries to the provided writer as CSV.
 func exportAllScoresCSV(ds DatedScores, w io.Writer) error {
@@ -41,12 +79,54 @@ func exportAllScoresCSV(ds DatedScores, w io.Writer) error {
 	return nil
 }
 
-// SaveAllScoresCSV creates (or truncates) the file at path and writes CSV into it.
+// SaveAllScoresCSV は既存CSVに新しいレコードのみ追記する。
+// ファイルが存在しない場合は新規作成する。
 func SaveAllScoresCSV(ds DatedScores, path string) error {
-	f, err := os.Create(path)
+	// ファイルが存在しない場合は新規作成（ヘッダー付き）
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		f, err := os.Create(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		return exportAllScoresCSV(ds, f)
+	}
+
+	// 新しいレコードがなければ何もしない
+	if len(ds) == 0 {
+		return nil
+	}
+
+	// 既存ファイルに追記（ヘッダーなし）
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
-	return exportAllScoresCSV(ds, f)
+
+	csvw := csv.NewWriter(f)
+	defer csvw.Flush()
+
+	for _, d := range ds {
+		row := []string{
+			d.Datatime.Format("2006-01-02 15:04"),
+			strconv.Itoa(d.PlayerNo),
+			d.PlayerScore.City,
+			d.PlayerScore.Name,
+			d.PlayerScore.Win,
+			d.PlayerScore.MsName,
+			d.PlayerScore.MsImage,
+			strconv.Itoa(d.PlayerScore.Point),
+			strconv.Itoa(d.PlayerScore.Kills),
+			strconv.Itoa(d.PlayerScore.Deaths),
+			strconv.Itoa(d.PlayerScore.Give_damage),
+			strconv.Itoa(d.PlayerScore.Receive_damage),
+			strconv.Itoa(d.PlayerScore.Ex_damage),
+		}
+		if err := csvw.Write(row); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -19,7 +19,16 @@ func main() {
 	// ms_list.json をCSVと同じディレクトリに配置
 	msListPath := filepath.Join(filepath.Dir(csvPath), "ms_list.json")
 
-	datedScores := Scraiping(username, password)
+	// 既存CSVの最新日時を取得し、それ以降の戦歴のみスクレイピング
+	since, err := getLatestDatetime(csvPath)
+	if err != nil {
+		log.Printf("[WARN] Failed to read existing CSV: %v", err)
+	}
+	if !since.IsZero() {
+		log.Printf("[INFO] Fetching scores after %s", since.Format("2006-01-02 15:04"))
+	}
+
+	datedScores := Scraiping(username, password, since)
 
 	// 機体名マッピング: ファイルがあればそこから読む、なければスクレイピングして保存
 	msList, err := LoadMSList(msListPath)

--- a/scraper.go
+++ b/scraper.go
@@ -174,7 +174,8 @@ func dateFormatMonthly(t time.Time) time.Time {
 }
 
 // スクレイピング処理を実行し、DatedScoresを返す
-func Scraiping(username, password string) DatedScores {
+// since より新しい戦歴のみ取得する。ゼロ値の場合は全件取得する。
+func Scraiping(username, password string, since time.Time) DatedScores {
 
 	var (
 		scores     DatedScores
@@ -201,6 +202,14 @@ func Scraiping(username, password string) DatedScores {
 		r := regexp.MustCompile(`\(.*`)
 		date = r.ReplaceAllString(e.ChildText("p.datetime.fz-ss"), "") // 2022/10/15(土) -> 2022/10/15
 
+		// since の日付より前の日はスキップ
+		if !since.IsZero() {
+			d, err := time.Parse("2006/01/02", date)
+			if err == nil && d.Before(since.Truncate(24*time.Hour)) {
+				return
+			}
+		}
+
 		link := e.ChildAttr("a", "href")
 
 		dailypage.Visit(link)
@@ -210,6 +219,14 @@ func Scraiping(username, password string) DatedScores {
 	dailypage.OnHTML("li.item", func(e *colly.HTMLElement) {
 
 		hour = e.ChildText("p.datetime.fz-ss")
+
+		// since 以前の試合はスキップ
+		if !since.IsZero() {
+			t, err := time.Parse("2006/01/02 15:04", date+" "+hour)
+			if err == nil && !t.After(since) {
+				return
+			}
+		}
 
 		// 判定: リンクの class に "win" が含まれるかで、1-2 人目が勝ち / 3-4 人目が負けとする
 		if e.ChildAttr("a", "class") == "right-arrow vs-detail win" {


### PR DESCRIPTION
既存CSVの最新日時を基準に、取得済みの戦歴はスクレイピング自体をスキップし、
新しいレコードのみCSVに追記する仕組みを追加。