### PR TITLE
feat: PRラベルでCI/CDの実行を制御

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,40 @@ on:
     branches: [main]
 
 jobs:
+  check-deploy-label:
+    runs-on: ubuntu-latest
+    outputs:
+      no-deploy: ${{ steps.check.outputs.no-deploy }}
+    steps:
+      - name: Check merged PR labels
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # マージコミットに関連するPRを取得
+          PR_NUMBER=$(gh api \
+            "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "no-deploy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LABELS=$(gh api \
+            "repos/${{ github.repository }}/pulls/${PR_NUMBER}/labels" \
+            --jq '.[].name' 2>/dev/null || echo "")
+
+          if echo "$LABELS" | grep -q "^no-deploy$"; then
+            echo "no-deploy=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping deploy: no-deploy label found on PR #${PR_NUMBER}"
+          else
+            echo "no-deploy=false" >> "$GITHUB_OUTPUT"
+          fi
+
   deploy:
+    needs: check-deploy-label
+    if: needs.check-deploy-label.outputs.no-deploy != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,24 @@ on:
     branches: [main]
 
 jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    outputs:
+      skip-ci: ${{ steps.labels.outputs.skip-ci }}
+    steps:
+      - name: Check PR labels
+        id: labels
+        run: |
+          LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+          if echo "$LABELS" | grep -q '"skip-ci"'; then
+            echo "skip-ci=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip-ci=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: check-labels
+    if: needs.check-labels.outputs.skip-ci != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -14,6 +31,8 @@ jobs:
         run: docker build -t exvs-analyzer .
 
   lint-go:
+    needs: check-labels
+    if: needs.check-labels.outputs.skip-ci != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -32,6 +51,8 @@ jobs:
         run: go build ./cmd/server
 
   lint-python:
+    needs: check-labels
+    if: needs.check-labels.outputs.skip-ci != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- CIワークフローに`check-labels`ジョブを追加。`skip-ci`ラベルでbuild/lint-go/lint-pythonジョブをスキップ
- CDワークフローに`check-deploy-label`ジョブを追加。マージ元PRに`no-deploy`ラベルがあればデプロイをスキップ
- ラベルなしの場合はこれまで通りCI実行・デプロイがデフォルト動作

## ラベル一覧
| ラベル | 対象 | 動作 |
|--------|------|------|
| `skip-ci` | CI | build, lint-go, lint-python をスキップ |
| `no-deploy` | CD | mainマージ後のデプロイをスキップ |
| （なし） | CI/CD | 通常通り実行（デフォルト） |

## Test plan
- [ ] `skip-ci`ラベル付きPRでCI jobがスキップされることを確認
- [ ] ラベルなしPRで通常通りCIが実行されることを確認
- [ ] `no-deploy`ラベル付きPRのマージ後にデプロイがスキップされることを確認

ref #90