### PR TITLE
fix: GitHub ActionsにAPI有効化権限を追加

### DIFF
--- a/infra/iam.ts
+++ b/infra/iam.ts
@@ -65,6 +65,7 @@ export const saUserBinding = new gcp.serviceaccount.IAMBinding(
 const projectRoles = [
   "roles/cloudbuild.builds.editor",
   "roles/run.developer",
+  "roles/serviceusage.serviceUsageAdmin",
   "roles/viewer",
 ];
 


### PR DESCRIPTION
## Summary
- `infra/iam.ts` の `projectRoles` に `roles/serviceusage.serviceUsageAdmin` を追加
- CDパイプラインからGCP APIの有効化・無効化が可能になる

## 原因
PR #125 で `cloudresourcemanager.googleapis.com` と `compute.googleapis.com` をPulumiで有効化するよう追加したが、GitHub Actionsのサービスアカウントにサービス有効化権限がなくCDが失敗していた。

## Test plan
- [ ] Infra CI (`pulumi preview`) がパスすること
- [ ] CDワークフローが正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)