### PR TITLE
feat: レポートUI改善（目次・名称変更・説明文）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Preview files
+static/preview.html
+static/sample_report.md

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -719,26 +719,51 @@ def main():
     report = []
     report.append(f"# EXVS2IB 戦績分析レポート - 「{player_name}」\n")
 
-    # 全体スタッツ
-    report.append("## 全体スタッツ\n")
+    # 目次
+    def toc_link(label, heading):
+        anchor = heading.replace(" ", "-")
+        return f"[{label}](#{anchor})"
+
+    ms_names_for_toc = [ms for ms in sorted(ms_data.keys(), key=lambda x: -len(ms_data[x])) if len(ms_data[ms]) >= 3]
+    toc = ["<details open><summary><strong>目次</strong></summary>\n"]
+    toc.append(f"1. {toc_link('基本データ', '基本データ')}")
+    n = 2
+    for i, ms_name in enumerate(ms_names_for_toc):
+        ms_count = len(ms_data[ms_name])
+        heading = f"機体別分析:-{ms_name}-({ms_count}戦)"
+        toc.append(f"{n+i}. {toc_link(ms_name + ' (' + str(ms_count) + '戦)', heading)}")
+        toc.append(f"   - {toc_link('基本データ', '基本データ（' + ms_name + '）')}")
+        toc.append(f"   - {toc_link('敵機体との相性', '敵機体との相性（' + ms_name + '）')}")
+        toc.append(f"   - {toc_link('相方機体との相性', '相方機体との相性（' + ms_name + '）')}")
+    n += len(ms_names_for_toc)
+    toc.append(f"{n}. {toc_link('固定相方分析', '固定相方分析（連続3戦以上）')}")
+    toc.append(f"{n+1}. {toc_link('被撃墜数と勝率', '被撃墜数と勝率の関係')}")
+    toc.append(f"{n+2}. {toc_link('時間帯別', '時間帯別の勝率')}")
+    toc.append(f"{n+3}. {toc_link('曜日別', '曜日別の勝率（平日-vs-土日）')}")
+    toc.append(f"{n+4}. {toc_link('日別推移', '日別勝率推移')}")
+    toc.append(f"{n+5}. {toc_link('シーズン別', 'シーズン別分析')}")
+    toc.append(f"{n+6}. {toc_link('総合アドバイス', '総合アドバイス')}")
+    toc.append("\n</details>")
+    report.append("\n".join(toc))
+
+    # 基本データ
+    report.append("\n\n---\n\n## 基本データ\n")
     report.append(md_basic_stats(all_data))
     report.append("\n### 勝ち/負け時のダメージ傾向\n")
     report.append(md_win_loss_pattern(all_data))
 
     # 機体別分析
-    for ms_name in sorted(ms_data.keys(), key=lambda x: -len(ms_data[x])):
+    for ms_name in ms_names_for_toc:
         data = ms_data[ms_name]
-        if len(data) < 3:
-            continue
 
         report.append(f"\n---\n\n## 機体別分析: {ms_name} ({len(data)}戦)\n")
-        report.append("### 基本スタッツ\n")
+        report.append(f"### 基本データ（{ms_name}）\n")
         report.append(md_basic_stats(data))
-        report.append("\n### 勝ち/負け時のダメージ傾向\n")
+        report.append(f"\n### 勝ち/負け時のダメージ傾向（{ms_name}）\n")
         report.append(md_win_loss_pattern(data))
-        report.append("\n### 敵機体との相性\n")
+        report.append(f"\n### 敵機体との相性（{ms_name}）\n")
         report.append(md_enemy_matchup(data))
-        report.append("\n### 相方機体との相性\n")
+        report.append(f"\n### 相方機体との相性（{ms_name}）\n")
         report.append(md_partner(data))
 
     # 固定相方分析

--- a/static/app.js
+++ b/static/app.js
@@ -70,6 +70,9 @@ async function analyze() {
 
         report.style.display = 'block';
         report.innerHTML = DOMPurify.sanitize(marked.parse(resultData.report));
+        report.querySelectorAll('h2, h3').forEach(function(h) {
+          h.id = h.textContent.replace(/\s+/g, '-');
+        });
         break;
       }
     }

--- a/static/index.html
+++ b/static/index.html
@@ -25,6 +25,7 @@
     }
     button:hover { background: #81d4fa; }
     button:disabled { background: #333; color: #666; cursor: not-allowed; }
+    .note { margin-top: 16px; font-size: 0.8em; color: #777; line-height: 1.6; }
     .status { text-align: center; margin: 20px 0; color: #aaa; }
     .spinner { display: inline-block; width: 20px; height: 20px; border: 3px solid #333; border-top: 3px solid #4fc3f7; border-radius: 50%; animation: spin 1s linear infinite; margin-right: 8px; vertical-align: middle; }
     @keyframes spin { to { transform: rotate(360deg); } }
@@ -58,6 +59,7 @@
         <input type="password" id="password" placeholder="パスワード">
       </div>
       <button id="analyzeBtn">分析開始</button>
+      <p class="note">公式サイトから直近30日分の戦績を取得して分析します。初回は全データを取得するため5〜10分ほどかかりますが、2回目以降は前回からの差分のみ取得するため短時間で完了します。</p>
     </div>
 
     <div class="status" id="status" style="display:none;">


### PR DESCRIPTION
## Summary
- 折りたたみ可能な目次を追加（機体別サブリンクつき、ページ内ジャンプ対応）
- 「スタッツ」→「基本データ」に名称変更
- 機体別の見出しに機体名を付与（例: 基本データ（ヴィシャス））
- ログイン画面に初回所要時間の説明文を追加

## Test plan
- [x] レポートの目次リンクでページ内ジャンプできること
- [x] 目次の折りたたみが動作すること
- [x] 「基本データ」表記に統一されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)