### PR TITLE
fix: MSリスト更新ブランチ名に時刻を含めて衝突を防止

### DIFF
--- a/.github/workflows/update-mslist.yml
+++ b/.github/workflows/update-mslist.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH="auto/update-mslist-$(date +%Y%m%d)"
+          BRANCH="auto/update-mslist-$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- ブランチ名を `auto/update-mslist-YYYYMMDD` → `auto/update-mslist-YYYYMMDD-HHMMSS` に変更
- 同じ日に複数回実行してもブランチ名が衝突しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)