### PR TITLE
fix: オーナーアカウントのStorage権限をPulumiで管理

### DIFF
--- a/infra/storage.ts
+++ b/infra/storage.ts
@@ -5,6 +5,7 @@ const config = new pulumi.Config();
 const pulumiStateBucket = config.requireSecret("pulumiStateBucket");
 const gcsBucket = config.requireSecret("gcsBucket");
 const computeSa = config.requireSecret("computeSa");
+const ownerEmail = config.requireSecret("ownerEmail");
 
 // Pulumiステート保存用バケット
 export const stateBucket = new gcp.storage.Bucket("pulumi-state", {
@@ -33,6 +34,16 @@ export const dataBucket = new gcp.storage.Bucket("app-data", {
     },
   ],
 });
+
+// オーナーアカウントにデータバケットの管理権限を付与
+export const dataBucketOwnerIam = new gcp.storage.BucketIAMMember(
+  "app-data-owner",
+  {
+    bucket: dataBucket.name,
+    role: "roles/storage.admin",
+    member: pulumi.interpolate`user:${ownerEmail}`,
+  }
+);
 
 // Cloud Runデフォルトcompute SAにデータバケットへの最低限の権限を付与
 export const dataBucketIam = new gcp.storage.BucketIAMMember(


### PR DESCRIPTION
## Summary
- `infra/storage.ts` にオーナーアカウントの `roles/storage.admin` を `BucketIAMMember` で追加
- メールアドレスは `Pulumi config secret` (`ownerEmail`) で管理し、コードにはハードコードしない

## 原因
Pulumiでバケットを管理し始めた後、プロジェクトレベルのOwnerロールからバケットへのアクセスが失われ、GCPコンソール・gsutilからCSVをダウンロードできなくなっていた。

## デプロイ前の手順
Pulumi configに `ownerEmail` を設定する必要があります:
```bash
cd infra && pulumi config set --secret ownerEmail <メールアドレス>
```

## Test plan
- [ ] Infra CI (`pulumi preview`) がパスすること
- [ ] デプロイ後、GCPコンソールからCSVダウンロードできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)