### PR TITLE
update カスタム期間UIの改善とJob not found修正

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -156,6 +156,11 @@ func StartServer() {
 		handleResult(w, r, path)
 	})
 
+	// GET /period?user_key=...&start=...&end=... → カスタム期間で再分析（ジョブ不要）
+	http.HandleFunc("/period", func(w http.ResponseWriter, r *http.Request) {
+		handlePeriod(w, r)
+	})
+
 	// 静的ファイル（フロントエンド）
 	fs := http.FileServer(http.Dir("static"))
 	http.Handle("/", fs)
@@ -178,7 +183,7 @@ func handleResult(w http.ResponseWriter, r *http.Request, id string) {
 
 	if snap.Status != pipeline.StatusDone && snap.Status != pipeline.StatusError {
 		if snap.PreliminaryReport != "" {
-			sendRawReport(w, http.StatusOK, snap.PreliminaryReport, string(snap.Status), true)
+			sendRawReport(w, http.StatusOK, snap.PreliminaryReport, string(snap.Status), snap.UserKey, true)
 			return
 		}
 		sendJSON(w, http.StatusAccepted, map[string]string{"status": string(snap.Status)})
@@ -190,7 +195,7 @@ func handleResult(w http.ResponseWriter, r *http.Request, id string) {
 		return
 	}
 
-	sendRawReport(w, http.StatusOK, snap.Report, "", false)
+	sendRawReport(w, http.StatusOK, snap.Report, "", snap.UserKey, false)
 }
 
 func handleCustomPeriod(w http.ResponseWriter, r *http.Request, id string) {
@@ -236,7 +241,37 @@ func handleCustomPeriod(w http.ResponseWriter, r *http.Request, id string) {
 		return
 	}
 
-	sendRawReport(w, http.StatusOK, report, "", false)
+	sendRawReport(w, http.StatusOK, report, "", snap.UserKey, false)
+}
+
+func handlePeriod(w http.ResponseWriter, r *http.Request) {
+	userKey := r.URL.Query().Get("user_key")
+	start := r.URL.Query().Get("start")
+	end := r.URL.Query().Get("end")
+
+	if userKey == "" || start == "" || end == "" {
+		sendJSON(w, http.StatusBadRequest, map[string]string{"error": "user_key, start and end parameters are required"})
+		return
+	}
+
+	const layout = "2006-01-02 15:04"
+	if _, err := time.Parse(layout, start); err != nil {
+		sendJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid start datetime format (expected: YYYY-MM-DD HH:MM)"})
+		return
+	}
+	if _, err := time.Parse(layout, end); err != nil {
+		sendJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid end datetime format (expected: YYYY-MM-DD HH:MM)"})
+		return
+	}
+
+	report, err := pipeline.RunCustomPeriod(userKey, start, end)
+	if err != nil {
+		log.Printf("[ERROR] Custom period analysis failed: %v", err)
+		sendJSON(w, http.StatusInternalServerError, map[string]string{"error": "カスタム期間の分析に失敗しました"})
+		return
+	}
+
+	sendRawReport(w, http.StatusOK, report, "", userKey, false)
 }
 
 // securityHeaders は全レスポンスにセキュリティヘッダーを付与する
@@ -258,16 +293,18 @@ func sendJSON(w http.ResponseWriter, code int, data interface{}) {
 
 // sendRawReport はJSON形式のレポートをレスポンスとして返す。
 // reportJSONはanalyze.pyが生成したJSON文字列。json.RawMessageで二重エンコードを防ぐ。
-func sendRawReport(w http.ResponseWriter, code int, reportJSON, status string, preliminary bool) {
+func sendRawReport(w http.ResponseWriter, code int, reportJSON, status, userKey string, preliminary bool) {
 	type reportResponse struct {
 		Report      json.RawMessage `json:"report"`
 		Status      string          `json:"status,omitempty"`
 		Preliminary bool            `json:"preliminary,omitempty"`
+		UserKey     string          `json:"user_key,omitempty"`
 	}
 	resp := reportResponse{
 		Report:      json.RawMessage(reportJSON),
 		Status:      status,
 		Preliminary: preliminary,
+		UserKey:     userKey,
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)

--- a/static/app.js
+++ b/static/app.js
@@ -154,6 +154,7 @@ function CalendarPicker({ selectedDate, onSelect }) {
   var cells = [];
   for (var i = 0; i < firstDay; i++) cells.push(null);
   for (var d = 1; d <= daysInMonth; d++) cells.push(d);
+  while (cells.length < 42) cells.push(null);
 
   var selStr = selectedDate || '';
 
@@ -211,9 +212,9 @@ function TimeSelector({ hour, minute, onChangeHour, onChangeMinute, isEnd }) {
 
 // --- Period selector (GCP/AWS style dropdown) ---
 
-function PeriodSelector({ periods, selected, onSelect, jobId, onCustomReport }) {
+function PeriodSelector({ periods, selected, onSelect, userKey, onCustomReport }) {
   var keys = PERIOD_KEYS.filter(function (k) { return periods[k]; });
-  if (keys.length <= 1 && !jobId) return null;
+  if (keys.length <= 1 && !userKey) return null;
 
   var openRef = useState(false);
   var isOpen = openRef[0], setIsOpen = openRef[1];
@@ -275,7 +276,7 @@ function PeriodSelector({ periods, selected, onSelect, jobId, onCustomReport }) 
     var end = showTime ? formatDt(endDate, endHour, endMin) : endDate + ' 23:59';
     setIsLoading(true);
     setCustomError('');
-    fetch('/result/' + jobId + '/period?start=' + encodeURIComponent(start) + '&end=' + encodeURIComponent(end))
+    fetch('/period?user_key=' + encodeURIComponent(userKey) + '&start=' + encodeURIComponent(start) + '&end=' + encodeURIComponent(end))
       .then(function (res) { return res.json(); })
       .then(function (data) {
         setIsLoading(false);
@@ -302,7 +303,7 @@ function PeriodSelector({ periods, selected, onSelect, jobId, onCustomReport }) 
           return html`<button class=${'period-dropdown-item' + (selected === k ? ' active' : '')}
             onClick=${function () { selectPreset(k); }}>${periods[k].label}</button>`;
         })}
-        ${jobId && html`<button class=${'period-dropdown-item period-dropdown-custom' + (showCustom ? ' active' : '')}
+        ${userKey && html`<button class=${'period-dropdown-item period-dropdown-custom' + (showCustom ? ' active' : '')}
           onClick=${function () { setShowCustom(!showCustom); }}>カスタム</button>`}
       </div>
       ${showCustom && html`<div class="period-custom">
@@ -632,7 +633,7 @@ function TableOfContents({ data }) {
 
 // --- Main report ---
 
-function Report({ data, jobId }) {
+function Report({ data, userKey }) {
   if (!data) return null;
   var periodRef = useState('all');
   var selectedPeriod = periodRef[0], setSelectedPeriod = periodRef[1];
@@ -656,7 +657,7 @@ function Report({ data, jobId }) {
     <h1>${esc(data.player_name)} - 戦績分析レポート</h1>
     <${ShareArea} shareData=${shareData} />
     <${PeriodSelector} periods=${allPeriods} selected=${selectedPeriod} onSelect=${setSelectedPeriod}
-      jobId=${jobId} onCustomReport=${handleCustomReport} />
+      userKey=${userKey} onCustomReport=${handleCustomReport} />
     <${TableOfContents} data=${pd} />
     <div id="sec-summary"><${SummarySection} summary=${pd.summary} /></div>
     <div id="sec-basic"><${Section} title="基本データ">
@@ -676,10 +677,10 @@ function Report({ data, jobId }) {
 
 // --- Main app logic ---
 
-function renderReport(data, jobId) {
+function renderReport(data, userKey) {
   var reportEl = document.getElementById('report');
   reportEl.style.display = 'block';
-  render(html`<${Report} data=${data} jobId=${jobId} />`, reportEl);
+  render(html`<${Report} data=${data} userKey=${userKey} />`, reportEl);
 }
 
 async function analyze() {
@@ -748,7 +749,7 @@ async function analyze() {
         var prelimRes = await fetch('/result/' + jobId);
         var prelimData = await prelimRes.json();
         if (prelimData.report && prelimData.preliminary) {
-          renderReport(prelimData.report, jobId);
+          renderReport(prelimData.report, prelimData.user_key);
           statusText.textContent = '最新データを取得中...';
           preliminaryShown = true;
         }
@@ -766,7 +767,7 @@ async function analyze() {
           throw new Error(resultData.error);
         }
 
-        renderReport(resultData.report, jobId);
+        renderReport(resultData.report, resultData.user_key);
         break;
       }
     }


### PR DESCRIPTION
## Summary
- カスタム日時入力をカレンダー＋時刻プルダウンに改善
- 時刻指定はオプション（デフォルトは終日 00:00〜23:59）
- 分の選択肢を5分刻み（終了のみ59分あり）
- カレンダーを常に6行表示にして左右のずれを解消
- カスタム期間をjobId依存からuserKey方式に変更してJob not foundを修正
- `GET /period?user_key=...&start=...&end=...` エンドポイント追加

## Test plan
- [ ] プリセット期間の切り替えが正常に動作すること
- [ ] カスタムのカレンダーで日付選択→適用でレポートが更新されること
- [ ] 時刻指定トグルの表示/非表示が正常に動作すること
- [ ] 4月と5月など異なる月でカレンダーが左右揃うこと
- [ ] ジョブ削除後もカスタム期間が使えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)