### PR TITLE
fix: Pulumi configにownerEmail追加、CLAUDE.mdにローカル環境情報を追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,15 @@ python3 -m http.server 8888 --directory static
 # レポートプレビュー更新
 python3 scripts/analyze.py /tmp/scores.csv
 cp /tmp/report.md static/sample_report.md
+
+# Pulumiコマンド（Docker経由）
+PULUMI_CONFIG_PASSPHRASE=<passphrase> make pulumi-preview   # 変更プレビュー
+PULUMI_CONFIG_PASSPHRASE=<passphrase> make pulumi-up        # 変更適用
 ```
 
 http://localhost:8080 でアクセス可能。
+
+**ローカル環境にはGo/Python/Pulumiはインストールされていない。** すべてDocker経由（Makefile）で実行する。Pulumi操作時は `infra/.envrc`（direnv）から `PULUMI_CONFIG_PASSPHRASE` が自動で読み込まれる。
 
 CIでは `go vet`、`go build`、`py_compile` を実行。ラベル `skip-ci` でスキップ可能。
 

--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -20,3 +20,5 @@ config:
   exvs-analyzer:githubRepo: yuki9431/exvs-analyzer
   exvs-analyzer:computeSa:
     secure: v1:IgRCxU3FUKAgYFVM:84Vd9wpKbv4aii4ZiSsWCwdpXAEfNtx6l52NGnLzp6b2YZL/t04CeFNJTHSmsEOqGxHRazl1yAnoAUhe0ZfJKWRO
+  exvs-analyzer:ownerEmail:
+    secure: v1:PPXFgxigyRzBi94p:D9+0MQOCQGmsIsLGmPxFp8LzFnsuwRqgS+2HkAMWIXJR8FkJ


### PR DESCRIPTION
## Summary
- `infra/Pulumi.dev.yaml` に `ownerEmail` を暗号化secretとして追加（PR #128 の `dataBucketOwnerIam` に必要）
- `CLAUDE.md` にローカル環境情報（Docker経由の実行、Pulumiコマンド、`.envrc`）を追記

## Test plan
- [ ] CDワークフローが正常に完了すること（`no-deploy` ラベルなし）
- [ ] Pulumi upでオーナーのStorage権限が付与されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)