### PR TITLE
feat: カスタムドメインマッピングをPulumiで管理

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -13,3 +13,4 @@ config:
     secure: v1:t/btXxy5q94Z048L:UYbSe5mE/EkbOjVkfKLyvFGYbq0=
   exvs-analyzer:image:
     secure: v1:M0xwOizR13d1hFXd:NNKu4x2RQ5y20QPaE9b+/zhsh4MWfRFdWzTCQz6erSt0wboyLy8TT44PsFxNJM0q7vLeJ18=
+  exvs-analyzer:domain: exvs-analyzer.grimoire.tokyo

--- a/infra/domain.ts
+++ b/infra/domain.ts
@@ -1,0 +1,30 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as gcp from "@pulumi/gcp";
+import { service } from "./cloudrun";
+
+const config = new pulumi.Config();
+const domain = config.require("domain");
+
+export const domainMapping = new gcp.cloudrun.DomainMapping(
+  "exvs-analyzer-domain",
+  {
+    location: gcp.config.region!,
+    name: domain,
+    metadata: {
+      namespace: gcp.config.project!,
+    },
+    spec: {
+      routeName: service.name,
+    },
+  }
+);
+
+export const dnsRecords = domainMapping.statuses.apply((statuses) =>
+  (statuses || []).flatMap((s) =>
+    (s.resourceRecords || []).map((r) => ({
+      type: r.type,
+      name: r.name,
+      rrdata: r.rrdata,
+    }))
+  )
+);

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -1,6 +1,7 @@
 import { services } from "./apis";
 import { repository } from "./artifact-registry";
 import { service, url, iamBinding } from "./cloudrun";
+import { domainMapping, dnsRecords } from "./domain";
 // TODO: budget importはBilling Budget APIのquota project設定後に対応
 // import { budget } from "./budget";
 
@@ -8,3 +9,5 @@ export const enabledApis = services.map((s) => s.service);
 export const artifactRegistryId = repository.id;
 export const cloudRunUrl = url;
 export const cloudRunServiceName = service.name;
+export const customDomain = domainMapping.name;
+export const requiredDnsRecords = dnsRecords;


### PR DESCRIPTION
## Summary
- Cloud DNSマネージドゾーンをPulumiで管理
- Cloud RunのDomainMapping（`www.exvs-analyzer.com`）をPulumiで管理
- DNS API有効化、ネームサーバーをoutputに出力
- rootDomainはdomain configから自動導出

## マージ後の手順
1. CDでDomainMapping + Cloud DNSゾーンが作成される
2. `pulumi stack output dnsNameServers`でネームサーバーを確認
3. お名前.comのNSレコードをCloud DNSのネームサーバーに変更
4. SSL証明書の自動プロビジョニングを待つ

ref #110