### PR TITLE
fix タッグ相方取得でログイン済みセッションを使い回す

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -151,7 +151,7 @@ func Run(j *Job, username, password string) {
 		j.ProgressTotal = total
 		jobsMu.Unlock()
 	}
-	datedScores, err := scraper.Scraping(username, password, since, onProgress)
+	datedScores, jar, err := scraper.Scraping(username, password, since, onProgress)
 	if err != nil {
 		if errors.Is(err, scraper.ErrLoginFailed) {
 			setError(j, "ログインに失敗しました。メールアドレスとパスワードを確認してください。", err.Error())
@@ -199,7 +199,7 @@ func Run(j *Job, username, password string) {
 
 	// タッグ相方名を取得
 	var tagPartnersPath string
-	tagPartners := scraper.ScrapeTagPartners(username, password)
+	tagPartners := scraper.ScrapeTagPartners(jar)
 	if len(tagPartners) > 0 {
 		tagPartnersPath = filepath.Join(tmpDir, "tag_partners.json")
 		if err := saveTagPartners(tagPartners, tagPartnersPath); err != nil {

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -58,9 +58,9 @@ func parseNumber(s string) int {
 // ProgressFunc はスクレイピングの進捗を通知するコールバック型
 type ProgressFunc func(current, total int)
 
-// Scraping はスクレイピング処理を実行し、DatedScoresを返す
+// Scraping はスクレイピング処理を実行し、DatedScoresとログイン済みCookieJarを返す
 // 日別ページ収集と詳細ページ取得をパイプラインで並行実行し、高速化を図る
-func Scraping(username, password string, since time.Time, onProgress ...ProgressFunc) (model.DatedScores, error) {
+func Scraping(username, password string, since time.Time, onProgress ...ProgressFunc) (model.DatedScores, http.CookieJar, error) {
 	notify := func(current, total int) {
 		if len(onProgress) > 0 && onProgress[0] != nil {
 			onProgress[0](current, total)
@@ -69,7 +69,7 @@ func Scraping(username, password string, since time.Time, onProgress ...Progress
 
 	m := NewClient(username, password)
 	if err := m.Login(); err != nil {
-		return nil, fmt.Errorf("ログインに失敗: %w", err)
+		return nil, nil, fmt.Errorf("ログインに失敗: %w", err)
 	}
 
 	// Phase 1: rankpageから日別ページURLを収集
@@ -94,7 +94,7 @@ func Scraping(username, password string, since time.Time, onProgress ...Progress
 		return scores[i].PlayerNo < scores[j].PlayerNo
 	})
 
-	return scores, nil
+	return scores, m.HTTPClient.Jar, nil
 }
 
 // collectDailyLinks はrankpageから日別ページのURLを収集する
@@ -323,14 +323,11 @@ func parseDetailPage(e *colly.HTMLElement, date, hour string, wins []string) mod
 }
 
 // ScrapeTagPartners はタッグ戦歴ページからチーム名と相方のプレイヤー名を取得する
-func ScrapeTagPartners(username, password string) []TagPartner {
+func ScrapeTagPartners(jar http.CookieJar) []TagPartner {
 	var partners []TagPartner
 
-	m := NewClient(username, password)
-	m.Login()
-
 	c := colly.NewCollector(colly.AllowedDomains(vsmobile))
-	c.SetCookieJar(m.HTTPClient.Jar)
+	c.SetCookieJar(jar)
 
 	c.OnHTML("li.item", func(e *colly.HTMLElement) {
 		teamName := strings.TrimSpace(e.ChildText("p.tag-name"))


### PR DESCRIPTION
## Summary
- `ScrapeTagPartners`が毎回`NewClient`/`Login`で新規セッションを作成しており、ログインエラーが無視されてタッグ相方情報が取得できなかった
- `Scraping`の戻り値に`http.CookieJar`を追加し、ログイン済みセッションを`ScrapeTagPartners`に渡すように変更
- 不要なログイン処理を排除し、セッションの一貫性を確保

## Test plan
- [x] `make build` でビルドが通ることを確認
- [ ] タッグ戦歴のある環境で分析を実行し、固定相方情報が正しく取得されることを確認
- [ ] タッグ戦歴がない環境で分析を実行し、エラーなく完了することを確認