### PR TITLE
feat: MSリスト自動更新にバリデーションCIとauto-mergeを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,49 @@ jobs:
 
       - name: Python syntax check
         run: python -m py_compile scripts/analyze.py
+
+  validate-mslist:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.title, 'MSリスト')
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate ms_list.json
+        run: |
+          python3 -c "
+          import json, sys
+
+          with open('data/ms_list.json') as f:
+              data = json.load(f)
+
+          # 空でないこと
+          if len(data) == 0:
+              print('ERROR: ms_list.json is empty')
+              sys.exit(1)
+
+          # 必須フィールドチェック
+          for i, ms in enumerate(data):
+              if not ms.get('Name'):
+                  print(f'ERROR: entry {i} has empty Name')
+                  sys.exit(1)
+              if not ms.get('ImageURL'):
+                  print(f'ERROR: entry {i} has empty ImageURL')
+                  sys.exit(1)
+
+          # 機体数が減っていないこと（mainブランチと比較）
+          import subprocess
+          result = subprocess.run(
+              ['git', 'show', 'origin/main:data/ms_list.json'],
+              capture_output=True, text=True
+          )
+          if result.returncode == 0:
+              main_data = json.loads(result.stdout)
+              if len(data) < len(main_data):
+                  print(f'ERROR: MS count decreased ({len(main_data)} -> {len(data)})')
+                  sys.exit(1)
+              print(f'OK: {len(main_data)} -> {len(data)} entries')
+          else:
+              print(f'OK: {len(data)} entries (no main branch to compare)')
+          "

--- a/.github/workflows/update-mslist.yml
+++ b/.github/workflows/update-mslist.yml
@@ -39,6 +39,7 @@ jobs:
           fi
 
       - name: Create PR
+        id: create-pr
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -50,6 +51,13 @@ jobs:
           git add data/ms_list.json
           git commit -m "chore: MSリストを自動更新"
           git push origin "$BRANCH"
-          gh pr create \
+          PR_URL=$(gh pr create \
             --title "chore: MSリストを自動更新" \
-            --body "GitHub Actionsによる自動更新です。新機体の追加や名前の変更があれば差分を確認してマージしてください。"
+            --body "GitHub Actionsによる自動更新です。CIのバリデーション通過後に自動マージされます。")
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pr_url
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --merge "${{ steps.create-pr.outputs.pr_url }}"


### PR DESCRIPTION
## Summary
- CIに`validate-mslist`ジョブを追加（PRタイトルに「MSリスト」を含む場合のみ実行）
  - JSONパースチェック
  - 必須フィールド（Name, ImageURL）の空チェック
  - 機体数が減っていないことを検証
- `update-mslist.yml`でPR作成後に`gh pr merge --auto`で自動マージを予約

## 残作業
このPRのCIが通った後、Rulesetでrequired status checks（build, lint-go, lint-python）を設定する

## Test plan
- [x] CIが通ることを確認
- [x] Ruleset設定後にUpdate MS Listを手動実行して自動マージされることを確認