### PR TITLE
fix: セキュリティ注記の文言を修正

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -77,7 +77,7 @@
         <label for="password">パスワード</label>
         <input type="password" id="password" placeholder="パスワード">
       </div>
-      <p class="security-note">パスワードはバンダイナムコの公式サイトへのログインにのみ使用し、サーバーには保存しません。通信はHTTPSで暗号化されています。</p>
+      <p class="security-note">パスワードはガンダムモバイルへのログインにのみ使用し、サーバーには保存しません。通信はHTTPSで暗号化されています。</p>
       <button id="analyzeBtn">分析開始</button>
       <p class="note">公式サイトから直近30日分の戦績を取得して分析します。初回は全データを取得するため5〜10分ほどかかりますが、2回目以降は前回からの差分のみ取得するため短時間で完了します。</p>
     </div>


### PR DESCRIPTION
## Summary
- 「バンダイナムコの公式サイト」→「ガンダムモバイル」に文言修正

refs #97