### PR TITLE
feat: MSリスト自動更新の仕組みを追加

### DIFF
--- a/.github/workflows/update-mslist.yml
+++ b/.github/workflows/update-mslist.yml
@@ -1,0 +1,54 @@
+name: Update MS List
+
+on:
+  schedule:
+    - cron: "0 18 * * *"  # 毎日 18:00 UTC（日本時間 03:00）
+  workflow_dispatch:  # 手動実行も可能
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Random delay (0-180 min)
+        run: sleep $((RANDOM % 10800))
+
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+
+      - name: Run update-mslist
+        env:
+          USERNAME: ${{ secrets.USERNAME }}
+          PASSWORD: ${{ secrets.PASSWORD }}
+        run: go run ./cmd/update-mslist
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet data/ms_list.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create PR
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="auto/update-mslist-$(date +%Y%m%d)"
+          git checkout -b "$BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/ms_list.json
+          git commit -m "chore: MSリストを自動更新"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: MSリストを自動更新" \
+            --body "GitHub Actionsによる自動更新です。新機体の追加や名前の変更があれば差分を確認してマージしてください。"

--- a/cmd/update-mslist/main.go
+++ b/cmd/update-mslist/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/yuki9431/exvs-analyzer/internal/model"
+	"github.com/yuki9431/exvs-analyzer/internal/scraper"
+)
+
+func main() {
+	username := os.Getenv("USERNAME")
+	password := os.Getenv("PASSWORD")
+
+	if username == "" || password == "" {
+		log.Fatal("USERNAME and PASSWORD are required")
+	}
+
+	outputPath := "data/ms_list.json"
+	if len(os.Args) > 1 {
+		outputPath = os.Args[1]
+	}
+
+	log.Println("Scraping MS list...")
+	msList := scraper.ScrapeMSList(username, password)
+
+	if len(msList) == 0 {
+		log.Fatal("No MS data found")
+	}
+
+	if err := model.SaveMSList(msList, outputPath); err != nil {
+		log.Fatalf("Failed to save MS list: %v", err)
+	}
+
+	fmt.Printf("Saved %d MS entries to %s\n", len(msList), outputPath)
+}


### PR DESCRIPTION
## Summary
- `cmd/update-mslist`: ScrapeMSListをCLIから実行するコマンドを追加
- GitHub Actionsで毎日03:00-06:00 JST（ランダムスリープ）に実行
- ms_list.jsonに変更があればPRを自動作成

## 必要なSecrets
- `USERNAME` ✅ 設定済み
- `PASSWORD` ✅ 設定済み

## Test plan
- [x] CIが通る
- [x] workflow_dispatchで手動実行して動作確認
- [x] 変更があればPRが自動作成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)