### PR TITLE
fix: CDでイメージタグにSHA含める + 共有ボタン上下配置

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,7 +65,20 @@ jobs:
       - uses: google-github-actions/setup-gcloud@v3
 
       - name: Build and push image
-        run: gcloud builds submit --tag ${{ secrets.GCR_IMAGE }}
+        run: |
+          IMAGE="${{ secrets.GCR_IMAGE }}:${{ github.sha }}"
+          gcloud builds submit --tag "$IMAGE"
+          echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
+
+      - name: Update Pulumi image config
+        working-directory: infra
+        run: |
+          npm install -g @pulumi/pulumi 2>/dev/null || true
+          pulumi login gs://${{ secrets.PULUMI_STATE_BUCKET }}
+          pulumi stack select dev
+          pulumi config set exvs-analyzer:image "$IMAGE" --secret
+        env:
+          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
 
       - name: Deploy with Pulumi
         uses: pulumi/actions@v6

--- a/static/app.js
+++ b/static/app.js
@@ -114,9 +114,33 @@ function buildShareText(items) {
   return lines.join('\n');
 }
 
+var SVG_X = '<svg viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>';
+var SVG_BSKY = '<svg viewBox="0 0 568 501"><path d="M123.121 33.664C188.241 82.553 258.281 181.68 284 234.873c25.719-53.192 95.759-152.32 160.879-201.21C491.866-1.611 568-28.906 568 57.947c0 17.346-9.945 145.713-15.778 166.555-20.275 72.453-94.155 90.933-159.875 79.748C507.222 323.8 536.444 388.56 473.333 453.32c-119.86 122.992-172.272-30.859-185.702-70.281-2.462-7.227-3.614-10.608-3.631-7.733-.017-2.875-1.169.506-3.631 7.733-13.43 39.422-65.842 193.273-185.702 70.281-63.111-64.76-33.889-129.52 80.986-149.071-65.72 11.185-139.6-7.295-159.875-79.748C9.945 203.659 0 75.291 0 57.946 0-28.906 76.135-1.612 123.121 33.664z"/></svg>';
+var SVG_LINE = '<svg viewBox="0 0 24 24"><path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/></svg>';
+var SVG_COPY = '<svg viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>';
+var SVG_CHECK = '<svg viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>';
+
+function createShareArea(id, text) {
+  var encoded = encodeURIComponent(text);
+  var xUrl = 'https://x.com/intent/tweet?text=' + encoded;
+  var bskyUrl = 'https://bsky.app/intent/compose?text=' + encoded;
+  var lineUrl = 'https://line.me/R/share?text=' + encoded;
+
+  var area = document.createElement('div');
+  area.id = id;
+  area.className = 'share-area';
+  area.innerHTML =
+    '<span class="share-label">共有</span>' +
+    '<a href="' + xUrl + '" target="_blank" rel="noopener noreferrer" class="share-btn share-x" aria-label="Xで共有">' + SVG_X + '</a>' +
+    '<a href="' + bskyUrl + '" target="_blank" rel="noopener noreferrer" class="share-btn share-bsky" aria-label="Blueskyで共有">' + SVG_BSKY + '</a>' +
+    '<a href="' + lineUrl + '" target="_blank" rel="noopener noreferrer" class="share-btn share-line" aria-label="LINEで共有">' + SVG_LINE + '</a>' +
+    '<button class="share-btn share-copy" onclick="copyShareText(this)" aria-label="テキストをコピー">' + SVG_COPY + '</button>';
+  area.dataset.shareText = text;
+  return area;
+}
+
 function showShareButton(markdown) {
-  var existing = document.getElementById('shareArea');
-  if (existing) existing.remove();
+  document.querySelectorAll('.share-area').forEach(function(el) { el.remove(); });
 
   var match = markdown.match(/<!-- SHARE_DATA:(.*?) -->/);
   if (!match) return;
@@ -126,40 +150,20 @@ function showShareButton(markdown) {
   if (!items.length) return;
 
   var text = buildShareText(items);
-  var encoded = encodeURIComponent(text);
-  var xUrl = 'https://x.com/intent/tweet?text=' + encoded;
-  var bskyUrl = 'https://bsky.app/intent/compose?text=' + encoded;
-  var lineUrl = 'https://line.me/R/share?text=' + encoded;
-
-  var svgX = '<svg viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>';
-  var svgBsky = '<svg viewBox="0 0 568 501"><path d="M123.121 33.664C188.241 82.553 258.281 181.68 284 234.873c25.719-53.192 95.759-152.32 160.879-201.21C491.866-1.611 568-28.906 568 57.947c0 17.346-9.945 145.713-15.778 166.555-20.275 72.453-94.155 90.933-159.875 79.748C507.222 323.8 536.444 388.56 473.333 453.32c-119.86 122.992-172.272-30.859-185.702-70.281-2.462-7.227-3.614-10.608-3.631-7.733-.017-2.875-1.169.506-3.631 7.733-13.43 39.422-65.842 193.273-185.702 70.281-63.111-64.76-33.889-129.52 80.986-149.071-65.72 11.185-139.6-7.295-159.875-79.748C9.945 203.659 0 75.291 0 57.946 0-28.906 76.135-1.612 123.121 33.664z"/></svg>';
-  var svgLine = '<svg viewBox="0 0 24 24"><path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/></svg>';
-  var svgCopy = '<svg viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>';
-
-  var area = document.createElement('div');
-  area.id = 'shareArea';
-  area.className = 'share-area';
-  area.innerHTML =
-    '<span class="share-label">共有</span>' +
-    '<a href="' + xUrl + '" target="_blank" rel="noopener noreferrer" class="share-btn share-x" aria-label="Xで共有">' + svgX + '</a>' +
-    '<a href="' + bskyUrl + '" target="_blank" rel="noopener noreferrer" class="share-btn share-bsky" aria-label="Blueskyで共有">' + svgBsky + '</a>' +
-    '<a href="' + lineUrl + '" target="_blank" rel="noopener noreferrer" class="share-btn share-line" aria-label="LINEで共有">' + svgLine + '</a>' +
-    '<button class="share-btn share-copy" onclick="copyShareText()" aria-label="テキストをコピー">' + svgCopy + '</button>';
-  area.dataset.shareText = text;
-
-  document.getElementById('report').before(area);
+  var report = document.getElementById('report');
+  report.before(createShareArea('shareAreaTop', text));
+  report.after(createShareArea('shareAreaBottom', text));
 }
 
-function copyShareText() {
-  var area = document.getElementById('shareArea');
+function copyShareText(btn) {
+  var area = btn.closest('.share-area');
   if (!area) return;
-  var btn = area.querySelector('.share-copy');
   navigator.clipboard.writeText(area.dataset.shareText).then(function() {
     btn.classList.add('copied');
-    btn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>';
+    btn.innerHTML = SVG_CHECK;
     setTimeout(function() {
       btn.classList.remove('copied');
-      btn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>';
+      btn.innerHTML = SVG_COPY;
     }, 2000);
   });
 }


### PR DESCRIPTION
## Summary
- CDのイメージタグを固定値から`<image>:<commit-sha>`に変更。`pulumi up`が毎回差分を検出し、新リビジョンが確実に作成されるようにする
- 共有ボタンをレポートの上下両方に配置

## 修正した問題
前回のデプロイ (#106) で`gcloud builds submit`は新イメージをpushしたが、Pulumiのconfigのイメージタグが同じだったため`pulumi up`が「変更なし」と判断し、Cloud Runの新リビジョンが作成されなかった。

## Test plan
- [ ] CDでデプロイ後、新しいリビジョンが作成されることを確認
- [ ] 分析実行後に共有ボタンがレポートの上下に表示されることを確認