### PR TITLE
feat: GCPリソース全量Pulumi管理 + ベストプラクティス改善

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -17,3 +17,4 @@ config:
   exvs-analyzer:domainVerificationTxt: google-site-verification=TAXKxm2PncupGRZkk0mBxIxslp_7aZj-w9dxPAi-ObE
   exvs-analyzer:pulumiStateBucket:
     secure: v1:DTT5hikna9CWd6by:Nx5wUNbRTnn7SC03sCc5yPzugTPiZSwmiwJ0vjNRrsparkbP48cmYa5OJAFp
+  exvs-analyzer:githubRepo: yuki9431/exvs-analyzer

--- a/infra/apis.ts
+++ b/infra/apis.ts
@@ -4,6 +4,8 @@ const enabledApis = [
   "run.googleapis.com",
   "artifactregistry.googleapis.com",
   "cloudbuild.googleapis.com",
+  "dns.googleapis.com",
+  "iam.googleapis.com",
 ];
 
 export const services = enabledApis.map(

--- a/infra/cloudrun.ts
+++ b/infra/cloudrun.ts
@@ -34,12 +34,21 @@ export const service = new gcp.cloudrunv2.Service(
             },
           },
           startupProbe: {
-            failureThreshold: 1,
-            periodSeconds: 240,
+            failureThreshold: 5,
+            periodSeconds: 10,
             tcpSocket: {
               port: 8080,
             },
-            timeoutSeconds: 240,
+            timeoutSeconds: 5,
+          },
+          livenessProbe: {
+            httpGet: {
+              path: "/health",
+              port: 8080,
+            },
+            periodSeconds: 30,
+            failureThreshold: 3,
+            timeoutSeconds: 5,
           },
         },
       ],

--- a/infra/domain.ts
+++ b/infra/domain.ts
@@ -1,6 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as gcp from "@pulumi/gcp";
 import { service } from "./cloudrun";
+import { services as enabledApis } from "./apis";
 
 const config = new pulumi.Config();
 const domain = config.require("domain");
@@ -9,12 +10,6 @@ const domainVerificationTxt = config.require("domainVerificationTxt");
 const parts = domain.split(".");
 const rootDomain = parts.slice(-2).join(".");
 
-// Cloud DNS API有効化
-export const dnsApi = new gcp.projects.Service("dns.googleapis.com", {
-  service: "dns.googleapis.com",
-  disableOnDestroy: false,
-});
-
 // Cloud DNSマネージドゾーン（ルートドメインで管理）
 export const dnsZone = new gcp.dns.ManagedZone(
   "exvs-analyzer-zone",
@@ -22,8 +17,11 @@ export const dnsZone = new gcp.dns.ManagedZone(
     name: "exvs-analyzer",
     dnsName: rootDomain + ".",
     description: "EXVS Analyzer DNS zone",
+    dnssecConfig: {
+      state: "on",
+    },
   },
-  { dependsOn: [dnsApi] }
+  { dependsOn: enabledApis }
 );
 
 // Cloud Runドメインマッピング

--- a/infra/iam.ts
+++ b/infra/iam.ts
@@ -1,0 +1,77 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as gcp from "@pulumi/gcp";
+
+const config = new pulumi.Config();
+const githubRepo = config.require("githubRepo");
+
+// GitHub Actions用サービスアカウント
+export const githubActionsSa = new gcp.serviceaccount.Account(
+  "github-actions",
+  {
+    accountId: "github-actions",
+    displayName: "GitHub Actions",
+  }
+);
+
+// Workload Identity Pool
+export const wifPool = new gcp.iam.WorkloadIdentityPool("github-pool", {
+  workloadIdentityPoolId: "github-pool",
+  displayName: "GitHub Actions Pool",
+});
+
+// Workload Identity Provider（OIDC）
+export const wifProvider = new gcp.iam.WorkloadIdentityPoolProvider(
+  "github-provider",
+  {
+    workloadIdentityPoolId: wifPool.workloadIdentityPoolId,
+    workloadIdentityPoolProviderId: "github-provider",
+    displayName: "GitHub Provider",
+    attributeMapping: {
+      "google.subject": "assertion.sub",
+      "attribute.repository": "assertion.repository",
+    },
+    attributeCondition: `assertion.repository=='${githubRepo}'`,
+    oidc: {
+      issuerUri: "https://token.actions.githubusercontent.com",
+    },
+  }
+);
+
+// WIF → サービスアカウントへのworkloadIdentityUser権限
+export const wifBinding = new gcp.serviceaccount.IAMBinding(
+  "github-actions-wif",
+  {
+    serviceAccountId: githubActionsSa.name,
+    role: "roles/iam.workloadIdentityUser",
+    members: [
+      pulumi.interpolate`principalSet://iam.googleapis.com/${wifPool.name}/attribute.repository/${githubRepo}`,
+    ],
+  }
+);
+
+// サービスアカウント自身のserviceAccountUser権限
+export const saUserBinding = new gcp.serviceaccount.IAMBinding(
+  "github-actions-sa-user",
+  {
+    serviceAccountId: githubActionsSa.name,
+    role: "roles/iam.serviceAccountUser",
+    members: [githubActionsSa.member],
+  }
+);
+
+// プロジェクトレベルのIAMロール
+const projectRoles = [
+  "roles/cloudbuild.builds.editor",
+  "roles/run.admin",
+  "roles/storage.admin",
+  "roles/viewer",
+];
+
+export const projectBindings = projectRoles.map(
+  (role) =>
+    new gcp.projects.IAMMember(`github-actions-${role.split("/")[1]}`, {
+      project: gcp.config.project!,
+      role: role,
+      member: githubActionsSa.member,
+    })
+);

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -3,6 +3,7 @@ import { repository } from "./artifact-registry";
 import { service, url, iamBinding } from "./cloudrun";
 import { nameServers, dnsZone, domainMapping, dnsRecords } from "./domain";
 import { stateBucket, dataBucket } from "./storage";
+import { githubActionsSa, wifPool, wifProvider } from "./iam";
 // TODO: budget importはBilling Budget APIのquota project設定後に対応
 // import { budget } from "./budget";
 
@@ -16,3 +17,6 @@ export const customDomain = domainMapping.name;
 export const requiredDnsRecords = dnsRecords;
 export const pulumiStateBucketName = stateBucket.name;
 export const appDataBucketName = dataBucket.name;
+export const serviceAccountEmail = githubActionsSa.email;
+export const wifPoolId = wifPool.workloadIdentityPoolId;
+export const wifProviderId = wifProvider.workloadIdentityPoolProviderId;

--- a/infra/storage.ts
+++ b/infra/storage.ts
@@ -10,6 +10,8 @@ export const stateBucket = new gcp.storage.Bucket("pulumi-state", {
   name: pulumiStateBucket,
   location: gcp.config.region!,
   uniformBucketLevelAccess: true,
+  publicAccessPrevention: "enforced",
+  forceDestroy: false,
 });
 
 // アプリ用データバケット（ユーザーCSV保存）
@@ -17,4 +19,16 @@ export const dataBucket = new gcp.storage.Bucket("app-data", {
   name: gcsBucket,
   location: gcp.config.region!,
   uniformBucketLevelAccess: true,
+  publicAccessPrevention: "enforced",
+  versioning: { enabled: true },
+  forceDestroy: false,
+  lifecycleRules: [
+    {
+      action: { type: "Delete" },
+      condition: {
+        numNewerVersions: 3,
+        withState: "ARCHIVED",
+      },
+    },
+  ],
 });


### PR DESCRIPTION
## Summary
### 新規Pulumi管理リソース
- Workload Identity Pool / Provider (`iam.ts`)
- GitHub Actionsサービスアカウント + IAMバインディング (`iam.ts`)

### ベストプラクティス改善
- GCSバケット: `publicAccessPrevention: "enforced"`, バージョニング, ライフサイクルルール
- Cloud Run: ライブネスプローブ追加 (`/health`), スタートアッププローブ調整
- DNSSEC有効化
- API有効化をapis.tsに統合（dns, iam追加）

## マージ後に必要な作業
1. 既存リソースの`pulumi import`（WIF Pool, Provider, SA, IAMバインディング）
2. `pulumi preview`で差分確認 → `pulumi up`
3. DNSSEC有効化後、お名前.comでDSレコード登録が必要な場合あり

## 費用への影響
- すべて無料（DNSSEC、ライブネスプローブ、publicAccessPrevention等）
- バージョニングはストレージ費用が微増（古いバージョン3世代まで保持）

ref #116