### PR TITLE
feat: プログレスバーをCSSベースのモダンなデザインに変更

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -31,21 +31,25 @@ const (
 
 // Job はバックグラウンドジョブの情報
 type Job struct {
-	ID          string    `json:"id"`
-	Status      JobStatus `json:"status"`
-	Message     string    `json:"message,omitempty"`
-	Report      string    `json:"report,omitempty"`
-	Error       string    `json:"error,omitempty"`
-	completedAt time.Time
+	ID            string    `json:"id"`
+	Status        JobStatus `json:"status"`
+	Message       string    `json:"message,omitempty"`
+	Progress      int       `json:"progress,omitempty"`
+	ProgressTotal int       `json:"progress_total,omitempty"`
+	Report        string    `json:"report,omitempty"`
+	Error         string    `json:"error,omitempty"`
+	completedAt   time.Time
 }
 
 // JobSnapshot はジョブ状態のスナップショット
 type JobSnapshot struct {
-	ID      string
-	Status  JobStatus
-	Message string
-	Report  string
-	Error   string
+	ID            string
+	Status        JobStatus
+	Message       string
+	Progress      int
+	ProgressTotal int
+	Report        string
+	Error         string
 }
 
 // ジョブストア（インメモリ）
@@ -79,11 +83,13 @@ func (j *Job) Snapshot() JobSnapshot {
 	jobsMu.RLock()
 	defer jobsMu.RUnlock()
 	return JobSnapshot{
-		ID:      j.ID,
-		Status:  j.Status,
-		Message: j.Message,
-		Report:  j.Report,
-		Error:   j.Error,
+		ID:            j.ID,
+		Status:        j.Status,
+		Message:       j.Message,
+		Progress:      j.Progress,
+		ProgressTotal: j.ProgressTotal,
+		Report:        j.Report,
+		Error:         j.Error,
 	}
 }
 
@@ -118,9 +124,11 @@ func Run(j *Job, username, password string) {
 
 	// スクレイピング
 	log.Printf("[INFO] Scraping for user (hash: %s)", storage.UserKey(username))
-	onProgress := func(msg string) {
+	onProgress := func(current, total int) {
 		jobsMu.Lock()
-		j.Message = msg
+		j.Message = "戦歴データを取得中"
+		j.Progress = current
+		j.ProgressTotal = total
 		jobsMu.Unlock()
 	}
 	datedScores := scraper.Scraping(username, password, since, onProgress)

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -23,15 +23,6 @@ const (
 	maxParallelism = 3
 )
 
-// progressBar はプログレスバー文字列を生成する
-func progressBar(label string, current, total int) string {
-	const barLen = 25
-	filled := barLen * current / total
-	bar := strings.Repeat("━", filled) + strings.Repeat("─", barLen-filled)
-	pct := 100 * current / total
-	return fmt.Sprintf("%s [%s] %d%%  %d/%d件", label, bar, pct, current, total)
-}
-
 // dailyLink はrankpageから収集した日別ページ情報
 type dailyLink struct {
 	date string
@@ -58,19 +49,18 @@ func parseNumber(s string) int {
 }
 
 // ProgressFunc はスクレイピングの進捗を通知するコールバック型
-type ProgressFunc func(message string)
+type ProgressFunc func(current, total int)
 
 // Scraping はスクレイピング処理を実行し、DatedScoresを返す
 // 日別ページと詳細ページを並列で取得し、高速化を図る
 func Scraping(username, password string, since time.Time, onProgress ...ProgressFunc) model.DatedScores {
-	notify := func(msg string) {
+	notify := func(current, total int) {
 		if len(onProgress) > 0 && onProgress[0] != nil {
-			onProgress[0](msg)
+			onProgress[0](current, total)
 		}
 	}
 
 	m := NewClient(username, password)
-	notify("ログイン中...")
 	m.Login()
 
 	// Phase 1: rankpageから日別ページURLを収集
@@ -209,7 +199,7 @@ func collectMatchEntries(jar http.CookieJar, dl dailyLink, since time.Time) []ma
 }
 
 // fetchDetailPages は試合詳細ページを並列で取得しDatedScoresを返す
-func fetchDetailPages(jar http.CookieJar, entries []matchEntry, notify func(string)) model.DatedScores {
+func fetchDetailPages(jar http.CookieJar, entries []matchEntry, notify func(int, int)) model.DatedScores {
 	var (
 		scores model.DatedScores
 		mu     sync.Mutex
@@ -240,7 +230,7 @@ func fetchDetailPages(jar http.CookieJar, entries []matchEntry, notify func(stri
 		current := processed
 		mu.Unlock()
 
-		notify(progressBar("戦歴データを取得中", current, total))
+		notify(current, total)
 	})
 
 	for _, entry := range entries {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -119,12 +119,16 @@ func StartServer() {
 		}
 
 		snap := j.Snapshot()
-		resp := map[string]string{
+		resp := map[string]interface{}{
 			"id":     snap.ID,
 			"status": string(snap.Status),
 		}
 		if snap.Message != "" {
 			resp["message"] = snap.Message
+		}
+		if snap.ProgressTotal > 0 {
+			resp["progress"] = snap.Progress
+			resp["progress_total"] = snap.ProgressTotal
 		}
 		if snap.Error != "" {
 			resp["error"] = snap.Error

--- a/static/app.js
+++ b/static/app.js
@@ -56,6 +56,17 @@ async function analyze() {
 
       statusText.textContent = statusData.message || STATUS_MESSAGES[statusData.status] || statusData.status;
 
+      var progressWrap = document.getElementById('progressWrap');
+      if (statusData.progress_total > 0) {
+        var pct = Math.round(100 * statusData.progress / statusData.progress_total);
+        document.getElementById('progressFill').style.width = pct + '%';
+        document.getElementById('progressPct').textContent = pct + '%';
+        document.getElementById('progressCount').textContent = statusData.progress + '/' + statusData.progress_total + '件';
+        progressWrap.style.display = 'block';
+      } else {
+        progressWrap.style.display = 'none';
+      }
+
       if (statusData.status === 'error') {
         throw new Error(statusData.error || '分析に失敗しました');
       }

--- a/static/index.html
+++ b/static/index.html
@@ -30,6 +30,10 @@
     .status { text-align: center; margin: 20px 0; color: #aaa; }
     .spinner { display: inline-block; width: 20px; height: 20px; border: 3px solid #333; border-top: 3px solid #4fc3f7; border-radius: 50%; animation: spin 1s linear infinite; margin-right: 8px; vertical-align: middle; }
     @keyframes spin { to { transform: rotate(360deg); } }
+    .progress-wrap { margin-top: 12px; }
+    .progress-bar { width: 100%; height: 8px; background: #1a2633; border-radius: 4px; overflow: hidden; }
+    .progress-fill { height: 100%; background: linear-gradient(90deg, #4fc3f7, #81d4fa); border-radius: 4px; transition: width 0.4s ease; width: 0%; }
+    .progress-label { display: flex; justify-content: space-between; margin-top: 6px; font-size: 0.85em; color: #aaa; }
     .report { background: #1a2633; border-radius: 12px; padding: 30px; line-height: 1.8; }
     .report h1 { font-size: 1.5em; margin: 20px 0 10px; text-align: left; }
     .report h2 { font-size: 1.3em; color: #4fc3f7; margin: 25px 0 10px; border-bottom: 1px solid #333; padding-bottom: 5px; }
@@ -95,6 +99,10 @@
     <div class="status" id="status" style="display:none;">
       <span class="spinner"></span>
       <span id="statusText">準備中...</span>
+      <div class="progress-wrap" id="progressWrap" style="display:none;">
+        <div class="progress-bar"><div class="progress-fill" id="progressFill"></div></div>
+        <div class="progress-label"><span id="progressPct"></span><span id="progressCount"></span></div>
+      </div>
     </div>
 
     <div class="error" id="error" style="display:none;"></div>


### PR DESCRIPTION
## Summary
- テキストベースのUnicodeプログレスバーを廃止し、HTML/CSSで描画するモダンなプログレスバーに変更
- サーバーから`progress`/`progress_total`の数値データをJSON経由で返す構造に変更
- UIテーマに合わせた青グラデーション(`#4fc3f7→#81d4fa`)のバー、パーセント表示、`○/○件`表示を追加

## Test plan
- [ ] `make build` が成功すること
- [ ] スクレイピング中にプログレスバーが表示され、進捗に応じてバーが伸びること
- [ ] パーセントと件数(`○/○件`)が正しく表示されること
- [ ] スクレイピング完了後、プログレスバーが非表示になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)