### PR TITLE
fix: Cloud BuildバケットへのStorage権限を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 ## セキュリティルール
 
 - **GCPプロジェクトID、バケット名、サービスアカウント等のインフラ識別子をコードやCLAUDE.mdにハードコードしない。** 環境変数またはGitHub Secrets/Variablesを使うこと。
+- **IAM権限は最小権限の原則を徹底する。** プロジェクトレベルの広範なロール（例: `roles/storage.admin`）ではなく、バケット単位・リソース単位で必要最低限のロール（例: `roles/storage.objectUser`）を付与すること。
 - 公開リポジトリのため、コミット履歴にも残ることを意識する。
 - マルチステージDockerfile: `golang:1.26-alpine` でビルド、`python:3.11-alpine` で実行
 - CSP: `script-src 'self'`（インラインスクリプト禁止）、`style-src 'self' 'unsafe-inline'`

--- a/infra/iam.ts
+++ b/infra/iam.ts
@@ -101,3 +101,13 @@ export const dataBucketBinding = new gcp.storage.BucketIAMMember(
     member: githubActionsSa.member,
   }
 );
+
+// Cloud Buildバケットへのストレージ権限（gcloud builds submitのソースアップロード用）
+export const cloudbuildBucketBinding = new gcp.storage.BucketIAMMember(
+  "github-actions-cloudbuild-bucket",
+  {
+    bucket: `${gcp.config.project}_cloudbuild`,
+    role: "roles/storage.objectUser",
+    member: githubActionsSa.member,
+  }
+);


### PR DESCRIPTION
## Summary
- GitHub ActionsサービスアカウントにCloud Buildバケットへの`roles/storage.objectUser`権限を追加
- `gcloud builds submit`時の`storage.objects.create`権限エラーを解消
- CLAUDE.mdにIAM最小権限の原則を追記

## 背景
CDワークフローで`gcloud builds submit`実行時、Cloud Buildバケットへのソースアップロードで403エラーが発生していた。
https://github.com/yuki9431/exvs-analyzer/actions/runs/24273449734/job/70882807039

## Test plan
- [x] `gcloud`で即時権限付与済み
- [x] `pulumi preview`で差分確認済み（BucketIAMMember 1リソース追加）
- [ ] CDワークフロー再実行で動作確認