### PR TITLE
fix スマホでドロップダウンが見切れる問題を修正し期間ラベルを変更

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1144,17 +1144,17 @@ def build_json_report(player_name, all_data, ms_data, tag_partners=None):
 
     # 全期間
     periods["all"] = build_period_report(all_data, ms_data, tag_partners)
-    periods["all"]["label"] = "全期間"
+    periods["all"]["label"] = "全データ"
 
     # プリセット期間
     preset_periods = [
-        ("90d", 90, "直近90日"),
-        ("60d", 60, "直近60日"),
-        ("30d", 30, "直近30日"),
-        ("14d", 14, "直近14日"),
-        ("7d", 7, "直近7日"),
-        ("3d", 3, "直近3日"),
-        ("1d", 1, "直近1日"),
+        ("90d", 90, "90日間"),
+        ("60d", 60, "60日間"),
+        ("30d", 30, "30日間"),
+        ("14d", 14, "14日間"),
+        ("7d", 7, "7日間"),
+        ("3d", 3, "3日間"),
+        ("1d", 1, "1日間"),
     ]
     for key, days, label in preset_periods:
         filtered = filter_by_days(all_data, days)

--- a/static/app.js
+++ b/static/app.js
@@ -253,6 +253,16 @@ function PeriodSelector({ periods, selected, onSelect, userKey, onCustomReport }
     return function () { document.removeEventListener('mousedown', handleClick); };
   }, []);
 
+  // スマホでドロップダウン表示中はbodyスクロールを止める
+  useEffect(function () {
+    if (isOpen && window.innerWidth <= 600) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return function () { document.body.style.overflow = ''; };
+  }, [isOpen]);
+
   var currentLabel = selected === 'custom'
     ? (periods.custom ? periods.custom.label : 'カスタム')
     : (periods[selected] ? periods[selected].label : '全期間');
@@ -297,6 +307,7 @@ function PeriodSelector({ periods, selected, onSelect, userKey, onCustomReport }
     <button class="period-trigger" onClick=${function () { setIsOpen(!isOpen); }}>
       ${currentLabel} <span class="period-arrow">${isOpen ? '\u25B2' : '\u25BC'}</span>
     </button>
+    ${isOpen && html`<div class="period-backdrop" onClick=${function () { setIsOpen(false); }} />`}
     ${isOpen && html`<div class="period-dropdown">
       <div class="period-dropdown-list">
         ${keys.map(function (k) {

--- a/static/app.js
+++ b/static/app.js
@@ -264,8 +264,8 @@ function PeriodSelector({ periods, selected, onSelect, userKey, onCustomReport }
   }, [isOpen]);
 
   var currentLabel = selected === 'custom'
-    ? (periods.custom ? periods.custom.label : 'カスタム')
-    : (periods[selected] ? periods[selected].label : '全期間');
+    ? (periods.custom ? periods.custom.label : '日付指定')
+    : (periods[selected] ? periods[selected].label : '全データ');
 
   function selectPreset(k) {
     onSelect(k);
@@ -315,7 +315,7 @@ function PeriodSelector({ periods, selected, onSelect, userKey, onCustomReport }
             onClick=${function () { selectPreset(k); }}>${periods[k].label}</button>`;
         })}
         ${userKey && html`<button class=${'period-dropdown-item period-dropdown-custom' + (showCustom ? ' active' : '')}
-          onClick=${function () { setShowCustom(!showCustom); }}>カスタム</button>`}
+          onClick=${function () { setShowCustom(!showCustom); }}>日付指定</button>`}
       </div>
       ${showCustom && html`<div class="period-custom">
         <div class="period-custom-range">

--- a/static/index.html
+++ b/static/index.html
@@ -109,6 +109,7 @@
     .toggle-all { display: flex; gap: 8px; margin-top: 8px; }
     .toggle-btn { padding: 4px 12px; border: 1px solid #333; border-radius: 4px; background: #162029; color: #aaa; font-size: 0.8em; cursor: pointer; transition: all 0.2s; }
     .toggle-btn:hover { border-color: #4fc3f7; color: #e0e0e0; }
+    .period-backdrop { display: none; }
     @media (max-width: 600px) {
       .container { padding: 10px; }
       h1 { font-size: 1.4em; margin: 20px 0 8px; }
@@ -121,7 +122,8 @@
       .report table { font-size: 0.8em; }
       .report th, .report td { padding: 5px 8px; }
       .report blockquote { padding: 8px 10px; font-size: 0.85em; }
-      .period-dropdown { position: fixed; top: auto; left: 10px; right: 10px; min-width: 0; width: auto; max-height: 80vh; overflow-y: auto; }
+      .period-backdrop { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99; }
+      .period-dropdown { position: fixed; bottom: 0; top: auto; left: 0; right: 0; min-width: 0; width: 100%; max-height: 85vh; overflow: visible; overflow-y: auto; border-radius: 12px 12px 0 0; z-index: 100; margin-top: 0; }
       .period-custom-range { flex-direction: column; }
     }
   </style>


### PR DESCRIPTION
## Summary
- スマホでドロップダウンをボトムシート型UIに変更（バックドロップ＋bodyスクロール抑制）
- 期間ラベルを「全データ / 90日間〜1日間 / 日付指定」に統一

## Test plan
- [x] スマホでドロップダウンが画面内に収まりスクロールしないこと
- [x] カレンダー表示時も見切れないこと
- [ ] バックドロップタップで閉じること
- [x] 期間ラベルが正しく表示されること