### PR TITLE
feat: Cloud DNSゾーン作成（Step 1）

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -13,4 +13,4 @@ config:
     secure: v1:t/btXxy5q94Z048L:UYbSe5mE/EkbOjVkfKLyvFGYbq0=
   exvs-analyzer:image:
     secure: v1:M0xwOizR13d1hFXd:NNKu4x2RQ5y20QPaE9b+/zhsh4MWfRFdWzTCQz6erSt0wboyLy8TT44PsFxNJM0q7vLeJ18=
-  exvs-analyzer:domain: exvs-analyzer.grimoire.tokyo
+  exvs-analyzer:domain: www.exvs-analyzer.com

--- a/infra/domain.ts
+++ b/infra/domain.ts
@@ -1,6 +1,5 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as gcp from "@pulumi/gcp";
-import { service } from "./cloudrun";
 
 const config = new pulumi.Config();
 const domain = config.require("domain");
@@ -25,32 +24,9 @@ export const dnsZone = new gcp.dns.ManagedZone(
   { dependsOn: [dnsApi] }
 );
 
-// Cloud Runドメインマッピング（wwwサブドメイン）
-export const domainMapping = new gcp.cloudrun.DomainMapping(
-  "exvs-analyzer-domain",
-  {
-    location: gcp.config.region!,
-    name: domain,
-    metadata: {
-      namespace: gcp.config.project!,
-    },
-    spec: {
-      routeName: service.name,
-    },
-  }
-);
-
-// DomainMappingが返すDNSレコード
-export const dnsRecords = domainMapping.statuses.apply((statuses) => {
-  const records = (statuses || []).flatMap((s) =>
-    (s.resourceRecords || []).map((r) => ({
-      type: r.type,
-      name: r.name,
-      rrdata: r.rrdata,
-    }))
-  );
-  return records;
-});
-
 // ネームサーバー（お名前.comに設定する値）
 export const nameServers = dnsZone.nameServers;
+
+// TODO: Step 2 - お名前.comでNSレコード設定後にDomainMappingを有効化
+// import { service } from "./cloudrun";
+// export const domainMapping = new gcp.cloudrun.DomainMapping(...)

--- a/infra/domain.ts
+++ b/infra/domain.ts
@@ -4,7 +4,28 @@ import { service } from "./cloudrun";
 
 const config = new pulumi.Config();
 const domain = config.require("domain");
+// www.exvs-analyzer.com → exvs-analyzer.com
+const parts = domain.split(".");
+const rootDomain = parts.slice(-2).join(".");
 
+// Cloud DNS API有効化
+export const dnsApi = new gcp.projects.Service("dns.googleapis.com", {
+  service: "dns.googleapis.com",
+  disableOnDestroy: false,
+});
+
+// Cloud DNSマネージドゾーン（ルートドメインで管理）
+export const dnsZone = new gcp.dns.ManagedZone(
+  "exvs-analyzer-zone",
+  {
+    name: "exvs-analyzer",
+    dnsName: rootDomain + ".",
+    description: "EXVS Analyzer DNS zone",
+  },
+  { dependsOn: [dnsApi] }
+);
+
+// Cloud Runドメインマッピング（wwwサブドメイン）
 export const domainMapping = new gcp.cloudrun.DomainMapping(
   "exvs-analyzer-domain",
   {
@@ -19,12 +40,17 @@ export const domainMapping = new gcp.cloudrun.DomainMapping(
   }
 );
 
-export const dnsRecords = domainMapping.statuses.apply((statuses) =>
-  (statuses || []).flatMap((s) =>
+// DomainMappingが返すDNSレコード
+export const dnsRecords = domainMapping.statuses.apply((statuses) => {
+  const records = (statuses || []).flatMap((s) =>
     (s.resourceRecords || []).map((r) => ({
       type: r.type,
       name: r.name,
       rrdata: r.rrdata,
     }))
-  )
-);
+  );
+  return records;
+});
+
+// ネームサーバー（お名前.comに設定する値）
+export const nameServers = dnsZone.nameServers;

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -1,7 +1,7 @@
 import { services } from "./apis";
 import { repository } from "./artifact-registry";
 import { service, url, iamBinding } from "./cloudrun";
-import { domainMapping, dnsRecords } from "./domain";
+import { domainMapping, dnsRecords, nameServers, dnsZone } from "./domain";
 // TODO: budget importはBilling Budget APIのquota project設定後に対応
 // import { budget } from "./budget";
 
@@ -11,3 +11,5 @@ export const cloudRunUrl = url;
 export const cloudRunServiceName = service.name;
 export const customDomain = domainMapping.name;
 export const requiredDnsRecords = dnsRecords;
+export const dnsNameServers = nameServers;
+export const dnsZoneId = dnsZone.id;

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -1,7 +1,7 @@
 import { services } from "./apis";
 import { repository } from "./artifact-registry";
 import { service, url, iamBinding } from "./cloudrun";
-import { domainMapping, dnsRecords, nameServers, dnsZone } from "./domain";
+import { nameServers, dnsZone } from "./domain";
 // TODO: budget importはBilling Budget APIのquota project設定後に対応
 // import { budget } from "./budget";
 
@@ -9,7 +9,5 @@ export const enabledApis = services.map((s) => s.service);
 export const artifactRegistryId = repository.id;
 export const cloudRunUrl = url;
 export const cloudRunServiceName = service.name;
-export const customDomain = domainMapping.name;
-export const requiredDnsRecords = dnsRecords;
 export const dnsNameServers = nameServers;
 export const dnsZoneId = dnsZone.id;


### PR DESCRIPTION
## Summary
Cloud DNSマネージドゾーンとDNS API有効化のみ。DomainMappingはNSレコード設定後にStep 2で追加。

## 手順
1. このPRをマージ → CDでCloud DNSゾーン作成
2. outputのネームサーバーをお名前.comに設定
3. Step 2のPRでDomainMappingを追加

ref #110