### PR TITLE
fix: 手動実行時はランダムスリープをスキップ

### DIFF
--- a/.github/workflows/update-mslist.yml
+++ b/.github/workflows/update-mslist.yml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
       - name: Random delay (0-180 min)
+        if: github.event_name == 'schedule'
         run: sleep $((RANDOM % 10800))
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- `workflow_dispatch`（手動実行）時はランダムスリープをスキップして即時実行
- スケジュール実行時のみ0-180分のランダム遅延を適用

🤖 Generated with [Claude Code](https://claude.com/claude-code)