### PR TITLE
perf: スクレイピングを並列化して高速化

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -2,9 +2,12 @@ package scraper
 
 import (
 	"fmt"
+	"net/http"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gocolly/colly/v2"
@@ -15,7 +18,24 @@ const (
 	vsmobile         = "web.vsmobile.jp"
 	mobileRankpage   = "https://web.vsmobile.jp/exvs2ib/results/classmatch/fight"
 	mobileMSUsedRate = "https://web.vsmobile.jp/exvs2ib/ranking/ms_used_rate"
+
+	// maxParallelism はバンナムサーバーへの最大同時リクエスト数
+	maxParallelism = 3
 )
+
+// dailyLink はrankpageから収集した日別ページ情報
+type dailyLink struct {
+	date string
+	url  string
+}
+
+// matchEntry は日別ページから収集した試合情報
+type matchEntry struct {
+	date      string
+	hour      string
+	wins      []string
+	detailURL string
+}
 
 func parseNumber(s string) int {
 	re := regexp.MustCompile(`[\d,]+`)
@@ -32,13 +52,8 @@ func parseNumber(s string) int {
 type ProgressFunc func(message string)
 
 // Scraping はスクレイピング処理を実行し、DatedScoresを返す
+// 日別ページと詳細ページを並列で取得し、高速化を図る
 func Scraping(username, password string, since time.Time, onProgress ...ProgressFunc) model.DatedScores {
-	var (
-		scores     model.DatedScores
-		date, hour string
-		wins       []string
-	)
-
 	notify := func(msg string) {
 		if len(onProgress) > 0 && onProgress[0] != nil {
 			onProgress[0](msg)
@@ -49,16 +64,43 @@ func Scraping(username, password string, since time.Time, onProgress ...Progress
 	notify("ログイン中...")
 	m.Login()
 
-	rankpage := colly.NewCollector(
-		colly.AllowedDomains(vsmobile),
-	)
-	rankpage.SetCookieJar(m.HTTPClient.Jar)
-	dailypage := rankpage.Clone()
-	detailpage := rankpage.Clone()
+	// Phase 1: rankpageから日別ページURLを収集
+	dailyLinks := collectDailyLinks(m.HTTPClient.Jar, since)
 
-	rankpage.OnHTML("li.item", func(e *colly.HTMLElement) {
+	// Phase 2: 日別ページから試合エントリを並列収集
+	entries := collectAllMatchEntries(m.HTTPClient.Jar, dailyLinks, since)
+
+	// 日時降順でソートして元の取得順序を再現
+	sort.Slice(entries, func(i, j int) bool {
+		ti, _ := time.Parse("2006/01/02 15:04", entries[i].date+" "+entries[i].hour)
+		tj, _ := time.Parse("2006/01/02 15:04", entries[j].date+" "+entries[j].hour)
+		return ti.After(tj)
+	})
+
+	// Phase 3: 試合詳細ページを並列取得
+	scores := fetchDetailPages(m.HTTPClient.Jar, entries, notify)
+
+	// 日時降順・プレイヤーNo昇順でソートして元の順序を保つ
+	sort.Slice(scores, func(i, j int) bool {
+		if !scores[i].Datetime.Equal(scores[j].Datetime) {
+			return scores[i].Datetime.After(scores[j].Datetime)
+		}
+		return scores[i].PlayerNo < scores[j].PlayerNo
+	})
+
+	return scores
+}
+
+// collectDailyLinks はrankpageから日別ページのURLを収集する
+func collectDailyLinks(jar http.CookieJar, since time.Time) []dailyLink {
+	var links []dailyLink
+
+	c := colly.NewCollector(colly.AllowedDomains(vsmobile))
+	c.SetCookieJar(jar)
+
+	c.OnHTML("li.item", func(e *colly.HTMLElement) {
 		r := regexp.MustCompile(`\(.*`)
-		date = r.ReplaceAllString(e.ChildText("p.datetime.fz-ss"), "")
+		date := r.ReplaceAllString(e.ChildText("p.datetime.fz-ss"), "")
 
 		if !since.IsZero() {
 			d, err := time.Parse("2006/01/02", date)
@@ -67,105 +109,201 @@ func Scraping(username, password string, since time.Time, onProgress ...Progress
 			}
 		}
 
-		link := e.ChildAttr("a", "href")
-		dailypage.Visit(link)
+		link := e.Request.AbsoluteURL(e.ChildAttr("a", "href"))
+		links = append(links, dailyLink{date: date, url: link})
 	})
 
-	dailypage.OnHTML("li.item", func(e *colly.HTMLElement) {
-		hour = e.ChildText("p.datetime.fz-ss")
+	c.Visit(mobileRankpage)
+	return links
+}
+
+// collectAllMatchEntries は複数の日別ページから試合エントリを並列で収集する
+func collectAllMatchEntries(jar http.CookieJar, links []dailyLink, since time.Time) []matchEntry {
+	var (
+		allEntries []matchEntry
+		mu         sync.Mutex
+	)
+
+	sem := make(chan struct{}, maxParallelism)
+	var wg sync.WaitGroup
+
+	for _, dl := range links {
+		wg.Add(1)
+		go func(dl dailyLink) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			entries := collectMatchEntries(jar, dl, since)
+			mu.Lock()
+			allEntries = append(allEntries, entries...)
+			mu.Unlock()
+		}(dl)
+	}
+
+	wg.Wait()
+	return allEntries
+}
+
+// collectMatchEntries は単一の日別ページから試合エントリを収集する（ページネーション対応）
+// since以前の試合が出たらページネーションを早期終了する
+func collectMatchEntries(jar http.CookieJar, dl dailyLink, since time.Time) []matchEntry {
+	var entries []matchEntry
+	stopPagination := false
+
+	c := colly.NewCollector(colly.AllowedDomains(vsmobile))
+	c.SetCookieJar(jar)
+
+	c.OnHTML("li.item", func(e *colly.HTMLElement) {
+		hour := e.ChildText("p.datetime.fz-ss")
 
 		if !since.IsZero() {
-			t, err := time.Parse("2006/01/02 15:04", date+" "+hour)
+			t, err := time.Parse("2006/01/02 15:04", dl.date+" "+hour)
 			if err == nil && !t.After(since) {
+				stopPagination = true
 				return
 			}
 		}
 
-		if d, err := time.Parse("2006/01/02 15:04", date+" "+hour); err == nil {
-			notify(fmt.Sprintf("%sの戦歴データを取得中...", d.Format("01/02 15:04")))
-		}
-
+		var wins []string
 		if e.ChildAttr("a", "class") == "right-arrow vs-detail win" {
 			wins = []string{"win", "win", "lose", "lose"}
 		} else {
 			wins = []string{"lose", "lose", "win", "win"}
 		}
 
-		link := e.ChildAttr("a", "href")
-		detailpage.Visit(link)
+		link := e.Request.AbsoluteURL(e.ChildAttr("a", "href"))
+		entries = append(entries, matchEntry{
+			date:      dl.date,
+			hour:      hour,
+			wins:      wins,
+			detailURL: link,
+		})
 	})
 
-	dailypage.OnHTML("div.block.control", func(e *colly.HTMLElement) {
+	c.OnHTML("div.block.control", func(e *colly.HTMLElement) {
+		if stopPagination {
+			return
+		}
 		// 「>」(次へ)ボタンは末尾から2番目のリンク
 		links := e.ChildAttrs("ul.clearfix > li > a", "href")
 		if len(links) >= 2 {
 			nextLink := links[len(links)-2]
 			if nextLink != "javascript:void(0);" {
-				dailypage.Visit(nextLink)
+				c.Visit(e.Request.AbsoluteURL(nextLink))
 			}
 		}
 	})
 
-	detailpage.OnHTML("div.panel_area", func(e *colly.HTMLElement) {
-		selectorLeftValue := "div.w45.pr-ss > dl > dd"
-		selectorRightValue := "div.w55 > dl > dd"
-		selectorCity := "div.w80.ta-r > p.col-stand"
-		selectorName := "p.mb-ss.fz-m > span.name"
-		selectorMSImage := "#panel3 img.item-icon-img"
+	c.Visit(dl.url)
+	return entries
+}
 
-		cities := e.ChildTexts(selectorCity)
-		names := e.ChildTexts(selectorName)
-		msImages := e.ChildAttrs(selectorMSImage, "data-original")
-		leftValue := e.ChildTexts(selectorLeftValue)
-		rightValue := e.ChildTexts(selectorRightValue)
+// fetchDetailPages は試合詳細ページを並列で取得しDatedScoresを返す
+func fetchDetailPages(jar http.CookieJar, entries []matchEntry, notify func(string)) model.DatedScores {
+	var (
+		scores model.DatedScores
+		mu     sync.Mutex
+	)
 
-		var layout = "2006/01/02 15:04"
-		t := date + " " + hour
-		datatime, _ := time.Parse(layout, t)
-
-		playerCount := 4
-
-		for i := 0; i < playerCount; i++ {
-			offL := i * 3
-			offR := i * 3
-
-			city := cities[i]
-			name := names[i]
-			win := wins[i]
-			msImage := ""
-			if i < len(msImages) {
-				msImage = msImages[i]
-			}
-			point := parseNumber(leftValue[0+offL])
-			kills := parseNumber(leftValue[1+offL])
-			deaths := parseNumber(leftValue[2+offL])
-			giveDamage := parseNumber(rightValue[0+offR])
-			receiveDamage := parseNumber(rightValue[1+offR])
-			exDamage := parseNumber(rightValue[2+offR])
-
-			result := model.DatedScore{
-				PlayerNo: i + 1,
-				Datetime: datatime,
-				PlayerScore: model.PlayerScore{
-					City:           city,
-					Name:           name,
-					Win:            win,
-					MsImage:        msImage,
-					MsName:         "",
-					Point:          point,
-					Kills:          kills,
-					Deaths:         deaths,
-					Give_damage:    giveDamage,
-					Receive_damage: receiveDamage,
-					Ex_damage:      exDamage,
-				},
-			}
-
-			scores = append(scores, result)
-		}
+	c := colly.NewCollector(
+		colly.AllowedDomains(vsmobile),
+		colly.Async(true),
+	)
+	c.SetCookieJar(jar)
+	c.Limit(&colly.LimitRule{
+		DomainGlob:  "*",
+		Parallelism: maxParallelism,
 	})
 
-	rankpage.Visit(mobileRankpage)
+	c.OnHTML("div.panel_area", func(e *colly.HTMLElement) {
+		date := e.Request.Ctx.Get("date")
+		hour := e.Request.Ctx.Get("hour")
+		wins := strings.Split(e.Request.Ctx.Get("wins"), ",")
+
+		parsed := parseDetailPage(e, date, hour, wins)
+		mu.Lock()
+		scores = append(scores, parsed...)
+		mu.Unlock()
+	})
+
+	for _, entry := range entries {
+		if d, err := time.Parse("2006/01/02 15:04", entry.date+" "+entry.hour); err == nil {
+			notify(fmt.Sprintf("%sの戦歴データを取得中...", d.Format("01/02 15:04")))
+		}
+
+		ctx := colly.NewContext()
+		ctx.Put("date", entry.date)
+		ctx.Put("hour", entry.hour)
+		ctx.Put("wins", strings.Join(entry.wins, ","))
+		c.Request("GET", entry.detailURL, nil, ctx, nil)
+	}
+
+	c.Wait()
+	return scores
+}
+
+// parseDetailPage は試合詳細ページからスコアを抽出する
+func parseDetailPage(e *colly.HTMLElement, date, hour string, wins []string) model.DatedScores {
+	var scores model.DatedScores
+
+	selectorLeftValue := "div.w45.pr-ss > dl > dd"
+	selectorRightValue := "div.w55 > dl > dd"
+	selectorCity := "div.w80.ta-r > p.col-stand"
+	selectorName := "p.mb-ss.fz-m > span.name"
+	selectorMSImage := "#panel3 img.item-icon-img"
+
+	cities := e.ChildTexts(selectorCity)
+	names := e.ChildTexts(selectorName)
+	msImages := e.ChildAttrs(selectorMSImage, "data-original")
+	leftValue := e.ChildTexts(selectorLeftValue)
+	rightValue := e.ChildTexts(selectorRightValue)
+
+	layout := "2006/01/02 15:04"
+	t := date + " " + hour
+	datetime, _ := time.Parse(layout, t)
+
+	playerCount := 4
+
+	for i := 0; i < playerCount; i++ {
+		offL := i * 3
+		offR := i * 3
+
+		city := cities[i]
+		name := names[i]
+		win := wins[i]
+		msImage := ""
+		if i < len(msImages) {
+			msImage = msImages[i]
+		}
+		point := parseNumber(leftValue[0+offL])
+		kills := parseNumber(leftValue[1+offL])
+		deaths := parseNumber(leftValue[2+offL])
+		giveDamage := parseNumber(rightValue[0+offR])
+		receiveDamage := parseNumber(rightValue[1+offR])
+		exDamage := parseNumber(rightValue[2+offR])
+
+		result := model.DatedScore{
+			PlayerNo: i + 1,
+			Datetime: datetime,
+			PlayerScore: model.PlayerScore{
+				City:           city,
+				Name:           name,
+				Win:            win,
+				MsImage:        msImage,
+				MsName:         "",
+				Point:          point,
+				Kills:          kills,
+				Deaths:         deaths,
+				Give_damage:    giveDamage,
+				Receive_damage: receiveDamage,
+				Ex_damage:      exDamage,
+			},
+		}
+
+		scores = append(scores, result)
+	}
+
 	return scores
 }
 


### PR DESCRIPTION
## Summary
- スクレイピング処理を3フェーズ構成に分割し、日別ページと試合詳細ページの取得を並列化
- バンナムサーバーへの同時リクエストを最大3に制限（goroutine+セマフォ / Colly Async+Parallelism）
- since以前の試合検出時にページネーションを早期終了し、不要なリクエストを削減
- 結果を日時降順ソートして従来と同じ出力順序を保持

## 変更内容

### 1. Collyの並列化
- 試合詳細ページの取得を`colly.Async(true)` + `Parallelism: 3`で並列化
- `colly.Context`を使って各リクエストに日時・勝敗情報を紐付け（共有変数の排除）
- `c.Wait()`で全リクエスト完了を待機

### 2. 日別ページの並列処理
- `collectAllMatchEntries`でgoroutine + チャネルセマフォ（上限3）による並列処理
- 各日別ページごとに独立したCollyコレクターを使用し、ページネーションを独立制御

### 3. 不要なリクエスト削減
- 日別ページ内でsince以前の試合を検出したらページネーションを早期終了
- rankpageでsince以前の日付をスキップ（既存動作の維持）

## Test plan
- [ ] `make build` でビルド成功を確認
- [ ] `go vet ./...` でエラーなしを確認
- [ ] 初回実行（since=ゼロ値）で全戦績が取得されることを確認
- [ ] 2回目以降（since指定あり）で差分のみ取得されることを確認
- [ ] 結果のCSV出力が従来と同じ順序・内容であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)