### PR TITLE
fix: MSリストの並び順を安定化

### DIFF
--- a/cmd/update-mslist/main.go
+++ b/cmd/update-mslist/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"sort"
 
 	"github.com/yuki9431/exvs-analyzer/internal/model"
 	"github.com/yuki9431/exvs-analyzer/internal/scraper"
@@ -65,6 +66,14 @@ func main() {
 			merged = append(merged, ms)
 		}
 	}
+
+	// 名前→ImageURLの順でソートし、毎回同じ順番で出力する
+	sort.Slice(merged, func(i, j int) bool {
+		if merged[i].Name != merged[j].Name {
+			return merged[i].Name < merged[j].Name
+		}
+		return merged[i].ImageURL < merged[j].ImageURL
+	})
 
 	if err := model.SaveMSList(merged, outputPath); err != nil {
 		log.Fatalf("Failed to save MS list: %v", err)


### PR DESCRIPTION
## Summary
- 同名機体（色違い）のImageURL順が毎回入れ替わり不要な差分が出る問題を修正
- マージ後にName→ImageURLの順でソートし、出力を安定化

refs #87