### PR TITLE
fix: actions/setup-node を v4 → v6 にアップデート

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
         if: steps.check-secrets.outputs.skip != 'true'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         if: steps.check-secrets.outputs.skip != 'true'
         with:
           node-version: "22"


### PR DESCRIPTION
## Summary
- cd.yml, infra-ci.yml の `actions/setup-node` を v4 → v6 にアップデート
- Node.js 20 ランタイムの非推奨警告を解消
- `pulumi/actions@v6` は現時点で最新のため据え置き（v7未リリース）

## Test plan
- [x] CD/Infra CIワークフローでNode.js 20の非推奨警告が出なくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)