### PR TITLE
fix: CSP対応、日別ページング修正、テーブルソート改善

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -108,9 +108,14 @@ func Scraping(username, password string, since time.Time, onProgress ...Progress
 	})
 
 	dailypage.OnHTML("div.block.control", func(e *colly.HTMLElement) {
+		// 「>」(次へ)ボタンは末尾から2番目のリンク
 		links := e.ChildAttrs("ul.clearfix > li > a", "href")
-		link := links[len(links)-1]
-		dailypage.Visit(link)
+		if len(links) >= 2 {
+			nextLink := links[len(links)-2]
+			if nextLink != "javascript:void(0);" {
+				dailypage.Visit(nextLink)
+			}
+		}
 	})
 
 	detailpage.OnHTML("div.panel_area", func(e *colly.HTMLElement) {

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -243,8 +243,8 @@ def md_enemy_matchup(data_list, min_matches=3):
             avg_taken = avg([d["dmg_taken"] for d in matches])
             results.append((ms, len(matches), wr, eff, avg_given, avg_taken))
 
-    strong = sorted([r for r in results if r[2] >= 60], key=lambda x: -x[2])
-    weak = sorted([r for r in results if r[2] <= 40], key=lambda x: x[2])
+    strong = sorted([r for r in results if r[2] >= 60], key=lambda x: -x[1])
+    weak = sorted([r for r in results if r[2] <= 40], key=lambda x: -x[1])
     even = sorted([r for r in results if 40 < r[2] < 60], key=lambda x: -x[1])
 
     header_row = "| 機体名 | 試合 | 勝率 | ダメ効率 | 与ダメ | 被ダメ |"
@@ -304,7 +304,7 @@ def md_partner(data_list, min_matches=3):
             eff = dmg_efficiency(matches)
             results.append((ms, len(matches), wr, eff))
 
-    results.sort(key=lambda x: -x[2])
+    results.sort(key=lambda x: -x[1])
     lines = [
         "| 相方機体 | 試合 | 勝率 | ダメ効率 |",
         "|----------|------|------|----------|",

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,88 @@
+const STATUS_MESSAGES = {
+  pending: '準備中...',
+  scraping: '戦績を取得中...（数分かかります）',
+  analyzing: '分析中...',
+  done: '完了',
+  error: 'エラーが発生しました',
+};
+
+async function analyze() {
+  const username = document.getElementById('username').value;
+  const password = document.getElementById('password').value;
+  const btn = document.getElementById('analyzeBtn');
+  const status = document.getElementById('status');
+  const statusText = document.getElementById('statusText');
+  const error = document.getElementById('error');
+  const report = document.getElementById('report');
+
+  if (!username || !password) {
+    error.style.display = 'block';
+    error.textContent = 'メールアドレスとパスワードを入力してください。';
+    return;
+  }
+
+  btn.disabled = true;
+  status.style.display = 'block';
+  statusText.textContent = STATUS_MESSAGES.pending;
+  error.style.display = 'none';
+  report.style.display = 'none';
+
+  try {
+    // ジョブ作成
+    const res = await fetch('/analyze', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+
+    const data = await res.json();
+    if (data.error) {
+      throw new Error(data.error);
+    }
+
+    const jobId = data.id;
+
+    // ポーリングで進捗確認
+    while (true) {
+      await new Promise(r => setTimeout(r, 3000));
+
+      const statusRes = await fetch(`/status/${jobId}`);
+      const statusData = await statusRes.json();
+
+      if (statusData.error && statusData.status !== 'error') {
+        throw new Error(statusData.error);
+      }
+
+      statusText.textContent = statusData.message || STATUS_MESSAGES[statusData.status] || statusData.status;
+
+      if (statusData.status === 'error') {
+        throw new Error(statusData.error || '分析に失敗しました');
+      }
+
+      if (statusData.status === 'done') {
+        // レポート取得
+        const resultRes = await fetch(`/result/${jobId}`);
+        const resultData = await resultRes.json();
+
+        if (resultData.error) {
+          throw new Error(resultData.error);
+        }
+
+        report.style.display = 'block';
+        report.innerHTML = DOMPurify.sanitize(marked.parse(resultData.report));
+        break;
+      }
+    }
+  } catch (e) {
+    error.style.display = 'block';
+    error.textContent = e.message;
+  } finally {
+    btn.disabled = false;
+    status.style.display = 'none';
+  }
+}
+
+document.getElementById('analyzeBtn').addEventListener('click', analyze);
+document.getElementById('password').addEventListener('keypress', function(e) {
+  if (e.key === 'Enter') analyze();
+});

--- a/static/index.html
+++ b/static/index.html
@@ -57,7 +57,7 @@
         <label for="password">パスワード</label>
         <input type="password" id="password" placeholder="パスワード">
       </div>
-      <button id="analyzeBtn" onclick="analyze()">分析開始</button>
+      <button id="analyzeBtn">分析開始</button>
     </div>
 
     <div class="status" id="status" style="display:none;">
@@ -71,94 +71,6 @@
 
   <script src="marked.min.js"></script>
   <script src="purify.min.js"></script>
-  <script>
-    const STATUS_MESSAGES = {
-      pending: '準備中...',
-      scraping: '戦績を取得中...（1〜2分かかります）',
-      analyzing: '分析中...',
-      done: '完了',
-      error: 'エラーが発生しました',
-    };
-
-    async function analyze() {
-      const username = document.getElementById('username').value;
-      const password = document.getElementById('password').value;
-      const btn = document.getElementById('analyzeBtn');
-      const status = document.getElementById('status');
-      const statusText = document.getElementById('statusText');
-      const error = document.getElementById('error');
-      const report = document.getElementById('report');
-
-      if (!username || !password) {
-        error.style.display = 'block';
-        error.textContent = 'メールアドレスとパスワードを入力してください。';
-        return;
-      }
-
-      btn.disabled = true;
-      status.style.display = 'block';
-      statusText.textContent = STATUS_MESSAGES.pending;
-      error.style.display = 'none';
-      report.style.display = 'none';
-
-      try {
-        // ジョブ作成
-        const res = await fetch('/analyze', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ username, password }),
-        });
-
-        const data = await res.json();
-        if (data.error) {
-          throw new Error(data.error);
-        }
-
-        const jobId = data.id;
-
-        // ポーリングで進捗確認
-        while (true) {
-          await new Promise(r => setTimeout(r, 3000));
-
-          const statusRes = await fetch(`/status/${jobId}`);
-          const statusData = await statusRes.json();
-
-          if (statusData.error && statusData.status !== 'error') {
-            throw new Error(statusData.error);
-          }
-
-          statusText.textContent = statusData.message || STATUS_MESSAGES[statusData.status] || statusData.status;
-
-          if (statusData.status === 'error') {
-            throw new Error(statusData.error || '分析に失敗しました');
-          }
-
-          if (statusData.status === 'done') {
-            // レポート取得
-            const resultRes = await fetch(`/result/${jobId}`);
-            const resultData = await resultRes.json();
-
-            if (resultData.error) {
-              throw new Error(resultData.error);
-            }
-
-            report.style.display = 'block';
-            report.innerHTML = DOMPurify.sanitize(marked.parse(resultData.report));
-            break;
-          }
-        }
-      } catch (e) {
-        error.style.display = 'block';
-        error.textContent = e.message;
-      } finally {
-        btn.disabled = false;
-        status.style.display = 'none';
-      }
-    }
-
-    document.getElementById('password').addEventListener('keypress', function(e) {
-      if (e.key === 'Enter') analyze();
-    });
-  </script>
+  <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- CSPの`script-src 'unsafe-inline'`を除去するためインラインJSを`app.js`に外部化
- 日別戦績スクレイピングのページネーションで全ページを巡回するよう修正（50戦中20戦しか取得できない問題を解消）
- 敵機体・相方機体テーブルのソートを対戦回数の多い順に変更
- MSリスト自動更新にバリデーションCIとauto-mergeを追加

## Test plan
- [x] `make restart`でビルド・起動を確認
- [x] ログイン画面でボタンが反応すること（CSP修正）
- [x] 50戦以上の日で全戦績が取得されること（ページング修正）
- [x] 敵機体・相方テーブルが対戦回数順に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)