### PR TITLE
feat タッグ戦歴ページから固定相方を判定する

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -131,8 +132,8 @@ func Run(j *Job, username, password string) {
 			log.Printf("[INFO] Fetching scores after %s", since.Format("2006-01-02 15:04"))
 		}
 
-		// 前回データで即座に分析（速報レポート）
-		prelimReport := runAnalysis(csvPath, tmpDir)
+		// 前回データで即座に分析（速報レポート、タッグ情報なし）
+		prelimReport := runAnalysis(csvPath, tmpDir, "")
 		if prelimReport != "" {
 			jobsMu.Lock()
 			j.PreliminaryReport = prelimReport
@@ -196,9 +197,24 @@ func Run(j *Job, username, password string) {
 		log.Printf("[WARN] Failed to upload CSV to Cloud Storage: %v", err)
 	}
 
+	// タッグ相方名を取得
+	var tagPartnersPath string
+	tagPartners := scraper.ScrapeTagPartners(username, password)
+	if len(tagPartners) > 0 {
+		tagPartnersPath = filepath.Join(tmpDir, "tag_partners.json")
+		if err := saveTagPartners(tagPartners, tagPartnersPath); err != nil {
+			log.Printf("[WARN] Failed to save tag partners: %v", err)
+			tagPartnersPath = ""
+		} else {
+			log.Printf("[INFO] Found %d tag partners", len(tagPartners))
+		}
+	} else {
+		log.Printf("[INFO] No tag partners found")
+	}
+
 	// Python分析実行
 	updateStatus(j, StatusAnalyzing)
-	report := runAnalysis(csvPath, tmpDir)
+	report := runAnalysis(csvPath, tmpDir, tagPartnersPath)
 	if report == "" {
 		setError(j, "分析処理に失敗しました", "analysis returned empty report")
 		return
@@ -245,9 +261,32 @@ func RunCustomPeriod(userKey, start, end string) (string, error) {
 	return string(report), nil
 }
 
+// saveTagPartners はタッグ相方情報をJSONファイルに保存する
+func saveTagPartners(partners []scraper.TagPartner, path string) error {
+	type tagPartnerJSON struct {
+		TeamName   string `json:"team_name"`
+		PlayerName string `json:"player_name"`
+	}
+
+	data := make([]tagPartnerJSON, len(partners))
+	for i, p := range partners {
+		data[i] = tagPartnerJSON{TeamName: p.TeamName, PlayerName: p.PlayerName}
+	}
+
+	b, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshal tag partners: %w", err)
+	}
+	return os.WriteFile(path, b, 0644)
+}
+
 // runAnalysis はPython分析を実行してJSON形式のレポートを返す。失敗時は空文字を返す。
-func runAnalysis(csvPath, tmpDir string) string {
-	cmd := exec.Command("python3", "scripts/analyze.py", csvPath)
+func runAnalysis(csvPath, tmpDir, tagPartnersPath string) string {
+	args := []string{"scripts/analyze.py", csvPath}
+	if tagPartnersPath != "" {
+		args = append(args, "--tag-partners", tagPartnersPath)
+	}
+	cmd := exec.Command("python3", args...)
 	cmd.Dir = "/app"
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -17,11 +17,18 @@ import (
 const (
 	vsmobile         = "web.vsmobile.jp"
 	mobileRankpage   = "https://web.vsmobile.jp/exvs2ib/results/classmatch/fight"
+	mobileTagPage    = "https://web.vsmobile.jp/exvs2ib/results/classmatch/tag"
 	mobileMSUsedRate = "https://web.vsmobile.jp/exvs2ib/ranking/ms_used_rate"
 
 	// maxParallelism はバンナムサーバーへの最大同時リクエスト数
 	maxParallelism = 5
 )
+
+// TagPartner はタッグ戦歴ページから取得した固定相方情報
+type TagPartner struct {
+	TeamName   string
+	PlayerName string
+}
 
 // dailyLink はrankpageから収集した日別ページ情報
 type dailyLink struct {
@@ -313,6 +320,32 @@ func parseDetailPage(e *colly.HTMLElement, date, hour string, wins []string) mod
 	}
 
 	return scores
+}
+
+// ScrapeTagPartners はタッグ戦歴ページからチーム名と相方のプレイヤー名を取得する
+func ScrapeTagPartners(username, password string) []TagPartner {
+	var partners []TagPartner
+
+	m := NewClient(username, password)
+	m.Login()
+
+	c := colly.NewCollector(colly.AllowedDomains(vsmobile))
+	c.SetCookieJar(m.HTTPClient.Jar)
+
+	c.OnHTML("li.item", func(e *colly.HTMLElement) {
+		teamName := strings.TrimSpace(e.ChildText("p.tag-name"))
+		playerName := strings.TrimSpace(e.ChildText("p.ml-ss"))
+
+		if playerName != "" {
+			partners = append(partners, TagPartner{
+				TeamName:   teamName,
+				PlayerName: playerName,
+			})
+		}
+	})
+
+	c.Visit(mobileTagPage)
+	return partners
 }
 
 // ScrapeMSList は機体使用率ランキングページから画像URLと機体名の一覧を取得する

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -150,28 +150,29 @@ def get_my_data(match, cost_map=None):
     }
 
 
-def detect_fixed_partners(all_data, min_streak=10):
-    """連続で同じ相方と組んでいる区間を検出し、固定相方の試合を返す。
-    時系列順で連続10戦以上同じ相方名ならその区間を固定とみなす。
+def load_tag_partners(path):
+    """タッグ相方JSONファイルを読み込み、{player_name: team_name} の辞書を返す。"""
+    if not path or not os.path.exists(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return {entry["player_name"]: entry["team_name"] for entry in data}
+
+
+def detect_fixed_partners(all_data, tag_partners=None):
+    """タッグ相方名リストに基づいて固定相方の試合を返す。
+    tag_partners が指定されている場合、相方名が一致する試合を固定扱いにする。
+    tag_partners が空の場合、固定相方なしとして空を返す。
     """
-    sorted_data = sorted(all_data, key=lambda d: d["datetime"])
+    if not tag_partners:
+        return {}
 
+    partner_names = set(tag_partners.keys())
     fixed_matches = defaultdict(list)
-    streak = [sorted_data[0]]
 
-    for i in range(1, len(sorted_data)):
-        if sorted_data[i]["partner_name"] == streak[-1]["partner_name"]:
-            streak.append(sorted_data[i])
-        else:
-            if len(streak) >= min_streak:
-                name = streak[0]["partner_name"]
-                fixed_matches[name].extend(streak)
-            streak = [sorted_data[i]]
-
-    # 最後のストリーク
-    if len(streak) >= min_streak:
-        name = streak[0]["partner_name"]
-        fixed_matches[name].extend(streak)
+    for d in all_data:
+        if d["partner_name"] in partner_names:
+            fixed_matches[d["partner_name"]].append(d)
 
     return fixed_matches
 
@@ -511,11 +512,13 @@ def data_dmg_contribution(data_list, min_matches=3):
     }
 
 
-def data_fixed_partners(all_data):
-    fixed = detect_fixed_partners(all_data)
+def data_fixed_partners(all_data, tag_partners=None):
+    fixed = detect_fixed_partners(all_data, tag_partners)
 
     if not fixed:
-        return []
+        if not tag_partners:
+            return {"notice": "タッグ情報が見つかりませんでした。フレンドを登録してタッグを組むと、固定相方の詳細分析が利用できます。", "partners": []}
+        return {"partners": []}
 
     results = []
     for partner_name in sorted(fixed.keys(), key=lambda x: -len(fixed[x])):
@@ -571,7 +574,7 @@ def data_fixed_partners(all_data):
             elif wr >= 60:
                 tips.append(f"好調です！勝率{wr:.0f}%、安定した連携ができています。さらに勝率を伸ばすために相方との役割分担を意識してみましょう。")
 
-        results.append({
+        entry = {
             "partner_name": partner_name,
             "matches": n,
             "wins": w,
@@ -593,9 +596,12 @@ def data_fixed_partners(all_data):
             },
             "partner_ms_breakdown": ms_breakdown,
             "tips": tips,
-        })
+        }
+        if tag_partners and partner_name in tag_partners:
+            entry["team_name"] = tag_partners[partner_name]
+        results.append(entry)
 
-    return results
+    return {"partners": results}
 
 
 def data_deaths_impact(data_list):
@@ -858,7 +864,7 @@ def data_season(data_list):
     return results
 
 
-def data_advice(all_data, ms_data):
+def data_advice(all_data, ms_data, tag_partners=None):
     advices = []
 
     cost_groups = defaultdict(list)
@@ -949,7 +955,7 @@ def data_advice(all_data, ms_data):
                 "text": f"{better}の勝率({max(wd_wr, we_wr):.0f}%)が{worse}({min(wd_wr, we_wr):.0f}%)より{diff:.0f}ポイント高いです。",
             })
 
-    fixed = detect_fixed_partners(all_data)
+    fixed = detect_fixed_partners(all_data, tag_partners)
     if len(fixed) >= 2:
         partner_wrs = [(name, win_rate(data), len(data)) for name, data in fixed.items() if len(data) >= 5]
         if len(partner_wrs) >= 2:
@@ -1076,7 +1082,7 @@ def build_share_data(all_data, ms_data):
     return items
 
 
-def build_period_report(all_data, ms_data):
+def build_period_report(all_data, ms_data, tag_partners=None):
     """1期間分の分析レポートを生成する"""
     ms_names = [ms for ms in sorted(ms_data.keys(), key=lambda x: -len(ms_data[x])) if len(ms_data[ms]) >= 3]
 
@@ -1095,11 +1101,11 @@ def build_period_report(all_data, ms_data):
         }
 
     return {
-        "summary": data_advice(all_data, ms_data),
+        "summary": data_advice(all_data, ms_data, tag_partners),
         "basic_stats": data_basic_stats(all_data),
         "win_loss_pattern": data_win_loss_pattern(all_data),
         "ms_stats": ms_stats,
-        "fixed_partners": data_fixed_partners(all_data),
+        "fixed_partners": data_fixed_partners(all_data, tag_partners),
         "deaths_impact": data_deaths_impact(all_data),
         "time_of_day": data_time_of_day(all_data),
         "day_of_week": data_day_of_week(all_data),
@@ -1132,12 +1138,12 @@ def build_ms_data(data_list):
     return ms_data
 
 
-def build_json_report(player_name, all_data, ms_data):
+def build_json_report(player_name, all_data, ms_data, tag_partners=None):
     """期間別の構造化JSONレポートを生成する"""
     periods = {}
 
     # 全期間
-    periods["all"] = build_period_report(all_data, ms_data)
+    periods["all"] = build_period_report(all_data, ms_data, tag_partners)
     periods["all"]["label"] = "全期間"
 
     # プリセット期間
@@ -1154,7 +1160,7 @@ def build_json_report(player_name, all_data, ms_data):
         filtered = filter_by_days(all_data, days)
         if filtered:
             ms_filtered = build_ms_data(filtered)
-            periods[key] = build_period_report(filtered, ms_filtered)
+            periods[key] = build_period_report(filtered, ms_filtered, tag_partners)
             periods[key]["label"] = label
 
     return {
@@ -1190,6 +1196,7 @@ def main():
     parser.add_argument("csv_path", help="CSVファイルパス")
     parser.add_argument("--start", help="開始日時 (YYYY-MM-DD HH:MM)")
     parser.add_argument("--end", help="終了日時 (YYYY-MM-DD HH:MM)")
+    parser.add_argument("--tag-partners", help="タッグ相方JSONファイルパス", default=None)
     args = parser.parse_args()
 
     matches = load_csv(args.csv_path)
@@ -1200,6 +1207,7 @@ def main():
 
     cost_map = load_ms_cost_map(args.csv_path)
     player_name = detect_player_name(matches)
+    tag_partners = load_tag_partners(args.tag_partners)
 
     all_data = [get_my_data(m, cost_map) for m in matches]
 
@@ -1215,7 +1223,7 @@ def main():
             print("指定期間のデータが見つかりませんでした。")
             sys.exit(1)
     else:
-        report_data = build_json_report(player_name, all_data, ms_data)
+        report_data = build_json_report(player_name, all_data, ms_data, tag_partners)
 
     output_path = os.path.join(os.path.dirname(args.csv_path), "report.json")
     with open(output_path, "w", encoding="utf-8") as f:

--- a/static/app.js
+++ b/static/app.js
@@ -471,9 +471,20 @@ function DmgContributionSubSection({ dmg }) {
 }
 
 function FixedPartnersSection({ partners }) {
-  if (!partners || !partners.length) return null;
-  return html`<${Section} title="固定相方分析（連続10戦以上）">
-    ${partners.map(function (p) {
+  if (!partners) return null;
+  var list = partners.partners || partners;
+  if (Array.isArray(list) && !list.length) {
+    if (partners.notice) {
+      return html`<${Section} title="固定相方分析">
+        <p class="notice">${esc(partners.notice)}</p>
+      <//>`;
+    }
+    return null;
+  }
+  var items = Array.isArray(list) ? list : [];
+  return html`<${Section} title="固定相方分析">
+    ${partners.notice && html`<p class="notice">${esc(partners.notice)}</p>`}
+    ${items.map(function (p) {
       var statsRows = [
         ['平均与ダメージ', num(p.my_stats.avg_dmg_given), num(p.partner_stats.avg_dmg_given)],
         ['平均被ダメージ', num(p.my_stats.avg_dmg_taken), num(p.partner_stats.avg_dmg_taken)],
@@ -484,8 +495,9 @@ function FixedPartnersSection({ partners }) {
       var msRows = (p.partner_ms_breakdown || []).map(function (m) {
         return [esc(m.ms), m.matches, pct(m.win_rate)];
       });
+      var title = p.team_name ? esc(p.partner_name) + '【' + esc(p.team_name) + '】' : esc(p.partner_name);
       return html`<div>
-        <h3>${esc(p.partner_name)} (${p.matches}戦)</h3>
+        <h3>${title} (${p.matches}戦)</h3>
         <p>${p.wins}勝${p.losses}敗 (勝率 ${pct(p.win_rate)})</p>
         <${Table} headers=${['項目', '自分', '相方']} rows=${statsRows} />
         ${msRows.length > 0 && html`<p><strong>相方の使用機体:</strong></p><${Table} headers=${['機体', '試合', '勝率']} rows=${msRows} />`}


### PR DESCRIPTION
## Summary
- 公式サイトのタッグ戦歴ページ（`/results/classmatch/tag`）をスクレイピングして固定相方名を取得
- 名前一致で固定相方の試合を判定するように変更（従来のストリーク検出を廃止）
- タッグ情報がない場合はフレンド登録を促す注意メッセージを表示
- フロントエンドでチーム名（【チーム名】）を表示

## 変更内容
- `internal/scraper/scraper.go`: `ScrapeTagPartners`関数追加（グループタッグ・フレンドタッグ両方から取得）
- `internal/pipeline/pipeline.go`: タッグ相方名をJSON経由でPythonに渡す
- `scripts/analyze.py`: `detect_fixed_partners`を名前一致ベースに変更、`--tag-partners`引数追加
- `static/app.js`: 新データ形式対応、チーム名表示、注意メッセージ表示

## Test plan
- [x] `make build` 成功
- [x] `make test` 全テスト通過

Close #168