### PR TITLE
fix: 目次リンク修正・固定相方10戦判定

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -99,9 +99,9 @@ def get_my_data(match):
     }
 
 
-def detect_fixed_partners(all_data, min_streak=3):
+def detect_fixed_partners(all_data, min_streak=10):
     """連続で同じ相方と組んでいる区間を検出し、固定相方の試合を返す。
-    時系列順で連続3戦以上同じ相方名ならその区間を固定とみなす。
+    時系列順で連続10戦以上同じ相方名ならその区間を固定とみなす。
     """
     sorted_data = sorted(all_data, key=lambda d: d["datetime"])
 
@@ -448,11 +448,11 @@ def md_daily_trend(data_list):
 
 
 def md_fixed_partners(all_data):
-    """固定相方（連続3戦以上）の分析"""
+    """固定相方（連続10戦以上）の分析"""
     fixed = detect_fixed_partners(all_data)
 
     if not fixed:
-        return "固定相方（連続3戦以上）は検出されませんでした。"
+        return "固定相方（連続10戦以上）は検出されませんでした。"
 
     lines = []
     for partner_name in sorted(fixed.keys(), key=lambda x: -len(fixed[x])):
@@ -736,7 +736,7 @@ def main():
         toc.append(f"   - {toc_link('敵機体との相性', '敵機体との相性（' + ms_name + '）')}")
         toc.append(f"   - {toc_link('相方機体との相性', '相方機体との相性（' + ms_name + '）')}")
     n += len(ms_names_for_toc)
-    toc.append(f"{n}. {toc_link('固定相方分析', '固定相方分析（連続3戦以上）')}")
+    toc.append(f"{n}. {toc_link('固定相方分析', '固定相方分析（連続10戦以上）')}")
     toc.append(f"{n+1}. {toc_link('被撃墜数と勝率', '被撃墜数と勝率の関係')}")
     toc.append(f"{n+2}. {toc_link('時間帯別', '時間帯別の勝率')}")
     toc.append(f"{n+3}. {toc_link('曜日別', '曜日別の勝率（平日-vs-土日）')}")
@@ -767,7 +767,7 @@ def main():
         report.append(md_partner(data))
 
     # 固定相方分析
-    report.append("\n---\n\n## 固定相方分析（連続3戦以上）\n")
+    report.append("\n---\n\n## 固定相方分析（連続10戦以上）\n")
     report.append(md_fixed_partners(all_data))
 
     # 被撃墜数と勝率

--- a/static/app.js
+++ b/static/app.js
@@ -69,7 +69,7 @@ async function analyze() {
         }
 
         report.style.display = 'block';
-        report.innerHTML = DOMPurify.sanitize(marked.parse(resultData.report));
+        report.innerHTML = DOMPurify.sanitize(marked.parse(resultData.report), {ADD_TAGS: ['details', 'summary']});
         report.querySelectorAll('h2, h3').forEach(function(h) {
           h.id = h.textContent.replace(/\s+/g, '-');
         });

--- a/static/index.html
+++ b/static/index.html
@@ -41,6 +41,10 @@
     .report hr { border: none; border-top: 1px solid #333; margin: 20px 0; }
     .report ul, .report ol { padding-left: 20px; }
     .report strong { color: #4fc3f7; }
+    .report a { color: #4fc3f7; text-decoration: none; }
+    .report a:hover { text-decoration: underline; }
+    .report details { margin-bottom: 20px; }
+    .report summary { cursor: pointer; font-weight: bold; color: #4fc3f7; }
     .error { background: #3d1f1f; border: 1px solid #ff5252; border-radius: 8px; padding: 15px; color: #ff8a80; margin: 20px 0; }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- DOMPurifyでdetails/summaryタグを許可し目次の折りたたみとリンクを有効化
- レポート内リンクのスタイルをダークテーマに合わせて修正
- 固定相方の判定基準を連続3戦→連続10戦に変更

## Test plan
- [x] Cloud Runで目次リンクが動作すること
- [x] リンクの色がダークテーマに馴染んでいること
- [x] 固定相方が連続10戦以上のみ表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)