### PR TITLE
feat: 前回データの即時表示とバックグラウンド更新

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -31,25 +31,27 @@ const (
 
 // Job はバックグラウンドジョブの情報
 type Job struct {
-	ID            string    `json:"id"`
-	Status        JobStatus `json:"status"`
-	Message       string    `json:"message,omitempty"`
-	Progress      int       `json:"progress,omitempty"`
-	ProgressTotal int       `json:"progress_total,omitempty"`
-	Report        string    `json:"report,omitempty"`
-	Error         string    `json:"error,omitempty"`
-	completedAt   time.Time
+	ID                 string    `json:"id"`
+	Status             JobStatus `json:"status"`
+	Message            string    `json:"message,omitempty"`
+	Progress           int       `json:"progress,omitempty"`
+	ProgressTotal      int       `json:"progress_total,omitempty"`
+	Report             string    `json:"report,omitempty"`
+	PreliminaryReport  string    `json:"preliminary_report,omitempty"`
+	Error              string    `json:"error,omitempty"`
+	completedAt        time.Time
 }
 
 // JobSnapshot はジョブ状態のスナップショット
 type JobSnapshot struct {
-	ID            string
-	Status        JobStatus
-	Message       string
-	Progress      int
-	ProgressTotal int
-	Report        string
-	Error         string
+	ID                string
+	Status            JobStatus
+	Message           string
+	Progress          int
+	ProgressTotal     int
+	Report            string
+	PreliminaryReport string
+	Error             string
 }
 
 // ジョブストア（インメモリ）
@@ -83,13 +85,14 @@ func (j *Job) Snapshot() JobSnapshot {
 	jobsMu.RLock()
 	defer jobsMu.RUnlock()
 	return JobSnapshot{
-		ID:            j.ID,
-		Status:        j.Status,
-		Message:       j.Message,
-		Progress:      j.Progress,
-		ProgressTotal: j.ProgressTotal,
-		Report:        j.Report,
-		Error:         j.Error,
+		ID:                j.ID,
+		Status:            j.Status,
+		Message:           j.Message,
+		Progress:          j.Progress,
+		ProgressTotal:     j.ProgressTotal,
+		Report:            j.Report,
+		PreliminaryReport: j.PreliminaryReport,
+		Error:             j.Error,
 	}
 }
 
@@ -120,6 +123,15 @@ func Run(j *Job, username, password string) {
 		if !since.IsZero() {
 			log.Printf("[INFO] Fetching scores after %s", since.Format("2006-01-02 15:04"))
 		}
+
+		// 前回データで即座に分析（速報レポート）
+		prelimReport := runAnalysis(csvPath, tmpDir)
+		if prelimReport != "" {
+			jobsMu.Lock()
+			j.PreliminaryReport = prelimReport
+			jobsMu.Unlock()
+			log.Printf("[INFO] Job %s: preliminary report ready", j.ID)
+		}
 	}
 
 	// スクレイピング
@@ -134,6 +146,17 @@ func Run(j *Job, username, password string) {
 	datedScores := scraper.Scraping(username, password, since, onProgress)
 	if len(datedScores) == 0 && !exists {
 		setError(j, "戦績データが見つかりませんでした", "no scores found")
+		return
+	}
+
+	// 新規データがない場合は速報レポートをそのまま最終結果にする
+	if len(datedScores) == 0 && j.PreliminaryReport != "" {
+		jobsMu.Lock()
+		j.Status = StatusDone
+		j.Report = j.PreliminaryReport
+		j.completedAt = time.Now()
+		jobsMu.Unlock()
+		log.Printf("[INFO] Job %s completed (no new data, using preliminary report)", j.ID)
 		return
 	}
 
@@ -160,28 +183,37 @@ func Run(j *Job, username, password string) {
 
 	// Python分析実行
 	updateStatus(j, StatusAnalyzing)
-	cmd := exec.Command("python3", "scripts/analyze.py", csvPath)
-	cmd.Dir = "/app"
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		setError(j, "分析処理に失敗しました", fmt.Sprintf("analysis failed: %v\n%s", err, string(output)))
-		return
-	}
-
-	// レポート読み込み
-	reportPath := filepath.Join(tmpDir, "report.md")
-	report, err := os.ReadFile(reportPath)
-	if err != nil {
-		setError(j, "内部エラーが発生しました", fmt.Sprintf("failed to read report: %v", err))
+	report := runAnalysis(csvPath, tmpDir)
+	if report == "" {
+		setError(j, "分析処理に失敗しました", "analysis returned empty report")
 		return
 	}
 
 	jobsMu.Lock()
 	j.Status = StatusDone
-	j.Report = string(report)
+	j.Report = report
 	j.completedAt = time.Now()
 	jobsMu.Unlock()
 	log.Printf("[INFO] Job %s completed", j.ID)
+}
+
+// runAnalysis はPython分析を実行してレポートを返す。失敗時は空文字を返す。
+func runAnalysis(csvPath, tmpDir string) string {
+	cmd := exec.Command("python3", "scripts/analyze.py", csvPath)
+	cmd.Dir = "/app"
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("[WARN] Analysis failed: %v\n%s", err, string(output))
+		return ""
+	}
+
+	reportPath := filepath.Join(tmpDir, "report.md")
+	report, err := os.ReadFile(reportPath)
+	if err != nil {
+		log.Printf("[WARN] Failed to read report: %v", err)
+		return ""
+	}
+	return string(report)
 }
 
 func updateStatus(j *Job, s JobStatus) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -133,6 +133,9 @@ func StartServer() {
 		if snap.Error != "" {
 			resp["error"] = snap.Error
 		}
+		if snap.PreliminaryReport != "" {
+			resp["has_preliminary_report"] = true
+		}
 
 		sendJSON(w, http.StatusOK, resp)
 	})
@@ -150,6 +153,14 @@ func StartServer() {
 		snap := j.Snapshot()
 
 		if snap.Status != pipeline.StatusDone && snap.Status != pipeline.StatusError {
+			if snap.PreliminaryReport != "" {
+				sendJSON(w, http.StatusOK, map[string]interface{}{
+					"status":      string(snap.Status),
+					"report":      snap.PreliminaryReport,
+					"preliminary": true,
+				})
+				return
+			}
 			sendJSON(w, http.StatusAccepted, map[string]string{"status": string(snap.Status)})
 			return
 		}

--- a/static/app.js
+++ b/static/app.js
@@ -28,6 +28,10 @@ async function analyze() {
   report.style.display = 'none';
   document.querySelectorAll('.share-area').forEach(function(el) { el.remove(); });
 
+  // ログインフォームを非表示
+  document.getElementById('loginForm').style.display = 'none';
+  var preliminaryShown = false;
+
   try {
     // ジョブ作成
     const res = await fetch('/analyze', {
@@ -67,12 +71,23 @@ async function analyze() {
         progressWrap.style.display = 'none';
       }
 
+      // 速報レポートが利用可能なら表示
+      if (statusData.has_preliminary_report && !preliminaryShown) {
+        const prelimRes = await fetch(`/result/${jobId}`);
+        const prelimData = await prelimRes.json();
+        if (prelimData.report && prelimData.preliminary) {
+          renderReport(prelimData.report);
+          statusText.textContent = '最新データを取得中...';
+          preliminaryShown = true;
+        }
+      }
+
       if (statusData.status === 'error') {
         throw new Error(statusData.error || '分析に失敗しました');
       }
 
       if (statusData.status === 'done') {
-        // レポート取得
+        // 最終レポート取得
         const resultRes = await fetch(`/result/${jobId}`);
         const resultData = await resultRes.json();
 
@@ -80,25 +95,7 @@ async function analyze() {
           throw new Error(resultData.error);
         }
 
-        report.style.display = 'block';
-        report.innerHTML = DOMPurify.sanitize(marked.parse(resultData.report), {ADD_TAGS: ['details', 'summary']});
-        report.querySelectorAll('h2, h3, summary').forEach(function(h) {
-          h.id = h.textContent.replace(/\s+/g, '-');
-        });
-        report.querySelectorAll('a[href^="#"]').forEach(function(a) {
-          a.addEventListener('click', function(e) {
-            var target = document.getElementById(decodeURIComponent(this.getAttribute('href').slice(1)));
-            if (!target) return;
-            var details = target.closest('details');
-            if (details && !details.open) details.open = true;
-          });
-        });
-        report.querySelectorAll('table').forEach(function(table) {
-          var wrap = document.createElement('div');
-          wrap.className = 'table-wrap';
-          table.parentNode.insertBefore(wrap, table);
-          wrap.appendChild(table);
-        });
+        renderReport(resultData.report);
         showShareButton(resultData.report);
         break;
       }
@@ -106,10 +103,35 @@ async function analyze() {
   } catch (e) {
     error.style.display = 'block';
     error.textContent = e.message;
+    document.getElementById('loginForm').style.display = 'block';
   } finally {
     btn.disabled = false;
     status.style.display = 'none';
   }
+}
+
+function renderReport(markdown) {
+  var report = document.getElementById('report');
+  report.style.display = 'block';
+  report.innerHTML = DOMPurify.sanitize(marked.parse(markdown), {ADD_TAGS: ['details', 'summary']});
+  report.querySelectorAll('h2, h3, summary').forEach(function(h) {
+    h.id = h.textContent.replace(/\s+/g, '-');
+  });
+  report.querySelectorAll('a[href^="#"]').forEach(function(a) {
+    a.addEventListener('click', function(e) {
+      var target = document.getElementById(decodeURIComponent(this.getAttribute('href').slice(1)));
+      if (!target) return;
+      var details = target.closest('details');
+      if (details && !details.open) details.open = true;
+    });
+  });
+  report.querySelectorAll('table').forEach(function(table) {
+    if (table.parentNode.classList.contains('table-wrap')) return;
+    var wrap = document.createElement('div');
+    wrap.className = 'table-wrap';
+    table.parentNode.insertBefore(wrap, table);
+    wrap.appendChild(table);
+  });
 }
 
 function buildShareText(items) {


### PR DESCRIPTION
## Summary
- GCSに前回CSVがある場合、スクレイピング前に即座に速報レポートを表示
- バックグラウンドでスクレイピングを実行し、完了後にレポートを自動更新
- 新規データがない場合は速報レポートをそのまま最終結果にして早期終了
- ログイン後にフォームを非表示（エラー時は再表示）

Close #107

## Test plan
- [ ] 2回目以降のユーザーで分析開始 → 速報レポートが即座に表示されることを確認
- [ ] スクレイピング完了後、最終レポートに自動更新されることを確認
- [ ] 新規データがない場合、速報レポートがそのまま最終結果になることを確認
- [ ] 初回ユーザー（GCSにCSVなし）で従来通り動作することを確認
- [ ] エラー時にログインフォームが再表示されることを確認