### PR TITLE
add ベーシック認証ミドルウェア

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMAGE_NAME := exvs-analyzer
 PORT ?= 8080
 
-.PHONY: build run restart stop test pulumi-install pulumi-init pulumi-preview pulumi-up
+.PHONY: build run restart stop test pulumi-install pulumi-init pulumi-preview pulumi-up pulumi-shell
 
 ## Docker イメージをビルド（キャッシュなし）
 build:
@@ -53,3 +53,15 @@ pulumi-preview:
 ## インフラ変更を適用
 pulumi-up:
 	$(PULUMI_RUN) sh -c "$(PULUMI_LOGIN) && pulumi up"
+
+## Pulumiコンテナにシェルで入る
+pulumi-shell:
+	docker run --rm -it --entrypoint "" \
+		-v "$(CURDIR)/infra":/infra \
+		-v "$(HOME)/.config/gcloud":/root/.config/gcloud \
+		-w /infra \
+		-e PULUMI_CONFIG_PASSPHRASE \
+		-e CLOUDSDK_CORE_PROJECT=$$(gcloud config get-value project 2>/dev/null) \
+		-e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json \
+		$(PULUMI_IMAGE) \
+		sh -c "$(PULUMI_LOGIN) && sh"

--- a/infra/cloudrun.ts
+++ b/infra/cloudrun.ts
@@ -4,6 +4,8 @@ import * as gcp from "@pulumi/gcp";
 const config = new pulumi.Config();
 const gcsBucket = config.requireSecret("gcsBucket");
 const image = config.requireSecret("image");
+const basicAuthUser = config.requireSecret("basicAuthUser");
+const basicAuthPass = config.requireSecret("basicAuthPass");
 
 export const service = new gcp.cloudrunv2.Service(
   "exvs-analyzer",
@@ -23,6 +25,14 @@ export const service = new gcp.cloudrunv2.Service(
             {
               name: "GCS_BUCKET",
               value: gcsBucket,
+            },
+            {
+              name: "BASIC_AUTH_USER",
+              value: basicAuthUser,
+            },
+            {
+              name: "BASIC_AUTH_PASS",
+              value: basicAuthPass,
             },
           ],
           resources: {

--- a/internal/server/basicauth.go
+++ b/internal/server/basicauth.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"net/http"
+	"os"
+)
+
+// basicAuth はベーシック認証ミドルウェアを返す。
+// 環境変数 BASIC_AUTH_USER / BASIC_AUTH_PASS が未設定の場合は認証をスキップする。
+// skipPaths に指定したパスは認証不要（ヘルスチェック用）。
+func basicAuth(next http.Handler, skipPaths ...string) http.Handler {
+	user := os.Getenv("BASIC_AUTH_USER")
+	pass := os.Getenv("BASIC_AUTH_PASS")
+
+	// 未設定なら認証なしで通す
+	if user == "" || pass == "" {
+		return next
+	}
+
+	// 比較用ハッシュを事前計算（タイミング攻撃対策）
+	expectedUserHash := sha256.Sum256([]byte(user))
+	expectedPassHash := sha256.Sum256([]byte(pass))
+
+	skip := make(map[string]bool, len(skipPaths))
+	for _, p := range skipPaths {
+		skip[p] = true
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// スキップ対象パスは認証不要
+		if skip[r.URL.Path] {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		givenUser, givenPass, ok := r.BasicAuth()
+		if !ok {
+			w.Header().Set("WWW-Authenticate", `Basic realm="restricted"`)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		givenUserHash := sha256.Sum256([]byte(givenUser))
+		givenPassHash := sha256.Sum256([]byte(givenPass))
+
+		userMatch := subtle.ConstantTimeCompare(givenUserHash[:], expectedUserHash[:]) == 1
+		passMatch := subtle.ConstantTimeCompare(givenPassHash[:], expectedPassHash[:]) == 1
+
+		if !userMatch || !passMatch {
+			w.Header().Set("WWW-Authenticate", `Basic realm="restricted"`)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/server/basicauth_test.go
+++ b/internal/server/basicauth_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBasicAuth(t *testing.T) {
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("環境変数未設定なら認証スキップ", func(t *testing.T) {
+		t.Setenv("BASIC_AUTH_USER", "")
+		t.Setenv("BASIC_AUTH_PASS", "")
+
+		handler := basicAuth(okHandler)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("認証情報なしで401", func(t *testing.T) {
+		t.Setenv("BASIC_AUTH_USER", "admin")
+		t.Setenv("BASIC_AUTH_PASS", "secret")
+
+		handler := basicAuth(okHandler)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rec.Code)
+		}
+		if rec.Header().Get("WWW-Authenticate") == "" {
+			t.Error("expected WWW-Authenticate header")
+		}
+	})
+
+	t.Run("誤った認証情報で401", func(t *testing.T) {
+		t.Setenv("BASIC_AUTH_USER", "admin")
+		t.Setenv("BASIC_AUTH_PASS", "secret")
+
+		handler := basicAuth(okHandler)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("admin", "wrong")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rec.Code)
+		}
+	})
+
+	t.Run("正しい認証情報で200", func(t *testing.T) {
+		t.Setenv("BASIC_AUTH_USER", "admin")
+		t.Setenv("BASIC_AUTH_PASS", "secret")
+
+		handler := basicAuth(okHandler)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("admin", "secret")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("skipPathsは認証不要", func(t *testing.T) {
+		t.Setenv("BASIC_AUTH_USER", "admin")
+		t.Setenv("BASIC_AUTH_PASS", "secret")
+
+		handler := basicAuth(okHandler, "/health")
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec.Code)
+		}
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -174,7 +174,7 @@ func StartServer() {
 	http.Handle("/", fs)
 
 	log.Printf("[INFO] Server starting on port %s", port)
-	handler := securityHeaders(http.DefaultServeMux)
+	handler := basicAuth(securityHeaders(http.DefaultServeMux), "/health")
 	if err := http.ListenAndServe(":"+port, handler); err != nil {
 		log.Fatalf("[ERROR] Server failed: %v", err)
 	}


### PR DESCRIPTION
## Summary
- ベーシック認証ミドルウェアを追加し、Cloud Runへの不特定アクセスを制限
- 環境変数 `BASIC_AUTH_USER` / `BASIC_AUTH_PASS` で認証情報を管理（未設定時は認証スキップ）
- `/health` エンドポイントは認証除外（Cloud Runヘルスチェック用）
- タイミング攻撃対策として SHA256 + `subtle.ConstantTimeCompare` を使用
- Pulumiに `basicAuthUser` / `basicAuthPass` のSecret設定を追加

## デプロイ時に必要な作業
```bash
pulumi config set --secret basicAuthUser <ユーザー名>
pulumi config set --secret basicAuthPass <パスワード>
```

## Test plan
- [x] `make test` で全テストパス確認済み
- [ ] デプロイ後、認証なしでアクセスして401が返ることを確認
- [ ] 正しい認証情報でアクセスして200が返ることを確認
- [ ] `/health` が認証なしで200を返すことを確認