### PR TITLE
feat: カスタムドメイン(www.exvs-analyzer.com) + GCSバケットのPulumi管理

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -14,3 +14,6 @@ config:
   exvs-analyzer:image:
     secure: v1:M0xwOizR13d1hFXd:NNKu4x2RQ5y20QPaE9b+/zhsh4MWfRFdWzTCQz6erSt0wboyLy8TT44PsFxNJM0q7vLeJ18=
   exvs-analyzer:domain: www.exvs-analyzer.com
+  exvs-analyzer:domainVerificationTxt: google-site-verification=TAXKxm2PncupGRZkk0mBxIxslp_7aZj-w9dxPAi-ObE
+  exvs-analyzer:pulumiStateBucket:
+    secure: v1:DTT5hikna9CWd6by:Nx5wUNbRTnn7SC03sCc5yPzugTPiZSwmiwJ0vjNRrsparkbP48cmYa5OJAFp

--- a/infra/domain.ts
+++ b/infra/domain.ts
@@ -1,8 +1,10 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as gcp from "@pulumi/gcp";
+import { service } from "./cloudrun";
 
 const config = new pulumi.Config();
 const domain = config.require("domain");
+const domainVerificationTxt = config.require("domainVerificationTxt");
 // www.exvs-analyzer.com → exvs-analyzer.com
 const parts = domain.split(".");
 const rootDomain = parts.slice(-2).join(".");
@@ -24,9 +26,49 @@ export const dnsZone = new gcp.dns.ManagedZone(
   { dependsOn: [dnsApi] }
 );
 
+// Cloud Runドメインマッピング
+export const domainMapping = new gcp.cloudrun.DomainMapping(
+  "exvs-analyzer-domain",
+  {
+    location: gcp.config.region!,
+    name: domain,
+    metadata: {
+      namespace: gcp.config.project!,
+    },
+    spec: {
+      routeName: service.name,
+    },
+  }
+);
+
+// wwwサブドメインのCNAMEレコード（Cloud Runのドメインマッピング用）
+export const cnameRecord = new gcp.dns.RecordSet("www-cname", {
+  managedZone: dnsZone.name,
+  name: domain + ".",
+  type: "CNAME",
+  ttl: 300,
+  rrdatas: ["ghs.googlehosted.com."],
+});
+
+// ドメイン所有権確認用TXTレコード
+export const verificationTxt = new gcp.dns.RecordSet("domain-verification", {
+  managedZone: dnsZone.name,
+  name: rootDomain + ".",
+  type: "TXT",
+  ttl: 300,
+  rrdatas: [`"${domainVerificationTxt}"`],
+});
+
 // ネームサーバー（お名前.comに設定する値）
 export const nameServers = dnsZone.nameServers;
 
-// TODO: Step 2 - お名前.comでNSレコード設定後にDomainMappingを有効化
-// import { service } from "./cloudrun";
-// export const domainMapping = new gcp.cloudrun.DomainMapping(...)
+// DomainMappingが返すDNSレコード
+export const dnsRecords = domainMapping.statuses.apply((statuses) =>
+  (statuses || []).flatMap((s) =>
+    (s.resourceRecords || []).map((r) => ({
+      type: r.type,
+      name: r.name,
+      rrdata: r.rrdata,
+    }))
+  )
+);

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -1,7 +1,8 @@
 import { services } from "./apis";
 import { repository } from "./artifact-registry";
 import { service, url, iamBinding } from "./cloudrun";
-import { nameServers, dnsZone } from "./domain";
+import { nameServers, dnsZone, domainMapping, dnsRecords } from "./domain";
+import { stateBucket, dataBucket } from "./storage";
 // TODO: budget importはBilling Budget APIのquota project設定後に対応
 // import { budget } from "./budget";
 
@@ -11,3 +12,7 @@ export const cloudRunUrl = url;
 export const cloudRunServiceName = service.name;
 export const dnsNameServers = nameServers;
 export const dnsZoneId = dnsZone.id;
+export const customDomain = domainMapping.name;
+export const requiredDnsRecords = dnsRecords;
+export const pulumiStateBucketName = stateBucket.name;
+export const appDataBucketName = dataBucket.name;

--- a/infra/storage.ts
+++ b/infra/storage.ts
@@ -1,0 +1,20 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as gcp from "@pulumi/gcp";
+
+const config = new pulumi.Config();
+const pulumiStateBucket = config.requireSecret("pulumiStateBucket");
+const gcsBucket = config.requireSecret("gcsBucket");
+
+// Pulumiステート保存用バケット
+export const stateBucket = new gcp.storage.Bucket("pulumi-state", {
+  name: pulumiStateBucket,
+  location: gcp.config.region!,
+  uniformBucketLevelAccess: true,
+});
+
+// アプリ用データバケット（ユーザーCSV保存）
+export const dataBucket = new gcp.storage.Bucket("app-data", {
+  name: gcsBucket,
+  location: gcp.config.region!,
+  uniformBucketLevelAccess: true,
+});


### PR DESCRIPTION
## Summary
- Cloud DNSマネージドゾーン、DomainMapping、CNAME/TXTレコードをPulumiで管理
- GCSバケット2つ（Pulumiステート、アプリデータ）をPulumi管理に追加
- ドメイン所有権確認用TXTレコードをconfig外出し
- rootDomainはdomain configから自動導出

## 管理対象リソース（新規追加）
| リソース | ファイル |
|---------|---------|
| Cloud DNS API | `domain.ts` |
| Cloud DNSマネージドゾーン | `domain.ts` |
| DomainMapping (`www.exvs-analyzer.com`) | `domain.ts` |
| CNAMEレコード | `domain.ts` |
| TXTレコード（所有権確認） | `domain.ts` |
| GCSバケット（Pulumiステート） | `storage.ts` |
| GCSバケット（アプリデータ） | `storage.ts` |

## 手動で実施済み
- Google Search Consoleでドメイン所有権確認
- お名前.comでNSレコードをCloud DNSに変更
- pulumi import で既存リソース取り込み
- pulumi up で差分ゼロ確認

ref #110