### PR TITLE
fix: GCSバケットIAM修正 + 共有ボタン表示修正

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -14,3 +14,9 @@ config:
   exvs-analyzer:image:
     secure: v1:M0xwOizR13d1hFXd:NNKu4x2RQ5y20QPaE9b+/zhsh4MWfRFdWzTCQz6erSt0wboyLy8TT44PsFxNJM0q7vLeJ18=
   exvs-analyzer:domain: www.exvs-analyzer.com
+  exvs-analyzer:domainVerificationTxt: google-site-verification=TAXKxm2PncupGRZkk0mBxIxslp_7aZj-w9dxPAi-ObE
+  exvs-analyzer:pulumiStateBucket:
+    secure: v1:DTT5hikna9CWd6by:Nx5wUNbRTnn7SC03sCc5yPzugTPiZSwmiwJ0vjNRrsparkbP48cmYa5OJAFp
+  exvs-analyzer:githubRepo: yuki9431/exvs-analyzer
+  exvs-analyzer:computeSa:
+    secure: v1:IgRCxU3FUKAgYFVM:84Vd9wpKbv4aii4ZiSsWCwdpXAEfNtx6l52NGnLzp6b2YZL/t04CeFNJTHSmsEOqGxHRazl1yAnoAUhe0ZfJKWRO

--- a/infra/storage.ts
+++ b/infra/storage.ts
@@ -4,6 +4,7 @@ import * as gcp from "@pulumi/gcp";
 const config = new pulumi.Config();
 const pulumiStateBucket = config.requireSecret("pulumiStateBucket");
 const gcsBucket = config.requireSecret("gcsBucket");
+const computeSa = config.requireSecret("computeSa");
 
 // Pulumiステート保存用バケット
 export const stateBucket = new gcp.storage.Bucket("pulumi-state", {
@@ -32,3 +33,13 @@ export const dataBucket = new gcp.storage.Bucket("app-data", {
     },
   ],
 });
+
+// Cloud Runデフォルトcompute SAにデータバケットへの最低限の権限を付与
+export const dataBucketIam = new gcp.storage.BucketIAMMember(
+  "app-data-compute-sa",
+  {
+    bucket: dataBucket.name,
+    role: "roles/storage.objectUser",
+    member: pulumi.interpolate`serviceAccount:${computeSa}`,
+  }
+);

--- a/static/app.js
+++ b/static/app.js
@@ -26,6 +26,7 @@ async function analyze() {
   statusText.textContent = STATUS_MESSAGES.pending;
   error.style.display = 'none';
   report.style.display = 'none';
+  document.querySelectorAll('.share-area').forEach(function(el) { el.remove(); });
 
   try {
     // ジョブ作成


### PR DESCRIPTION
## Summary
- デフォルトcompute SAにデータバケットへの`roles/storage.objectUser`を付与（最低限権限）
- `uniformBucketLevelAccess`有効化でGCSアクセスが失われていた問題の修正
- 分析再実行時に前回の共有ボタンが残る問題を修正

ref #116