### PR TITLE
fix: CIをPRのみに変更 + mainブランチ保護を設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- CIのトリガーからmainへのpushを削除（PRのみに変更）
- mainブランチの保護ルールを設定（PR必須、直接push不可）

## 設定内容
- mainへの直接pushを禁止
- PRを経由したマージのみ許可
- approve不要（個人開発のため）
- force pushを禁止

## Test plan
- [x] PRでCIが動作する
- [x] マージ後にCIが走らずCDだけ走る

🤖 Generated with [Claude Code](https://claude.com/claude-code)