### PR TITLE
fix: CDワークフローのno-deployラベル判定を修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,7 +27,7 @@ jobs:
           fi
 
           LABELS=$(gh api \
-            "repos/${{ github.repository }}/pulls/${PR_NUMBER}/labels" \
+            "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" \
             --jq '.[].name' 2>/dev/null || echo "")
 
           if echo "$LABELS" | grep -q "^no-deploy$"; then


### PR DESCRIPTION
## Summary
- CDワークフロー(`cd.yml`)でPRラベルを取得するGitHub APIエンドポイントが誤っていたのを修正
- `/pulls/${PR_NUMBER}/labels` は存在しないエンドポイントで常に404を返していた。`2>/dev/null || echo ""` でエラーが握りつぶされていたため、ラベルが常に空になり `no-deploy` ラベルが検出されなかった
- 正しいエンドポイント `/issues/${PR_NUMBER}/labels` に修正（GitHub APIではPRはissueとして扱われるため、ラベル取得はissues APIを使う）

## Test plan
- [ ] `no-deploy` ラベル付きPRをマージし、デプロイがスキップされることを確認
- [ ] `no-deploy` ラベルなしPRをマージし、デプロイが実行されることを確認