### PR TITLE
add GCP/AWS風の期間セレクタとカスタム日時範囲指定

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -39,6 +39,7 @@ type Job struct {
 	Report             string    `json:"report,omitempty"`
 	PreliminaryReport  string    `json:"preliminary_report,omitempty"`
 	Error              string    `json:"error,omitempty"`
+	UserKey            string    `json:"-"`
 	completedAt        time.Time
 }
 
@@ -52,6 +53,7 @@ type JobSnapshot struct {
 	Report            string
 	PreliminaryReport string
 	Error             string
+	UserKey           string
 }
 
 // ジョブストア（インメモリ）
@@ -93,11 +95,15 @@ func (j *Job) Snapshot() JobSnapshot {
 		Report:            j.Report,
 		PreliminaryReport: j.PreliminaryReport,
 		Error:             j.Error,
+		UserKey:           j.UserKey,
 	}
 }
 
 // Run はスクレイピング→分析を実行し、レポートをジョブに保存する
 func Run(j *Job, username, password string) {
+	jobsMu.Lock()
+	j.UserKey = storage.UserKey(username)
+	jobsMu.Unlock()
 	updateStatus(j, StatusScraping)
 
 	tmpDir, err := os.MkdirTemp("", "exvs-*")
@@ -195,6 +201,39 @@ func Run(j *Job, username, password string) {
 	j.completedAt = time.Now()
 	jobsMu.Unlock()
 	log.Printf("[INFO] Job %s completed", j.ID)
+}
+
+// RunCustomPeriod はカスタム日時範囲で再分析を実行してJSON文字列を返す
+func RunCustomPeriod(userKey, start, end string) (string, error) {
+	tmpDir, err := os.MkdirTemp("", "exvs-period-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	csvPath := filepath.Join(tmpDir, "scores.csv")
+
+	exists, err := storage.DownloadCSVByKey(userKey, csvPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to download CSV: %w", err)
+	}
+	if !exists {
+		return "", fmt.Errorf("CSV not found for user")
+	}
+
+	cmd := exec.Command("python3", "scripts/analyze.py", csvPath, "--start", start, "--end", end)
+	cmd.Dir = "/app"
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("analysis failed: %v\n%s", err, string(output))
+	}
+
+	reportPath := filepath.Join(tmpDir, "report.json")
+	report, err := os.ReadFile(reportPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read report: %w", err)
+	}
+	return string(report), nil
 }
 
 // runAnalysis はPython分析を実行してJSON形式のレポートを返す。失敗時は空文字を返す。

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -141,32 +141,19 @@ func StartServer() {
 	})
 
 	// GET /result/{id} → 分析結果(JSON)を返す
+	// GET /result/{id}/period?start=...&end=... → カスタム期間で再分析
 	http.HandleFunc("/result/", func(w http.ResponseWriter, r *http.Request) {
-		id := r.URL.Path[len("/result/"):]
+		path := r.URL.Path[len("/result/"):]
 
-		j, ok := pipeline.GetJob(id)
-		if !ok {
-			sendJSON(w, http.StatusNotFound, map[string]string{"error": "Job not found"})
+		// /result/{id}/period のパターンを判定
+		if idx := len(path) - len("/period"); idx > 0 && path[idx:] == "/period" {
+			id := path[:idx]
+			handleCustomPeriod(w, r, id)
 			return
 		}
 
-		snap := j.Snapshot()
-
-		if snap.Status != pipeline.StatusDone && snap.Status != pipeline.StatusError {
-			if snap.PreliminaryReport != "" {
-				sendRawReport(w, http.StatusOK, snap.PreliminaryReport, string(snap.Status), true)
-				return
-			}
-			sendJSON(w, http.StatusAccepted, map[string]string{"status": string(snap.Status)})
-			return
-		}
-
-		if snap.Status == pipeline.StatusError {
-			sendJSON(w, http.StatusInternalServerError, map[string]string{"error": snap.Error})
-			return
-		}
-
-		sendRawReport(w, http.StatusOK, snap.Report, "", false)
+		// 既存の /result/{id} 処理
+		handleResult(w, r, path)
 	})
 
 	// 静的ファイル（フロントエンド）
@@ -178,6 +165,78 @@ func StartServer() {
 	if err := http.ListenAndServe(":"+port, handler); err != nil {
 		log.Fatalf("[ERROR] Server failed: %v", err)
 	}
+}
+
+func handleResult(w http.ResponseWriter, r *http.Request, id string) {
+	j, ok := pipeline.GetJob(id)
+	if !ok {
+		sendJSON(w, http.StatusNotFound, map[string]string{"error": "Job not found"})
+		return
+	}
+
+	snap := j.Snapshot()
+
+	if snap.Status != pipeline.StatusDone && snap.Status != pipeline.StatusError {
+		if snap.PreliminaryReport != "" {
+			sendRawReport(w, http.StatusOK, snap.PreliminaryReport, string(snap.Status), true)
+			return
+		}
+		sendJSON(w, http.StatusAccepted, map[string]string{"status": string(snap.Status)})
+		return
+	}
+
+	if snap.Status == pipeline.StatusError {
+		sendJSON(w, http.StatusInternalServerError, map[string]string{"error": snap.Error})
+		return
+	}
+
+	sendRawReport(w, http.StatusOK, snap.Report, "", false)
+}
+
+func handleCustomPeriod(w http.ResponseWriter, r *http.Request, id string) {
+	j, ok := pipeline.GetJob(id)
+	if !ok {
+		sendJSON(w, http.StatusNotFound, map[string]string{"error": "Job not found"})
+		return
+	}
+
+	snap := j.Snapshot()
+	if snap.Status != pipeline.StatusDone {
+		sendJSON(w, http.StatusBadRequest, map[string]string{"error": "Job not completed"})
+		return
+	}
+
+	if snap.UserKey == "" {
+		sendJSON(w, http.StatusInternalServerError, map[string]string{"error": "User key not found"})
+		return
+	}
+
+	start := r.URL.Query().Get("start")
+	end := r.URL.Query().Get("end")
+	if start == "" || end == "" {
+		sendJSON(w, http.StatusBadRequest, map[string]string{"error": "start and end parameters are required"})
+		return
+	}
+
+	// 日時フォーマットの簡易バリデーション（YYYY-MM-DD HH:MM）
+	const layout = "2006-01-02 15:04"
+	if _, err := time.Parse(layout, start); err != nil {
+		sendJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid start datetime format (expected: YYYY-MM-DD HH:MM)"})
+		return
+	}
+	if _, err := time.Parse(layout, end); err != nil {
+		sendJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid end datetime format (expected: YYYY-MM-DD HH:MM)"})
+		return
+	}
+
+	report, err := pipeline.RunCustomPeriod(snap.UserKey, start, end)
+	if err != nil {
+		log.Printf("[ERROR] Custom period analysis failed: %v", err)
+		sendJSON(w, http.StatusInternalServerError, map[string]string{"error": "カスタム期間の分析に失敗しました"})
+		return
+	}
+
+	sendRawReport(w, http.StatusOK, report, "", false)
 }
 
 // securityHeaders は全レスポンスにセキュリティヘッダーを付与する

--- a/internal/storage/cloud_storage.go
+++ b/internal/storage/cloud_storage.go
@@ -63,6 +63,40 @@ func DownloadCSV(email, localPath string) (bool, error) {
 	return true, nil
 }
 
+// DownloadCSVByKey はユーザーキーを使ってCloud StorageからCSVをダウンロードする
+func DownloadCSVByKey(userKey, localPath string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to create storage client: %w", err)
+	}
+	defer client.Close()
+
+	objPath := fmt.Sprintf("users/%s/scores.csv", userKey)
+	reader, err := client.Bucket(BucketName).Object(objPath).NewReader(ctx)
+	if err != nil {
+		if err == storage.ErrObjectNotExist {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to read from GCS: %w", err)
+	}
+	defer reader.Close()
+
+	f, err := os.Create(localPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to create local file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, reader); err != nil {
+		return false, fmt.Errorf("failed to download CSV: %w", err)
+	}
+
+	return true, nil
+}
+
 // UploadCSV はローカルのCSVファイルをCloud Storageにアップロードする
 func UploadCSV(email, localPath string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -5,12 +5,13 @@ CSVファイルを読み込み、JSON形式の構造化分析レポートを出�
 プレイヤー名はCSVのプレイヤーNo.1から自動取得する。
 """
 
+import argparse
 import csv
 import json
 import os
 import sys
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 def get_season(dt):
@@ -1112,9 +1113,15 @@ def filter_by_days(all_data, days):
     if not all_data:
         return []
     latest = max(d["datetime"] for d in all_data)
-    from datetime import timedelta
     cutoff = latest - timedelta(days=days)
     return [d for d in all_data if d["datetime"] >= cutoff]
+
+
+def filter_by_datetime_range(all_data, start, end):
+    """開始日時〜終了日時でデータをフィルタする"""
+    if not all_data:
+        return []
+    return [d for d in all_data if start <= d["datetime"] <= end]
 
 
 def build_ms_data(data_list):
@@ -1133,19 +1140,22 @@ def build_json_report(player_name, all_data, ms_data):
     periods["all"] = build_period_report(all_data, ms_data)
     periods["all"]["label"] = "全期間"
 
-    # 直近30日
-    data_30d = filter_by_days(all_data, 30)
-    if data_30d:
-        ms_data_30d = build_ms_data(data_30d)
-        periods["30d"] = build_period_report(data_30d, ms_data_30d)
-        periods["30d"]["label"] = "直近30日"
-
-    # 直近7日
-    data_7d = filter_by_days(all_data, 7)
-    if data_7d:
-        ms_data_7d = build_ms_data(data_7d)
-        periods["7d"] = build_period_report(data_7d, ms_data_7d)
-        periods["7d"]["label"] = "直近7日"
+    # プリセット期間
+    preset_periods = [
+        ("90d", 90, "直近90日"),
+        ("60d", 60, "直近60日"),
+        ("30d", 30, "直近30日"),
+        ("14d", 14, "直近14日"),
+        ("7d", 7, "直近7日"),
+        ("3d", 3, "直近3日"),
+        ("1d", 1, "直近1日"),
+    ]
+    for key, days, label in preset_periods:
+        filtered = filter_by_days(all_data, days)
+        if filtered:
+            ms_filtered = build_ms_data(filtered)
+            periods[key] = build_period_report(filtered, ms_filtered)
+            periods[key]["label"] = label
 
     return {
         "player_name": player_name,
@@ -1155,20 +1165,40 @@ def build_json_report(player_name, all_data, ms_data):
     }
 
 
+def build_custom_period_report(player_name, all_data, ms_data, start, end):
+    """カスタム日時範囲の構造化JSONレポートを生成する"""
+    filtered = filter_by_datetime_range(all_data, start, end)
+    if not filtered:
+        return None
+
+    ms_filtered = build_ms_data(filtered)
+    period_report = build_period_report(filtered, ms_filtered)
+    start_str = start.strftime("%Y-%m-%d %H:%M")
+    end_str = end.strftime("%Y-%m-%d %H:%M")
+    period_report["label"] = f"{start_str} 〜 {end_str}"
+
+    return {
+        "player_name": player_name,
+        "generated_at": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+        "share_data": build_share_data(filtered, ms_filtered),
+        "periods": {"custom": period_report},
+    }
+
+
 def main():
-    if len(sys.argv) < 2:
-        print(f"Usage: {sys.argv[0]} <csv_path>")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(description="EXVS2IB 戦績分析")
+    parser.add_argument("csv_path", help="CSVファイルパス")
+    parser.add_argument("--start", help="開始日時 (YYYY-MM-DD HH:MM)")
+    parser.add_argument("--end", help="終了日時 (YYYY-MM-DD HH:MM)")
+    args = parser.parse_args()
 
-    csv_path = sys.argv[1]
-
-    matches = load_csv(csv_path)
+    matches = load_csv(args.csv_path)
 
     if not matches:
         print("試合データが見つかりませんでした。")
         sys.exit(1)
 
-    cost_map = load_ms_cost_map(csv_path)
+    cost_map = load_ms_cost_map(args.csv_path)
     player_name = detect_player_name(matches)
 
     all_data = [get_my_data(m, cost_map) for m in matches]
@@ -1177,8 +1207,17 @@ def main():
     for d in all_data:
         ms_data[d["ms"]].append(d)
 
-    report_data = build_json_report(player_name, all_data, ms_data)
-    output_path = os.path.join(os.path.dirname(csv_path), "report.json")
+    if args.start and args.end:
+        start = datetime.strptime(args.start, "%Y-%m-%d %H:%M")
+        end = datetime.strptime(args.end, "%Y-%m-%d %H:%M")
+        report_data = build_custom_period_report(player_name, all_data, ms_data, start, end)
+        if report_data is None:
+            print("指定期間のデータが見つかりませんでした。")
+            sys.exit(1)
+    else:
+        report_data = build_json_report(player_name, all_data, ms_data)
+
+    output_path = os.path.join(os.path.dirname(args.csv_path), "report.json")
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(report_data, f, ensure_ascii=False, indent=2)
     print(f"分析レポート(JSON)を出力しました: {output_path}")

--- a/static/app.js
+++ b/static/app.js
@@ -126,6 +126,89 @@ function Section({ title, open, children }) {
   </details><hr />`;
 }
 
+// --- Calendar component ---
+
+var DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
+
+function CalendarPicker({ selectedDate, onSelect }) {
+  var now = selectedDate ? new Date(selectedDate) : new Date();
+  var viewRef = useState({ year: now.getFullYear(), month: now.getMonth() });
+  var view = viewRef[0], setView = viewRef[1];
+
+  function prevMonth() {
+    setView(function (v) {
+      var m = v.month - 1;
+      return m < 0 ? { year: v.year - 1, month: 11 } : { year: v.year, month: m };
+    });
+  }
+  function nextMonth() {
+    setView(function (v) {
+      var m = v.month + 1;
+      return m > 11 ? { year: v.year + 1, month: 0 } : { year: v.year, month: m };
+    });
+  }
+
+  var firstDay = new Date(view.year, view.month, 1).getDay();
+  var daysInMonth = new Date(view.year, view.month + 1, 0).getDate();
+
+  var cells = [];
+  for (var i = 0; i < firstDay; i++) cells.push(null);
+  for (var d = 1; d <= daysInMonth; d++) cells.push(d);
+
+  var selStr = selectedDate || '';
+
+  function isSelected(day) {
+    if (!day || !selStr) return false;
+    var m = String(view.month + 1).padStart(2, '0');
+    var dd = String(day).padStart(2, '0');
+    return selStr === view.year + '-' + m + '-' + dd;
+  }
+
+  function handleClick(day) {
+    if (!day) return;
+    var m = String(view.month + 1).padStart(2, '0');
+    var dd = String(day).padStart(2, '0');
+    onSelect(view.year + '-' + m + '-' + dd);
+  }
+
+  return html`<div class="cal">
+    <div class="cal-header">
+      <button class="cal-nav" onClick=${prevMonth}>\u25C0</button>
+      <span class="cal-title">${view.year}年${view.month + 1}月</span>
+      <button class="cal-nav" onClick=${nextMonth}>\u25B6</button>
+    </div>
+    <div class="cal-grid">
+      ${DOW_LABELS.map(function (d) { return html`<span class="cal-dow">${d}</span>`; })}
+      ${cells.map(function (day) {
+        if (!day) return html`<span class="cal-empty" />`;
+        return html`<button class=${'cal-day' + (isSelected(day) ? ' selected' : '')}
+          onClick=${function () { handleClick(day); }}>${day}</button>`;
+      })}
+    </div>
+  </div>`;
+}
+
+// --- Time selector ---
+
+var MINUTES_START = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55];
+var MINUTES_END = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 59];
+
+function TimeSelector({ hour, minute, onChangeHour, onChangeMinute, isEnd }) {
+  var hours = [];
+  for (var h = 0; h < 24; h++) hours.push(h);
+  var minutes = isEnd ? MINUTES_END : MINUTES_START;
+
+  return html`<div class="time-sel">
+    <select class="time-select" value=${hour} onChange=${function (e) { onChangeHour(parseInt(e.target.value)); }}>
+      ${hours.map(function (h) { return html`<option value=${h}>${String(h).padStart(2, '0')}時</option>`; })}
+    </select>
+    <span class="time-colon">:</span>
+    <select class="time-select" value=${minute} onChange=${function (e) { onChangeMinute(parseInt(e.target.value)); }}>
+      ${minutes.map(function (m) { return html`<option value=${m}>${String(m).padStart(2, '0')}分</option>`; })}
+    </select>
+  </div>`;
+}
+
 // --- Period selector (GCP/AWS style dropdown) ---
 
 function PeriodSelector({ periods, selected, onSelect, jobId, onCustomReport }) {
@@ -140,14 +223,25 @@ function PeriodSelector({ periods, selected, onSelect, jobId, onCustomReport }) 
   var isLoading = loadingRef[0], setIsLoading = loadingRef[1];
   var errorRef = useState('');
   var customError = errorRef[0], setCustomError = errorRef[1];
-  var startRef = useState('');
-  var customStart = startRef[0], setCustomStart = startRef[1];
-  var endRef = useState('');
-  var customEnd = endRef[0], setCustomEnd = endRef[1];
+
+  // カスタム日時の状態（日付文字列 + 時/分）
+  var startDateRef = useState('');
+  var startDate = startDateRef[0], setStartDate = startDateRef[1];
+  var startHourRef = useState(0);
+  var startHour = startHourRef[0], setStartHour = startHourRef[1];
+  var startMinRef = useState(0);
+  var startMin = startMinRef[0], setStartMin = startMinRef[1];
+  var endDateRef = useState('');
+  var endDate = endDateRef[0], setEndDate = endDateRef[1];
+  var endHourRef = useState(23);
+  var endHour = endHourRef[0], setEndHour = endHourRef[1];
+  var endMinRef = useState(59);
+  var endMin = endMinRef[0], setEndMin = endMinRef[1];
+  var timeRef = useState(false);
+  var showTime = timeRef[0], setShowTime = timeRef[1];
 
   var containerRef = useRef(null);
 
-  // 外側クリックで閉じる
   useEffect(function () {
     function handleClick(e) {
       if (containerRef.current && !containerRef.current.contains(e.target)) {
@@ -168,13 +262,17 @@ function PeriodSelector({ periods, selected, onSelect, jobId, onCustomReport }) 
     setShowCustom(false);
   }
 
+  function formatDt(date, hour, min) {
+    return date + ' ' + String(hour).padStart(2, '0') + ':' + String(min).padStart(2, '0');
+  }
+
   function handleCustomApply() {
-    if (!customStart || !customEnd) {
-      setCustomError('開始日時と終了日時を入力してください');
+    if (!startDate || !endDate) {
+      setCustomError('開始日と終了日をカレンダーから選択してください');
       return;
     }
-    var start = customStart.replace('T', ' ');
-    var end = customEnd.replace('T', ' ');
+    var start = showTime ? formatDt(startDate, startHour, startMin) : startDate + ' 00:00';
+    var end = showTime ? formatDt(endDate, endHour, endMin) : endDate + ' 23:59';
     setIsLoading(true);
     setCustomError('');
     fetch('/result/' + jobId + '/period?start=' + encodeURIComponent(start) + '&end=' + encodeURIComponent(end))
@@ -204,14 +302,28 @@ function PeriodSelector({ periods, selected, onSelect, jobId, onCustomReport }) 
           return html`<button class=${'period-dropdown-item' + (selected === k ? ' active' : '')}
             onClick=${function () { selectPreset(k); }}>${periods[k].label}</button>`;
         })}
-        ${jobId && html`<button class=${'period-dropdown-item' + (showCustom ? ' active' : '')}
-          onClick=${function () { setShowCustom(true); }}>カスタム</button>`}
+        ${jobId && html`<button class=${'period-dropdown-item period-dropdown-custom' + (showCustom ? ' active' : '')}
+          onClick=${function () { setShowCustom(!showCustom); }}>カスタム</button>`}
       </div>
       ${showCustom && html`<div class="period-custom">
-        <label>開始<input type="datetime-local" value=${customStart}
-          onInput=${function (e) { setCustomStart(e.target.value); }} /></label>
-        <label>終了<input type="datetime-local" value=${customEnd}
-          onInput=${function (e) { setCustomEnd(e.target.value); }} /></label>
+        <div class="period-custom-range">
+          <div class="period-custom-col">
+            <span class="period-custom-title">開始</span>
+            <span class="period-custom-value">${startDate || '日付を選択'}${showTime ? ' ' + String(startHour).padStart(2, '0') + ':' + String(startMin).padStart(2, '0') : ''}</span>
+            <${CalendarPicker} selectedDate=${startDate} onSelect=${setStartDate} />
+            ${showTime && html`<${TimeSelector} hour=${startHour} minute=${startMin}
+              onChangeHour=${setStartHour} onChangeMinute=${setStartMin} />`}
+          </div>
+          <div class="period-custom-col">
+            <span class="period-custom-title">終了</span>
+            <span class="period-custom-value">${endDate || '日付を選択'}${showTime ? ' ' + String(endHour).padStart(2, '0') + ':' + String(endMin).padStart(2, '0') : ''}</span>
+            <${CalendarPicker} selectedDate=${endDate} onSelect=${setEndDate} />
+            ${showTime && html`<${TimeSelector} hour=${endHour} minute=${endMin}
+              onChangeHour=${setEndHour} onChangeMinute=${setEndMin} isEnd />`}
+          </div>
+        </div>
+        <button class="period-time-toggle" onClick=${function () { setShowTime(!showTime); }}>
+          ${showTime ? '時刻指定を解除' : '時刻を指定'}</button>
         <button class="period-custom-apply" onClick=${handleCustomApply} disabled=${isLoading}>
           ${isLoading ? '分析中...' : '適用'}</button>
         ${customError && html`<p class="period-custom-error">${customError}</p>`}

--- a/static/app.js
+++ b/static/app.js
@@ -1,4 +1,4 @@
-import { html, render, useState, useMemo, useCallback } from './htm-preact-standalone.js';
+import { html, render, useState, useMemo, useCallback, useEffect, useRef } from './htm-preact-standalone.js';
 
 // --- Constants ---
 var STATUS_MESSAGES = {
@@ -9,7 +9,7 @@ var STATUS_MESSAGES = {
   error: 'エラーが発生しました',
 };
 
-var PERIOD_KEYS = ['all', '30d', '7d'];
+var PERIOD_KEYS = ['all', '90d', '60d', '30d', '14d', '7d', '3d', '1d'];
 
 // --- Utility ---
 function esc(s) {
@@ -126,16 +126,97 @@ function Section({ title, open, children }) {
   </details><hr />`;
 }
 
-// --- Period selector ---
+// --- Period selector (GCP/AWS style dropdown) ---
 
-function PeriodSelector({ periods, selected, onSelect }) {
+function PeriodSelector({ periods, selected, onSelect, jobId, onCustomReport }) {
   var keys = PERIOD_KEYS.filter(function (k) { return periods[k]; });
-  if (keys.length <= 1) return null;
-  return html`<div class="period-selector">
-    ${keys.map(function (k) {
-      return html`<button class=${'period-btn' + (selected === k ? ' active' : '')}
-        onClick=${function () { onSelect(k); }}>${periods[k].label}</button>`;
-    })}
+  if (keys.length <= 1 && !jobId) return null;
+
+  var openRef = useState(false);
+  var isOpen = openRef[0], setIsOpen = openRef[1];
+  var customRef = useState(false);
+  var showCustom = customRef[0], setShowCustom = customRef[1];
+  var loadingRef = useState(false);
+  var isLoading = loadingRef[0], setIsLoading = loadingRef[1];
+  var errorRef = useState('');
+  var customError = errorRef[0], setCustomError = errorRef[1];
+  var startRef = useState('');
+  var customStart = startRef[0], setCustomStart = startRef[1];
+  var endRef = useState('');
+  var customEnd = endRef[0], setCustomEnd = endRef[1];
+
+  var containerRef = useRef(null);
+
+  // 外側クリックで閉じる
+  useEffect(function () {
+    function handleClick(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return function () { document.removeEventListener('mousedown', handleClick); };
+  }, []);
+
+  var currentLabel = selected === 'custom'
+    ? (periods.custom ? periods.custom.label : 'カスタム')
+    : (periods[selected] ? periods[selected].label : '全期間');
+
+  function selectPreset(k) {
+    onSelect(k);
+    setIsOpen(false);
+    setShowCustom(false);
+  }
+
+  function handleCustomApply() {
+    if (!customStart || !customEnd) {
+      setCustomError('開始日時と終了日時を入力してください');
+      return;
+    }
+    var start = customStart.replace('T', ' ');
+    var end = customEnd.replace('T', ' ');
+    setIsLoading(true);
+    setCustomError('');
+    fetch('/result/' + jobId + '/period?start=' + encodeURIComponent(start) + '&end=' + encodeURIComponent(end))
+      .then(function (res) { return res.json(); })
+      .then(function (data) {
+        setIsLoading(false);
+        if (data.error) {
+          setCustomError(data.error);
+          return;
+        }
+        onCustomReport(data.report);
+        setIsOpen(false);
+      })
+      .catch(function (e) {
+        setIsLoading(false);
+        setCustomError(e.message);
+      });
+  }
+
+  return html`<div class="period-selector" ref=${containerRef}>
+    <button class="period-trigger" onClick=${function () { setIsOpen(!isOpen); }}>
+      ${currentLabel} <span class="period-arrow">${isOpen ? '\u25B2' : '\u25BC'}</span>
+    </button>
+    ${isOpen && html`<div class="period-dropdown">
+      <div class="period-dropdown-list">
+        ${keys.map(function (k) {
+          return html`<button class=${'period-dropdown-item' + (selected === k ? ' active' : '')}
+            onClick=${function () { selectPreset(k); }}>${periods[k].label}</button>`;
+        })}
+        ${jobId && html`<button class=${'period-dropdown-item' + (showCustom ? ' active' : '')}
+          onClick=${function () { setShowCustom(true); }}>カスタム</button>`}
+      </div>
+      ${showCustom && html`<div class="period-custom">
+        <label>開始<input type="datetime-local" value=${customStart}
+          onInput=${function (e) { setCustomStart(e.target.value); }} /></label>
+        <label>終了<input type="datetime-local" value=${customEnd}
+          onInput=${function (e) { setCustomEnd(e.target.value); }} /></label>
+        <button class="period-custom-apply" onClick=${handleCustomApply} disabled=${isLoading}>
+          ${isLoading ? '分析中...' : '適用'}</button>
+        ${customError && html`<p class="period-custom-error">${customError}</p>`}
+      </div>`}
+    </div>`}
   </div>`;
 }
 
@@ -439,19 +520,31 @@ function TableOfContents({ data }) {
 
 // --- Main report ---
 
-function Report({ data }) {
+function Report({ data, jobId }) {
   if (!data) return null;
   var periodRef = useState('all');
   var selectedPeriod = periodRef[0], setSelectedPeriod = periodRef[1];
+  var customDataRef = useState(null);
+  var customData = customDataRef[0], setCustomData = customDataRef[1];
 
   var periods = data.periods || {};
-  var pd = periods[selectedPeriod] || periods['all'];
+  // カスタム期間データがある場合はマージ
+  var allPeriods = customData ? Object.assign({}, periods, { custom: customData.periods.custom }) : periods;
+  var pd = allPeriods[selectedPeriod] || allPeriods['all'];
   if (!pd) return null;
+
+  var shareData = selectedPeriod === 'custom' && customData ? customData.share_data : data.share_data;
+
+  function handleCustomReport(report) {
+    setCustomData(report);
+    setSelectedPeriod('custom');
+  }
 
   return html`
     <h1>${esc(data.player_name)} - 戦績分析レポート</h1>
-    <${ShareArea} shareData=${data.share_data} />
-    <${PeriodSelector} periods=${periods} selected=${selectedPeriod} onSelect=${setSelectedPeriod} />
+    <${ShareArea} shareData=${shareData} />
+    <${PeriodSelector} periods=${allPeriods} selected=${selectedPeriod} onSelect=${setSelectedPeriod}
+      jobId=${jobId} onCustomReport=${handleCustomReport} />
     <${TableOfContents} data=${pd} />
     <div id="sec-summary"><${SummarySection} summary=${pd.summary} /></div>
     <div id="sec-basic"><${Section} title="基本データ">
@@ -465,16 +558,16 @@ function Report({ data }) {
     <div id="sec-dow"><${DayOfWeekSection} dow=${pd.day_of_week} /></div>
     <div id="sec-daily"><${DailyTrendSection} daily=${pd.daily_trend} /></div>
     <div id="sec-season"><${SeasonSection} seasons=${pd.season} /></div>
-    <${ShareArea} shareData=${data.share_data} />
+    <${ShareArea} shareData=${shareData} />
   `;
 }
 
 // --- Main app logic ---
 
-function renderReport(data) {
+function renderReport(data, jobId) {
   var reportEl = document.getElementById('report');
   reportEl.style.display = 'block';
-  render(html`<${Report} data=${data} />`, reportEl);
+  render(html`<${Report} data=${data} jobId=${jobId} />`, reportEl);
 }
 
 async function analyze() {
@@ -543,7 +636,7 @@ async function analyze() {
         var prelimRes = await fetch('/result/' + jobId);
         var prelimData = await prelimRes.json();
         if (prelimData.report && prelimData.preliminary) {
-          renderReport(prelimData.report);
+          renderReport(prelimData.report, jobId);
           statusText.textContent = '最新データを取得中...';
           preliminaryShown = true;
         }
@@ -561,7 +654,7 @@ async function analyze() {
           throw new Error(resultData.error);
         }
 
-        renderReport(resultData.report);
+        renderReport(resultData.report, jobId);
         break;
       }
     }

--- a/static/index.html
+++ b/static/index.html
@@ -62,10 +62,23 @@
     .share-line { background: #06c755; }
     .share-copy { background: #333; }
     .share-copy.copied { background: #4fc3f7; }
-    .period-selector { display: flex; gap: 8px; margin: 16px 0; }
-    .period-btn { padding: 8px 16px; border: 1px solid #333; border-radius: 8px; background: #162029; color: #aaa; font-size: 0.9em; cursor: pointer; transition: all 0.2s; }
-    .period-btn:hover { border-color: #4fc3f7; color: #e0e0e0; }
-    .period-btn.active { background: #4fc3f7; color: #0f1923; border-color: #4fc3f7; font-weight: bold; }
+    .period-selector { position: relative; display: inline-block; margin: 16px 0; }
+    .period-trigger { display: flex; align-items: center; gap: 8px; padding: 8px 16px; border: 1px solid #333; border-radius: 8px; background: #162029; color: #e0e0e0; font-size: 0.9em; cursor: pointer; transition: all 0.2s; width: auto; }
+    .period-trigger:hover { border-color: #4fc3f7; }
+    .period-arrow { font-size: 0.7em; color: #888; }
+    .period-dropdown { position: absolute; top: 100%; left: 0; margin-top: 4px; background: #1a2633; border: 1px solid #333; border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.4); z-index: 100; min-width: 240px; overflow: hidden; }
+    .period-dropdown-list { display: flex; flex-direction: column; }
+    .period-dropdown-item { padding: 10px 16px; border: none; background: none; color: #aaa; font-size: 0.9em; cursor: pointer; text-align: left; transition: all 0.15s; width: 100%; }
+    .period-dropdown-item:hover { background: #162029; color: #e0e0e0; }
+    .period-dropdown-item.active { color: #4fc3f7; background: #0f1923; font-weight: bold; }
+    .period-custom { padding: 12px 16px; border-top: 1px solid #333; display: flex; flex-direction: column; gap: 8px; }
+    .period-custom label { display: flex; align-items: center; gap: 8px; color: #aaa; font-size: 0.85em; }
+    .period-custom input[type="datetime-local"] { flex: 1; padding: 6px 8px; border: 1px solid #333; border-radius: 4px; background: #0f1923; color: #e0e0e0; font-size: 0.85em; }
+    .period-custom input[type="datetime-local"]:focus { outline: none; border-color: #4fc3f7; }
+    .period-custom-apply { padding: 8px 16px; border: none; border-radius: 6px; background: #4fc3f7; color: #0f1923; font-size: 0.9em; font-weight: bold; cursor: pointer; transition: background 0.2s; width: 100%; }
+    .period-custom-apply:hover { background: #81d4fa; }
+    .period-custom-apply:disabled { background: #333; color: #666; cursor: not-allowed; }
+    .period-custom-error { color: #ff8a80; font-size: 0.8em; margin: 0; }
     .limit-controls { display: flex; gap: 4px; margin-bottom: 8px; }
     .limit-btn { padding: 4px 10px; border: 1px solid #333; border-radius: 4px; background: #162029; color: #aaa; font-size: 0.8em; cursor: pointer; transition: all 0.2s; }
     .limit-btn:hover { border-color: #4fc3f7; color: #e0e0e0; }

--- a/static/index.html
+++ b/static/index.html
@@ -71,14 +71,33 @@
     .period-dropdown-item { padding: 10px 16px; border: none; background: none; color: #aaa; font-size: 0.9em; cursor: pointer; text-align: left; transition: all 0.15s; width: 100%; }
     .period-dropdown-item:hover { background: #162029; color: #e0e0e0; }
     .period-dropdown-item.active { color: #4fc3f7; background: #0f1923; font-weight: bold; }
-    .period-custom { padding: 12px 16px; border-top: 1px solid #333; display: flex; flex-direction: column; gap: 8px; }
-    .period-custom label { display: flex; align-items: center; gap: 8px; color: #aaa; font-size: 0.85em; }
-    .period-custom input[type="datetime-local"] { flex: 1; padding: 6px 8px; border: 1px solid #333; border-radius: 4px; background: #0f1923; color: #e0e0e0; font-size: 0.85em; }
-    .period-custom input[type="datetime-local"]:focus { outline: none; border-color: #4fc3f7; }
+    .period-dropdown-custom { border-top: 1px solid #333; }
+    .period-custom { padding: 12px 16px; border-top: 1px solid #333; display: flex; flex-direction: column; gap: 10px; }
+    .period-custom-range { display: flex; gap: 12px; }
+    .period-custom-col { display: flex; flex-direction: column; gap: 6px; flex: 1; }
+    .period-custom-title { color: #4fc3f7; font-size: 0.85em; font-weight: bold; }
+    .period-custom-value { color: #e0e0e0; font-size: 0.8em; min-height: 1.2em; }
+    .period-time-toggle { padding: 4px 0; border: none; background: none; color: #888; font-size: 0.8em; cursor: pointer; text-align: left; text-decoration: underline; width: auto; }
+    .period-time-toggle:hover { color: #4fc3f7; }
     .period-custom-apply { padding: 8px 16px; border: none; border-radius: 6px; background: #4fc3f7; color: #0f1923; font-size: 0.9em; font-weight: bold; cursor: pointer; transition: background 0.2s; width: 100%; }
     .period-custom-apply:hover { background: #81d4fa; }
     .period-custom-apply:disabled { background: #333; color: #666; cursor: not-allowed; }
     .period-custom-error { color: #ff8a80; font-size: 0.8em; margin: 0; }
+    .cal { user-select: none; }
+    .cal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 6px; }
+    .cal-nav { background: none; border: none; color: #aaa; font-size: 0.85em; cursor: pointer; padding: 4px 8px; border-radius: 4px; width: auto; }
+    .cal-nav:hover { background: #162029; color: #e0e0e0; }
+    .cal-title { color: #e0e0e0; font-size: 0.85em; font-weight: bold; }
+    .cal-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; text-align: center; }
+    .cal-dow { font-size: 0.7em; color: #666; padding: 2px 0; }
+    .cal-empty { padding: 4px; }
+    .cal-day { background: none; border: 1px solid transparent; border-radius: 4px; color: #aaa; font-size: 0.8em; padding: 4px 0; cursor: pointer; width: auto; }
+    .cal-day:hover { background: #162029; color: #e0e0e0; border-color: #333; }
+    .cal-day.selected { background: #4fc3f7; color: #0f1923; font-weight: bold; border-color: #4fc3f7; }
+    .time-sel { display: flex; align-items: center; gap: 4px; }
+    .time-select { padding: 4px 6px; border: 1px solid #333; border-radius: 4px; background: #0f1923; color: #e0e0e0; font-size: 0.85em; cursor: pointer; }
+    .time-select:focus { outline: none; border-color: #4fc3f7; }
+    .time-colon { color: #666; }
     .limit-controls { display: flex; gap: 4px; margin-bottom: 8px; }
     .limit-btn { padding: 4px 10px; border: 1px solid #333; border-radius: 4px; background: #162029; color: #aaa; font-size: 0.8em; cursor: pointer; transition: all 0.2s; }
     .limit-btn:hover { border-color: #4fc3f7; color: #e0e0e0; }
@@ -102,6 +121,8 @@
       .report table { font-size: 0.8em; }
       .report th, .report td { padding: 5px 8px; }
       .report blockquote { padding: 8px 10px; font-size: 0.85em; }
+      .period-dropdown { left: auto; right: 0; min-width: 0; width: calc(100vw - 20px); max-width: 480px; }
+      .period-custom-range { flex-direction: column; }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- 期間選択UIをタブボタンからGCP/AWS風ドロップダウンセレクタに変更
- プリセット期間を3段階(全期間/30日/7日)から8段階(1d/3d/7d/14d/30d/60d/90d/全期間)に拡充
- カスタム日時範囲指定機能を追加（`datetime-local`入力→サーバーサイドで再分析）
- 新エンドポイント `GET /result/{id}/period?start=...&end=...` を追加

## Test plan
- [ ] `make build` でビルド確認
- [ ] プリセット期間の切り替えが正常に動作すること
- [ ] カスタム日時範囲を指定して「適用」→レポートが更新されること
- [ ] ドロップダウンの外側クリックで閉じること
- [ ] スマホでの操作性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)