### PR TITLE
fix スマホドロップダウン見切れと期間切替時の表示順崩れ

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -659,18 +659,18 @@ function Report({ data, userKey }) {
     <${PeriodSelector} periods=${allPeriods} selected=${selectedPeriod} onSelect=${setSelectedPeriod}
       userKey=${userKey} onCustomReport=${handleCustomReport} />
     <${TableOfContents} data=${pd} />
-    <div id="sec-summary"><${SummarySection} summary=${pd.summary} /></div>
-    <div id="sec-basic"><${Section} title="基本データ">
+    <div key="sec-summary" id="sec-summary"><${SummarySection} summary=${pd.summary} /></div>
+    <div key="sec-basic" id="sec-basic"><${Section} title="基本データ">
       <${BasicStatsSection} stats=${pd.basic_stats} />
       <${WinLossPatternSection} pattern=${pd.win_loss_pattern} />
     <//></div>
-    <${MsStatsSection} msStats=${pd.ms_stats} />
-    <div id="sec-fixed"><${FixedPartnersSection} partners=${pd.fixed_partners} /></div>
-    <div id="sec-deaths"><${DeathsImpactSection} deaths=${pd.deaths_impact} /></div>
-    <div id="sec-time"><${TimeOfDaySection} time=${pd.time_of_day} /></div>
-    <div id="sec-dow"><${DayOfWeekSection} dow=${pd.day_of_week} /></div>
-    <div id="sec-daily"><${DailyTrendSection} daily=${pd.daily_trend} /></div>
-    <div id="sec-season"><${SeasonSection} seasons=${pd.season} /></div>
+    <div key="sec-ms"><${MsStatsSection} msStats=${pd.ms_stats} /></div>
+    <div key="sec-fixed" id="sec-fixed"><${FixedPartnersSection} partners=${pd.fixed_partners} /></div>
+    <div key="sec-deaths" id="sec-deaths"><${DeathsImpactSection} deaths=${pd.deaths_impact} /></div>
+    <div key="sec-time" id="sec-time"><${TimeOfDaySection} time=${pd.time_of_day} /></div>
+    <div key="sec-dow" id="sec-dow"><${DayOfWeekSection} dow=${pd.day_of_week} /></div>
+    <div key="sec-daily" id="sec-daily"><${DailyTrendSection} daily=${pd.daily_trend} /></div>
+    <div key="sec-season" id="sec-season"><${SeasonSection} seasons=${pd.season} /></div>
     <${ShareArea} shareData=${shareData} />
   `;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -121,7 +121,7 @@
       .report table { font-size: 0.8em; }
       .report th, .report td { padding: 5px 8px; }
       .report blockquote { padding: 8px 10px; font-size: 0.85em; }
-      .period-dropdown { left: auto; right: 0; min-width: 0; width: calc(100vw - 20px); max-width: 480px; }
+      .period-dropdown { position: fixed; top: auto; left: 10px; right: 10px; min-width: 0; width: auto; max-height: 80vh; overflow-y: auto; }
       .period-custom-range { flex-direction: column; }
     }
   </style>


### PR DESCRIPTION
## Summary
- スマホではドロップダウンを`position: fixed`で画面幅に合わせて表示
- 各セクションに`key`属性を追加してPreactのDOM差分更新を安定化し、期間切替時の表示順崩れを修正

## Test plan
- [ ] スマホでドロップダウンが画面内に収まること
- [ ] 期間を切り替えてもセクションの順番が維持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)