### PR TITLE
feat: pipeline/APIのレポート出力をMarkdownからJSONに切替

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -197,9 +197,9 @@ func Run(j *Job, username, password string) {
 	log.Printf("[INFO] Job %s completed", j.ID)
 }
 
-// runAnalysis はPython分析を実行してレポートを返す。失敗時は空文字を返す。
+// runAnalysis はPython分析を実行してJSON形式のレポートを返す。失敗時は空文字を返す。
 func runAnalysis(csvPath, tmpDir string) string {
-	cmd := exec.Command("python3", "scripts/analyze.py", csvPath)
+	cmd := exec.Command("python3", "scripts/analyze.py", csvPath, "--format", "json")
 	cmd.Dir = "/app"
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -207,7 +207,7 @@ func runAnalysis(csvPath, tmpDir string) string {
 		return ""
 	}
 
-	reportPath := filepath.Join(tmpDir, "report.md")
+	reportPath := filepath.Join(tmpDir, "report.json")
 	report, err := os.ReadFile(reportPath)
 	if err != nil {
 		log.Printf("[WARN] Failed to read report: %v", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -140,7 +140,7 @@ func StartServer() {
 		sendJSON(w, http.StatusOK, resp)
 	})
 
-	// GET /result/{id} → レポートを返す
+	// GET /result/{id} → 分析結果(JSON)を返す
 	http.HandleFunc("/result/", func(w http.ResponseWriter, r *http.Request) {
 		id := r.URL.Path[len("/result/"):]
 
@@ -154,11 +154,7 @@ func StartServer() {
 
 		if snap.Status != pipeline.StatusDone && snap.Status != pipeline.StatusError {
 			if snap.PreliminaryReport != "" {
-				sendJSON(w, http.StatusOK, map[string]interface{}{
-					"status":      string(snap.Status),
-					"report":      snap.PreliminaryReport,
-					"preliminary": true,
-				})
+				sendRawReport(w, http.StatusOK, snap.PreliminaryReport, string(snap.Status), true)
 				return
 			}
 			sendJSON(w, http.StatusAccepted, map[string]string{"status": string(snap.Status)})
@@ -170,7 +166,7 @@ func StartServer() {
 			return
 		}
 
-		sendJSON(w, http.StatusOK, map[string]string{"report": snap.Report})
+		sendRawReport(w, http.StatusOK, snap.Report, "", false)
 	})
 
 	// 静的ファイル（フロントエンド）
@@ -199,4 +195,22 @@ func sendJSON(w http.ResponseWriter, code int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	json.NewEncoder(w).Encode(data)
+}
+
+// sendRawReport はJSON形式のレポートをレスポンスとして返す。
+// reportJSONはanalyze.pyが生成したJSON文字列。json.RawMessageで二重エンコードを防ぐ。
+func sendRawReport(w http.ResponseWriter, code int, reportJSON, status string, preliminary bool) {
+	type reportResponse struct {
+		Report      json.RawMessage `json:"report"`
+		Status      string          `json:"status,omitempty"`
+		Preliminary bool            `json:"preliminary,omitempty"`
+	}
+	resp := reportResponse{
+		Report:      json.RawMessage(reportJSON),
+		Status:      status,
+		Preliminary: preliminary,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(resp)
 }


### PR DESCRIPTION
## Summary
- `runAnalysis`が`--format json`引数を渡し、`report.json`を読み込むように変更
- `/result/{id}`エンドポイントで`json.RawMessage`を使い、構造化JSONデータを直接返却（二重エンコード防止）
- PR #149 (analyze.pyのJSON出力モード追加) の上に積む変更

## Test plan
- [ ] `make build` でビルド成功を確認
- [ ] ローカルで分析実行し、`/result/{id}`がJSON構造データを返すことを確認
- [ ] 速報レポート（preliminary）もJSON形式で返ることを確認

Ref: #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)