### PR TITLE
feat: 目次の機体別サブ項目を折りたたみ対応

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1085,9 +1085,11 @@ def main():
         ms_count = len(ms_data[ms_name])
         heading = f"機体別分析:-{ms_name}-({ms_count}戦)"
         toc.append(f"{n+i}. {toc_link(ms_name + ' (' + str(ms_count) + '戦)', heading)}")
+        toc.append(f"   <details><summary>詳細</summary>\n")
         toc.append(f"   - {toc_link('基本データ', '基本データ（' + ms_name + '）')}")
         toc.append(f"   - {toc_link('敵機体との相性', '敵機体との相性（' + ms_name + '）')}")
         toc.append(f"   - {toc_link('相方機体との相性', '相方機体との相性（' + ms_name + '）')}")
+        toc.append(f"   </details>")
     n += len(ms_names_for_toc)
     toc.append(f"{n}. {toc_link('機体編成別勝率', '機体編成別勝率')}")
     toc.append(f"{n+1}. {toc_link('コスト編成別勝率', 'コスト編成別勝率')}")


### PR DESCRIPTION
## Summary
- 目次内の機体別分析のサブ項目（基本データ、敵機体との相性、相方機体との相性）を `<details>` タグで折りたたみ対応
- 機体数が多い場合に目次が長くなりすぎる問題を改善

## Test plan
- [x] レポート生成後、目次の機体別項目にサブ項目が折りたたまれていること
- [x] 「詳細」クリックでサブ項目が展開されること
- [x] サブ項目のリンクが正しく動作すること