### PR TITLE
fix: CDに必要なGCP APIの有効化とIAM依存関係を追加

### DIFF
--- a/infra/apis.ts
+++ b/infra/apis.ts
@@ -6,6 +6,8 @@ const enabledApis = [
   "cloudbuild.googleapis.com",
   "dns.googleapis.com",
   "iam.googleapis.com",
+  "cloudresourcemanager.googleapis.com",
+  "compute.googleapis.com",
 ];
 
 export const services = enabledApis.map(

--- a/infra/iam.ts
+++ b/infra/iam.ts
@@ -1,6 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as gcp from "@pulumi/gcp";
 import { stateBucket, dataBucket } from "./storage";
+import { services } from "./apis";
 
 const config = new pulumi.Config();
 const githubRepo = config.require("githubRepo");
@@ -69,11 +70,15 @@ const projectRoles = [
 
 export const projectBindings = projectRoles.map(
   (role) =>
-    new gcp.projects.IAMMember(`github-actions-${role.split("/")[1]}`, {
-      project: gcp.config.project!,
-      role: role,
-      member: githubActionsSa.member,
-    })
+    new gcp.projects.IAMMember(
+      `github-actions-${role.split("/")[1]}`,
+      {
+        project: gcp.config.project!,
+        role: role,
+        member: githubActionsSa.member,
+      },
+      { dependsOn: services }
+    )
 );
 
 // バケット単位のStorage権限（プロジェクトレベルのstorage.adminを廃止）


### PR DESCRIPTION
## Summary
- `cloudresourcemanager.googleapis.com` と `compute.googleapis.com` を `infra/apis.ts` の有効化リストに追加
- `infra/iam.ts` の `projectBindings` に `dependsOn: services` を追加し、API有効化後にIAMリソースが作成されるよう依存関係を明示

## 原因
[CD #24271418209](https://github.com/yuki9431/exvs-analyzer/actions/runs/24271418209/job/70877039329) で `gcp.projects.IAMMember` の作成時に Cloud Resource Manager API が無効というエラーが発生。PR #122 で追加された `gcp.projects.IAMMember` がこのAPIを必要としていた。

## Test plan
- [ ] Infra CI (`pulumi preview`) がパスすること
- [ ] CDワークフローが正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)