### PR TITLE
refactor: GCPインフラ識別子を環境変数/Secretsに移行

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,17 +17,18 @@ jobs:
       - id: auth
         uses: google-github-actions/auth@v3
         with:
-          workload_identity_provider: "projects/483014325656/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
-          service_account: "github-actions@exvs2ib-analyzer.iam.gserviceaccount.com"
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
       - uses: google-github-actions/setup-gcloud@v3
 
       - name: Build and push image
-        run: gcloud builds submit --tag gcr.io/exvs2ib-analyzer/exvs-analyzer
+        run: gcloud builds submit --tag ${{ vars.GCR_IMAGE }}
 
       - name: Deploy to Cloud Run
         run: |
           gcloud run deploy exvs-analyzer \
-            --image gcr.io/exvs2ib-analyzer/exvs-analyzer \
+            --image ${{ vars.GCR_IMAGE }} \
             --region asia-northeast1 \
+            --set-env-vars "GCS_BUCKET=${{ vars.GCS_BUCKET }}" \
             --allow-unauthenticated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ PORT=3000 make run
 
 http://localhost:8080 でアクセス可能。
 
-GoテストおよびMakefileは存在しない。CIでは `go vet`、`go build`、`py_compile` のみ実行。
+CIでは `go vet`、`go test`、`go build`、`py_compile` を実行。
 
 ## アーキテクチャ
 
@@ -69,6 +69,11 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 
 - **Go 1.26**、Webフレームワーク不使用（標準 `net/http`）
 - **Python 3.11** で分析（pip依存なし）
-- GCSバケット: `exvs2ib-analyzer-data`、ユーザーキーは SHA256(email)[:8] の16進数
+- GCSバケットは環境変数 `GCS_BUCKET` で指定、ユーザーキーは SHA256(email)[:8] の16進数
 - Cloud Runデプロイ、`PORT` 環境変数（デフォルト 8080）
+
+## セキュリティルール
+
+- **GCPプロジェクトID、バケット名、サービスアカウント等のインフラ識別子をコードやCLAUDE.mdにハードコードしない。** 環境変数またはGitHub Secrets/Variablesを使うこと。
+- 公開リポジトリのため、コミット履歴にも残ることを意識する。
 - マルチステージDockerfile: `golang:1.26-alpine` でビルド、`python:3.11-alpine` で実行

--- a/internal/storage/cloud_storage.go
+++ b/internal/storage/cloud_storage.go
@@ -12,10 +12,8 @@ import (
 	"cloud.google.com/go/storage"
 )
 
-const (
-	// BucketName はCloud Storageのバケット名
-	BucketName = "exvs2ib-analyzer-data"
-)
+// BucketName は環境変数 GCS_BUCKET から取得するCloud Storageのバケット名
+var BucketName = os.Getenv("GCS_BUCKET")
 
 // UserKey はメールアドレスからユーザー固有のキーを生成する
 func UserKey(email string) string {


### PR DESCRIPTION
## Summary
- GCSバケット名を環境変数 `GCS_BUCKET` に移行（`cloud_storage.go`）
- cd.ymlのWIF設定を GitHub Secrets (`WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`) に移行
- GCRイメージパスを GitHub Variables (`GCR_IMAGE`, `GCS_BUCKET`) に移行
- CLAUDE.mdにセキュリティルール（インフラ識別子をハードコードしない）を追記

## マージ前に必要な作業
Settings > Secrets and variables > Actions で以下を設定してください。値は既存のcd.ymlから削除したものを使用。

**Secrets:**
| 名前 | 設定する値 |
|------|-----------|
| `WIF_PROVIDER` | Workload Identity Federationのプロバイダーパス |
| `WIF_SERVICE_ACCOUNT` | GitHub Actions用サービスアカウントのメールアドレス |

**Variables:**
| 名前 | 設定する値 |
|------|-----------|
| `GCR_IMAGE` | GCRのイメージパス |
| `GCS_BUCKET` | Cloud Storageのバケット名 |

## Test plan
- [x] GitHub Secrets/Variables を設定する
- [x] `make test` が通ること（確認済み）
- [x] マージ後、CDが正常にデプロイされること