### PR TITLE
fix: 機体編成別勝率セクションを折りたたみ対応

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1129,8 +1129,9 @@ def main():
         report.append("\n</details>")
 
     # 機体編成別勝率
-    report.append("\n---\n\n## 機体編成別勝率\n")
+    report.append("\n---\n\n<details><summary><strong>機体編成別勝率</strong></summary>\n")
     report.append(md_ms_pair(all_data))
+    report.append("\n</details>")
 
     # コスト編成別勝率
     report.append("\n---\n\n<details><summary><strong>コスト編成別勝率</strong></summary>\n")


### PR DESCRIPTION
## Summary
- #141で追加された機体編成別勝率セクションを`<details>`で折りたたみ対応
- #142の折りたたみ対応から漏れていた分の補完

## Test plan
- [ ] 機体編成別勝率セクションが閉じた状態で表示されること
- [ ] 目次リンクからクリックで自動展開＆ジャンプすること