### PR TITLE
feat: マルチステージビルドでGo+Python統合Docker環境を構築

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine
+FROM golang:1.19-alpine AS builder
 
 WORKDIR /app
 
@@ -6,7 +6,20 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY *.go ./
-
 RUN go build -o scraper .
 
-ENTRYPOINT ["./scraper"]
+FROM python:3.11-alpine
+
+WORKDIR /app
+
+# Goバイナリをコピー
+COPY --from=builder /app/scraper .
+
+# Python分析スクリプトをコピー
+COPY analyze.py .
+
+# エントリポイント
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+USERNAME="$1"
+PASSWORD="$2"
+OUTPUT_DIR="${3:-/output}"
+
+if [ -z "$USERNAME" ] || [ -z "$PASSWORD" ]; then
+  echo "Usage: $0 <username> <password> [output_dir]"
+  exit 1
+fi
+
+CSV_PATH="$OUTPUT_DIR/scores.csv"
+
+echo "[INFO] Starting scraping..."
+./scraper "$USERNAME" "$PASSWORD" "$CSV_PATH"
+
+echo "[INFO] Starting analysis..."
+python3 analyze.py "$CSV_PATH"
+
+echo "[INFO] Done! Output files:"
+ls -la "$OUTPUT_DIR"/*.csv "$OUTPUT_DIR"/*.md "$OUTPUT_DIR"/*.json 2>/dev/null || true


### PR DESCRIPTION
## Summary
- マルチステージビルドでGo(スクレイピング)+Python(分析)を1コンテナに統合
- `docker run` 1コマンドでスクレイピング→分析→レポート出力まで完了
- ローカルとCloud Runで同じイメージが動く構成

## 変更内容
- **Dockerfile**: マルチステージビルド化（Go builder → Python alpine実行環境）
- **entrypoint.sh**: スクレイピング→分析の一括実行スクリプト

## 使い方
```bash
docker build -t scraper-gundam .
docker run --rm -v $(pwd)/output:/output scraper-gundam $EMAIL $PASS
```
`output/` に `scores.csv`, `ms_list.json`, `report.md` が出力されます。

## Test plan
- [x] `docker build` が成功する
- [x] `docker run` でスクレイピング+分析が一括実行される
- [x] output/report.md が生成される

Closes #26
Ref #28