### PR TITLE
fix: GitHub ActionsにプロジェクトIAM管理権限を追加

### DIFF
--- a/infra/iam.ts
+++ b/infra/iam.ts
@@ -64,6 +64,7 @@ export const saUserBinding = new gcp.serviceaccount.IAMBinding(
 // プロジェクトレベルのIAMロール（最小権限）
 const projectRoles = [
   "roles/cloudbuild.builds.editor",
+  "roles/resourcemanager.projectIamAdmin",
   "roles/run.developer",
   "roles/serviceusage.serviceUsageAdmin",
   "roles/viewer",


### PR DESCRIPTION
## Summary
- `infra/iam.ts` の `projectRoles` に `roles/resourcemanager.projectIamAdmin` を追加
- CDパイプラインからプロジェクトレベルのIAMポリシー変更が可能になる

## 原因
PR #122 でIAMロールを変更（`run.admin` → `run.developer` 等）した際、新しい `IAMMember` リソースの作成が必要になったが、サービスアカウントに `resourcemanager.projects.setIamPolicy` 権限がなくCDが失敗していた。

## Test plan
- [ ] CDワークフローが正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)