### PR TITLE
fix: pulumi/actions@v6をCLI直接実行に置き換え

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,22 +70,13 @@ jobs:
           gcloud builds submit --tag "$IMAGE"
           echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
 
-      - name: Update Pulumi image config
+      - name: Deploy with Pulumi
         working-directory: infra
         run: |
           npm install -g @pulumi/pulumi 2>/dev/null || true
           pulumi login gs://${{ secrets.PULUMI_STATE_BUCKET }}
           pulumi stack select dev
           pulumi config set exvs-analyzer:image "$IMAGE" --secret
-        env:
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
-
-      - name: Deploy with Pulumi
-        uses: pulumi/actions@v6
-        with:
-          command: up
-          work-dir: infra
-          stack-name: dev
-          cloud-url: gs://${{ secrets.PULUMI_STATE_BUCKET }}
+          pulumi up --yes
         env:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -45,13 +45,24 @@ jobs:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
-      - uses: pulumi/actions@v6
+      - name: Pulumi preview
         if: steps.check-secrets.outputs.skip != 'true'
-        with:
-          command: preview
-          work-dir: infra
-          stack-name: dev
-          comment-on-pr: true
-          cloud-url: gs://${{ secrets.PULUMI_STATE_BUCKET }}
+        working-directory: infra
+        run: |
+          npm install -g @pulumi/pulumi 2>/dev/null || true
+          pulumi login gs://${{ secrets.PULUMI_STATE_BUCKET }}
+          pulumi stack select dev
+          pulumi preview 2>&1 | tee /tmp/pulumi-preview.txt
         env:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+
+      - name: Comment preview on PR
+        if: steps.check-secrets.outputs.skip != 'true' && always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREVIEW=$(cat /tmp/pulumi-preview.txt 2>/dev/null || echo "Preview output not available")
+          gh pr comment "${{ github.event.pull_request.number }}" --body "## Pulumi Preview
+          \`\`\`
+          ${PREVIEW}
+          \`\`\`"


### PR DESCRIPTION
## Summary
- cd.yml: `pulumi/actions@v6`を削除し、`pulumi up --yes`のCLI直接実行に変更
- infra-ci.yml: `pulumi/actions@v6`を削除し、`pulumi preview`のCLI直接実行に変更
- infra-ci.yml: preview結果を`gh pr comment`でPRにコメント投稿する機能を追加
- Node.js 20ランタイムの非推奨警告を解消

## Test plan
- [ ] CDワークフローでNode.js 20の非推奨警告が出なくなることを確認
- [ ] infra/変更時にPulumi previewがPRコメントに投稿されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)