### PR TITLE
fix: IAM権限を最小権限に変更

### DIFF
--- a/infra/iam.ts
+++ b/infra/iam.ts
@@ -1,5 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as gcp from "@pulumi/gcp";
+import { stateBucket, dataBucket } from "./storage";
 
 const config = new pulumi.Config();
 const githubRepo = config.require("githubRepo");
@@ -59,11 +60,10 @@ export const saUserBinding = new gcp.serviceaccount.IAMBinding(
   }
 );
 
-// プロジェクトレベルのIAMロール
+// プロジェクトレベルのIAMロール（最小権限）
 const projectRoles = [
   "roles/cloudbuild.builds.editor",
-  "roles/run.admin",
-  "roles/storage.admin",
+  "roles/run.developer",
   "roles/viewer",
 ];
 
@@ -74,4 +74,23 @@ export const projectBindings = projectRoles.map(
       role: role,
       member: githubActionsSa.member,
     })
+);
+
+// バケット単位のStorage権限（プロジェクトレベルのstorage.adminを廃止）
+export const stateBucketBinding = new gcp.storage.BucketIAMMember(
+  "github-actions-state-bucket",
+  {
+    bucket: stateBucket.name,
+    role: "roles/storage.objectAdmin",
+    member: githubActionsSa.member,
+  }
+);
+
+export const dataBucketBinding = new gcp.storage.BucketIAMMember(
+  "github-actions-data-bucket",
+  {
+    bucket: dataBucket.name,
+    role: "roles/storage.objectAdmin",
+    member: githubActionsSa.member,
+  }
 );


### PR DESCRIPTION
## Summary
- `roles/run.admin` → `roles/run.developer` に縮小（IAMポリシー変更権限を除去）
- `roles/storage.admin`（プロジェクト全体）を廃止
- Pulumiステートバケット・アプリデータバケットそれぞれに `roles/storage.objectAdmin` をバケット単位で付与

## 変更の背景
セキュリティ監査で以下のリスクを検出:
- `run.admin` はCloud RunサービスのIAMポリシー変更も可能で、権限昇格リスクがある
- `storage.admin` がプロジェクト全体に適用されており、CDパイプラインが任意のバケットを削除可能だった

## Test plan
- [ ] `pulumi preview` でIAM変更の差分を確認
- [ ] デプロイ後、CDワークフローが正常にビルド・デプロイできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)