### PR TITLE
fix ログインエラー時に専用のエラーメッセージを表示

### DIFF
--- a/cmd/update-mslist/main.go
+++ b/cmd/update-mslist/main.go
@@ -28,7 +28,10 @@ func main() {
 	}
 
 	log.Println("Scraping MS list...")
-	scraped := scraper.ScrapeMSList(username, password)
+	scraped, err := scraper.ScrapeMSList(username, password)
+	if err != nil {
+		log.Fatalf("Failed to scrape MS list: %v", err)
+	}
 
 	if len(scraped) == 0 {
 		log.Fatal("No MS data found")

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -143,7 +144,15 @@ func Run(j *Job, username, password string) {
 		j.ProgressTotal = total
 		jobsMu.Unlock()
 	}
-	datedScores := scraper.Scraping(username, password, since, onProgress)
+	datedScores, err := scraper.Scraping(username, password, since, onProgress)
+	if err != nil {
+		if errors.Is(err, scraper.ErrLoginFailed) {
+			setError(j, "ログインに失敗しました。メールアドレスとパスワードを確認してください。", err.Error())
+		} else {
+			setError(j, "データの取得に失敗しました", err.Error())
+		}
+		return
+	}
 	if len(datedScores) == 0 && !exists {
 		setError(j, "戦績データが見つかりませんでした", "no scores found")
 		return

--- a/internal/scraper/login.go
+++ b/internal/scraper/login.go
@@ -2,6 +2,7 @@ package scraper
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/cookiejar"
@@ -9,6 +10,9 @@ import (
 	"strings"
 	"time"
 )
+
+// ErrLoginFailed はログイン認証に失敗した場合のエラー
+var ErrLoginFailed = errors.New("ログイン認証に失敗しました")
 
 const (
 	loginURL    = "https://account-api.bandainamcoid.com/v3/login/idpw"
@@ -133,6 +137,10 @@ func (c *Client) Login() error {
 	var l loginResponse
 	if err := json.NewDecoder(loginPage.Body).Decode(&l); err != nil {
 		return fmt.Errorf("ログインレスポンスの解析に失敗: %w", err)
+	}
+
+	if l.RedirectUrl == "" {
+		return ErrLoginFailed
 	}
 
 	if strings.Contains(l.RedirectUrl, "passkey") {

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -53,7 +53,7 @@ type ProgressFunc func(current, total int)
 
 // Scraping はスクレイピング処理を実行し、DatedScoresを返す
 // 日別ページ収集と詳細ページ取得をパイプラインで並行実行し、高速化を図る
-func Scraping(username, password string, since time.Time, onProgress ...ProgressFunc) model.DatedScores {
+func Scraping(username, password string, since time.Time, onProgress ...ProgressFunc) (model.DatedScores, error) {
 	notify := func(current, total int) {
 		if len(onProgress) > 0 && onProgress[0] != nil {
 			onProgress[0](current, total)
@@ -61,7 +61,9 @@ func Scraping(username, password string, since time.Time, onProgress ...Progress
 	}
 
 	m := NewClient(username, password)
-	m.Login()
+	if err := m.Login(); err != nil {
+		return nil, fmt.Errorf("ログインに失敗: %w", err)
+	}
 
 	// Phase 1: rankpageから日別ページURLを収集
 	dailyLinks := collectDailyLinks(m.HTTPClient.Jar, since)
@@ -85,7 +87,7 @@ func Scraping(username, password string, since time.Time, onProgress ...Progress
 		return scores[i].PlayerNo < scores[j].PlayerNo
 	})
 
-	return scores
+	return scores, nil
 }
 
 // collectDailyLinks はrankpageから日別ページのURLを収集する
@@ -314,12 +316,14 @@ func parseDetailPage(e *colly.HTMLElement, date, hour string, wins []string) mod
 }
 
 // ScrapeMSList は機体使用率ランキングページから画像URLと機体名の一覧を取得する
-func ScrapeMSList(username, password string) []model.MSInfo {
+func ScrapeMSList(username, password string) ([]model.MSInfo, error) {
 	var msList []model.MSInfo
 	seen := make(map[string]bool)
 
 	m := NewClient(username, password)
-	m.Login()
+	if err := m.Login(); err != nil {
+		return nil, fmt.Errorf("ログインに失敗: %w", err)
+	}
 
 	// まずCSRFトークンを取得
 	var csrfToken string
@@ -370,5 +374,5 @@ func ScrapeMSList(username, password string) []model.MSInfo {
 		})
 	}
 
-	return msList
+	return msList, nil
 }


### PR DESCRIPTION
## Summary
- `Login()`のエラーが無視されていたため、ログイン失敗時も「戦績データが見つかりませんでした」という汎用メッセージが表示されていた
- `ErrLoginFailed`センチネルエラーを追加し、認証失敗を検出可能に
- `Scraping()`/`ScrapeMSList()`がerrorを返すように変更し、パイプラインでログインエラーと他のエラーを区別して表示

## Test plan
- [x] `make build` パス
- [x] `make test` パス
- [ ] 不正な認証情報で分析実行 → 「ログインに失敗しました。メールアドレスとパスワードを確認してください。」が表示されること
- [ ] 正しい認証情報で分析実行 → 従来通り動作すること

Close #169