### PR TITLE
feat 被撃墜分析を機体別に移動し、UI/UX改善

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -627,39 +627,25 @@ def data_deaths_impact(data_list):
             by_deaths[key].append(d)
 
         buckets = []
-        for i in range(max_bucket):
+        for i in range(fatal):
             key = str(i)
             if key in by_deaths:
                 matches = by_deaths[key]
                 wr = win_rate(matches)
                 eff = dmg_efficiency(matches)
-                if i >= fatal:
-                    status = "fatal"
-                elif i == fatal - 1:
+                if i == fatal - 1:
                     status = "danger"
                 else:
                     status = "safe"
                 buckets.append({
                     "deaths": i,
-                    "label": f"{i}回",
+                    "label": f"{i}落ち",
                     "matches": len(matches),
                     "win_rate": round(wr, 1),
                     "dmg_efficiency": round(eff, 3),
                     "status": status,
                 })
         over_key = f"{max_bucket}+"
-        if over_key in by_deaths:
-            matches = by_deaths[over_key]
-            wr = win_rate(matches)
-            eff = dmg_efficiency(matches)
-            buckets.append({
-                "deaths": max_bucket,
-                "label": f"{max_bucket}回以上",
-                "matches": len(matches),
-                "win_rate": round(wr, 1),
-                "dmg_efficiency": round(eff, 3),
-                "status": "fatal",
-            })
 
         fatal_count = sum(len(by_deaths.get(str(i), [])) for i in range(fatal, max_bucket))
         fatal_count += len(by_deaths.get(over_key, []))
@@ -788,27 +774,13 @@ def data_daily_trend(data_list):
             "mark": mark,
         })
 
-    # 連敗ストリーク
-    sorted_data = sorted(data_list, key=lambda d: d["datetime"])
-    max_lose_streak = 0
-    current_streak = 0
-    for d in sorted_data:
-        if not d["win"]:
-            current_streak += 1
-            max_lose_streak = max(max_lose_streak, current_streak)
-        else:
-            current_streak = 0
-
     tips = []
     bad_days = [ds for ds in sorted(daily.keys()) if win_rate(daily[ds]) <= 40 and len(daily[ds]) >= 5]
     if bad_days:
         tips.append(f"勝率40%以下の日: {', '.join(bad_days)}。不調時は早めに切り上げましょう。")
-    if max_lose_streak >= 4:
-        tips.append(f"最大{max_lose_streak}連敗の記録があります。3連敗したら休憩を挟むことを推奨します。")
 
     return {
         "days": results,
-        "max_lose_streak": max_lose_streak,
         "tips": tips,
     }
 
@@ -1098,6 +1070,7 @@ def build_period_report(all_data, ms_data, tag_partners=None):
             "ms_pair": data_ms_pair(data),
             "cost_pair": data_cost_pair(data),
             "dmg_contribution": data_dmg_contribution(data),
+            "deaths_impact": data_deaths_impact(data),
         }
 
     return {
@@ -1106,7 +1079,7 @@ def build_period_report(all_data, ms_data, tag_partners=None):
         "win_loss_pattern": data_win_loss_pattern(all_data),
         "ms_stats": ms_stats,
         "fixed_partners": data_fixed_partners(all_data, tag_partners),
-        "deaths_impact": data_deaths_impact(all_data),
+
         "time_of_day": data_time_of_day(all_data),
         "day_of_week": data_day_of_week(all_data),
         "daily_trend": data_daily_trend(all_data),

--- a/static/app.js
+++ b/static/app.js
@@ -52,7 +52,7 @@ function buildShareText(items) {
 
 function Tips({ tips }) {
   if (!tips || !tips.length) return null;
-  return html`<blockquote><strong>アドバイス:</strong><br />${tips.map(function (t, i) {
+  return html`<blockquote><strong>💡アドバイス:</strong><br />${tips.map(function (t, i) {
     return html`${i > 0 && html`<br />`}${t}`;
   })}</blockquote>`;
 }
@@ -81,6 +81,7 @@ function SortableTable({ headers, rows, sortableColumns, defaultLimit }) {
     return sorted;
   }, [rows, sortState]);
 
+  var expanded = limit === 0;
   var displayRows = limit > 0 ? sortedRows.slice(0, limit) : sortedRows;
   var hasMore = limit > 0 && sortedRows.length > limit;
 
@@ -95,22 +96,21 @@ function SortableTable({ headers, rows, sortableColumns, defaultLimit }) {
   var sortable = sortableColumns || [];
 
   return html`<div>
-    ${defaultLimit > 0 && html`<div class="limit-controls">
-      <button class=${'limit-btn' + (limit === 5 ? ' active' : '')} onClick=${function () { setLimit(5); }}>5件</button>
-      <button class=${'limit-btn' + (limit === 10 ? ' active' : '')} onClick=${function () { setLimit(10); }}>10件</button>
-      <button class=${'limit-btn' + (limit === 0 ? ' active' : '')} onClick=${function () { setLimit(0); }}>全件</button>
-    </div>`}
     <div class="table-wrap"><table>
       <thead><tr>${headers.map(function (h, i) {
-        var isSortable = sortable.length === 0 || sortable.indexOf(i) >= 0;
-        var indicator = sortState.col === i ? (sortState.asc ? ' ▲' : ' ▼') : '';
+        var isSortable = h !== '' && (sortable.length === 0 || sortable.indexOf(i) >= 0);
+        var indicator = sortState.col === i ? (sortState.asc ? ' ▲' : ' ▼') : (isSortable ? ' △' : '');
         return html`<th class=${isSortable ? 'sortable' : ''} onClick=${isSortable ? function () { handleSort(i); } : undefined}>${h}${indicator}</th>`;
       })}</tr></thead>
       <tbody>${displayRows.map(function (row) {
         return html`<tr>${row.map(function (cell) { return html`<td>${cell}</td>`; })}</tr>`;
       })}</tbody>
     </table></div>
-    ${hasMore && html`<p class="show-more">他 ${sortedRows.length - limit} 件</p>`}
+    ${defaultLimit > 0 && sortedRows.length > defaultLimit && html`<div class="show-more-wrap">
+      ${hasMore
+        ? html`<button class="show-more-btn" onClick=${function () { setLimit(0); }}>もっと見る (+${sortedRows.length - limit}件)</button>`
+        : html`<button class="show-more-btn" onClick=${function () { setLimit(defaultLimit); }}>折りたたむ</button>`}
+    </div>`}
   </div>`;
 }
 
@@ -124,6 +124,13 @@ function Section({ title, open, children }) {
     <summary><strong>${title}</strong></summary>
     ${children}
   </details><hr />`;
+}
+
+function SubSection({ title, open, children }) {
+  return html`<details ...${{ open: open || false }}>
+    <summary>${title}</summary>
+    ${children}
+  </details>`;
 }
 
 // --- Calendar component ---
@@ -372,7 +379,6 @@ function BasicStatsSection({ stats }) {
     ['平均EXダメージ', num(stats.avg_ex_dmg)],
   ];
   return html`<div>
-    <h3>基本データ</h3>
     <${Table} headers=${['項目', '値']} rows=${rows} />
     <${Tips} tips=${stats.tips} />
   </div>`;
@@ -385,7 +391,6 @@ function WinLossPatternSection({ pattern }) {
     return [m.label, num(m.win_avg, 1), num(m.loss_avg, 1), diff];
   });
   return html`<div>
-    <h3>勝利時/敗北時のダメージ傾向</h3>
     <${Table} headers=${['項目', '勝利時', '敗北時', '差分']} rows=${rows} />
     <${Tips} tips=${pattern.tips} />
   </div>`;
@@ -400,7 +405,6 @@ function EnemyMatchupSection({ matchup, msName }) {
     });
   }
   return html`<div>
-    <h3>敵機体との相性（${esc(msName)}）</h3>
     ${matchup.strong && matchup.strong.length > 0 && html`<p><strong>得意な相手:</strong></p><${SortableTable} headers=${headers} rows=${matchupRows(matchup.strong)} defaultLimit=${5} />`}
     ${matchup.weak && matchup.weak.length > 0 && html`<p><strong>苦手な相手:</strong></p><${SortableTable} headers=${headers} rows=${matchupRows(matchup.weak)} defaultLimit=${5} />`}
     ${matchup.even && matchup.even.length > 0 && html`<p><strong>互角の相手:</strong></p><${SortableTable} headers=${headers} rows=${matchupRows(matchup.even)} defaultLimit=${5} />`}
@@ -414,9 +418,12 @@ function PartnerSection({ partners, msName }) {
     return [esc(p.ms), p.matches, pct(p.win_rate), num(p.dmg_efficiency, 3)];
   });
   return html`<div>
-    <h3>相方機体との相性（${esc(msName)}）</h3>
     <${SortableTable} headers=${['機体名', '試合', '勝率', '与被ダメ比']} rows=${rows} defaultLimit=${10} />
   </div>`;
+}
+
+function msAnchorId(msName, idx) {
+  return 'sec-ms-' + idx;
 }
 
 function MsStatsSection({ msStats }) {
@@ -425,17 +432,34 @@ function MsStatsSection({ msStats }) {
     return msStats[b].matches - msStats[a].matches;
   });
   if (!entries.length) return null;
-  return entries.map(function (msName) {
+  return entries.map(function (msName, idx) {
     var ms = msStats[msName];
-    return html`<${Section} title=${'機体別分析: ' + msName + ' (' + ms.matches + '戦)'}>
-      <${BasicStatsSection} stats=${ms.basic_stats} />
-      <${WinLossPatternSection} pattern=${ms.win_loss_pattern} />
-      <${EnemyMatchupSection} matchup=${ms.enemy_matchup} msName=${msName} />
-      <${PartnerSection} partners=${ms.partner} msName=${msName} />
-      <${MsPairSubSection} msPair=${ms.ms_pair} />
-      <${CostPairSubSection} costPair=${ms.cost_pair} />
-      <${DmgContributionSubSection} dmg=${ms.dmg_contribution} />
-    <//>`;
+    return html`<div id=${msAnchorId(msName, idx)}><${Section} title=${'機体別分析: ' + msName}>
+      <${SubSection} title="基本データ" open>
+        <${BasicStatsSection} stats=${ms.basic_stats} />
+      <//>
+      <${SubSection} title="被撃墜数と勝率">
+        <${DeathsImpactSubSection} deaths=${ms.deaths_impact} />
+      <//>
+      <${SubSection} title="勝利時/敗北時のダメージ傾向">
+        <${WinLossPatternSection} pattern=${ms.win_loss_pattern} />
+      <//>
+      <${SubSection} title="敵機体との相性">
+        <${EnemyMatchupSection} matchup=${ms.enemy_matchup} msName=${msName} />
+      <//>
+      <${SubSection} title="相方機体との相性">
+        <${PartnerSection} partners=${ms.partner} msName=${msName} />
+      <//>
+      <${SubSection} title="編成別勝率">
+        <${MsPairSubSection} msPair=${ms.ms_pair} />
+      <//>
+      <${SubSection} title="コスト編成別勝率">
+        <${CostPairSubSection} costPair=${ms.cost_pair} />
+      <//>
+      <${SubSection} title="ダメージ貢献率">
+        <${DmgContributionSubSection} dmg=${ms.dmg_contribution} />
+      <//>
+    <//></div>`;
   });
 }
 
@@ -447,7 +471,6 @@ function MsPairSubSection({ msPair }) {
     return [esc(p.pair), p.matches, pct(p.win_rate), num(p.dmg_efficiency, 3)];
   });
   return html`<div>
-    <h3>編成別勝率</h3>
     <${SortableTable} headers=${['編成', '試合数', '勝率', '与被ダメ比']} rows=${rows} defaultLimit=${10} />
   </div>`;
 }
@@ -458,7 +481,6 @@ function CostPairSubSection({ costPair }) {
     return [esc(p.pair), p.matches, pct(p.win_rate), num(p.dmg_efficiency, 3)];
   });
   return html`<div>
-    <h3>コスト編成別勝率</h3>
     <${SortableTable} headers=${['コスト編成', '試合数', '勝率', '与被ダメ比']} rows=${rows} defaultLimit=${10} />
   </div>`;
 }
@@ -476,7 +498,6 @@ function DmgContributionSubSection({ dmg }) {
     rows.push([c.matches, pct(c.avg_contribution), pct(c.avg_win_contribution), pct(c.avg_lose_contribution), diffPct(c.avg_win_contribution, c.avg_lose_contribution)]);
   });
   return html`<div>
-    <h3>ダメージ貢献率（自分の与ダメ / チーム合計与ダメ）</h3>
     <${Table} headers=${['試合数', '平均貢献率', '勝利時', '敗北時', '差分']} rows=${rows} />
   </div>`;
 }
@@ -518,21 +539,17 @@ function FixedPartnersSection({ partners }) {
   <//>`;
 }
 
-function DeathsImpactSection({ deaths }) {
+function DeathsImpactSubSection({ deaths }) {
   if (!deaths || !deaths.length) return null;
-  return html`<${Section} title="被撃墜数と勝率の関係">
-    ${deaths.map(function (d) {
-      var rows = (d.buckets || []).map(function (b) {
-        var lossRate = 100 - b.win_rate;
-        return [b.label, b.matches + '戦', pct(lossRate)];
-      });
-      return html`<div>
-        <h3>${esc(d.cost_label)}</h3>
-        <${Table} headers=${['被撃墜数', '試合数', '敗北率']} rows=${rows} />
-        <${Tips} tips=${d.tips} />
-      </div>`;
-    })}
-  <//>`;
+  return deaths.map(function (d) {
+    var rows = (d.buckets || []).map(function (b) {
+      return [b.label, b.matches + '戦', pct(b.win_rate)];
+    });
+    return html`<div>
+      <${Table} headers=${['被撃墜数', '試合数', '勝率']} rows=${rows} />
+      <${Tips} tips=${d.tips} />
+    </div>`;
+  });
 }
 
 function TimeOfDaySection({ time }) {
@@ -549,14 +566,22 @@ function TimeOfDaySection({ time }) {
 
 function DayOfWeekSection({ dow }) {
   if (!dow) return null;
-  var rows = [];
-  if (dow.weekday) rows.push(['平日', dow.weekday.matches, pct(dow.weekday.win_rate), num(dow.weekday.dmg_efficiency, 3)]);
-  if (dow.weekend) rows.push(['土日', dow.weekend.matches, pct(dow.weekend.win_rate), num(dow.weekend.dmg_efficiency, 3)]);
-  (dow.days || []).forEach(function (d) {
-    rows.push([d.name + '曜', d.matches, pct(d.win_rate), num(d.dmg_efficiency, 3)]);
+  var summaryRows = [];
+  if (dow.weekday) summaryRows.push(['平日', dow.weekday.matches, pct(dow.weekday.win_rate), num(dow.weekday.dmg_efficiency, 3)]);
+  if (dow.weekend) summaryRows.push(['土日', dow.weekend.matches, pct(dow.weekend.win_rate), num(dow.weekend.dmg_efficiency, 3)]);
+  var dayRows = (dow.days || []).map(function (d) {
+    return [d.name + '曜', d.matches, pct(d.win_rate), num(d.dmg_efficiency, 3)];
   });
-  return html`<${Section} title="曜日別の勝率（平日 vs 土日）">
-    <${Table} headers=${['曜日', '試合', '勝率', '与被ダメ比']} rows=${rows} />
+  var headers = ['曜日', '試合', '勝率', '与被ダメ比'];
+  return html`<${Section} title="曜日別の勝率">
+    ${summaryRows.length > 0 && html`<div>
+      <h3>平日 vs 土日</h3>
+      <${Table} headers=${headers} rows=${summaryRows} />
+    </div>`}
+    ${dayRows.length > 0 && html`<div>
+      <h3>曜日別</h3>
+      <${Table} headers=${headers} rows=${dayRows} />
+    </div>`}
     <${Tips} tips=${dow.tips} />
   <//>`;
 }
@@ -567,8 +592,7 @@ function DailyTrendSection({ daily }) {
     var mark = d.mark === 'good' ? '◎' : d.mark === 'bad' ? '△' : '';
     return [d.date + ' (' + d.dow_name + ')', d.matches, pct(d.win_rate), num(d.dmg_efficiency, 3), mark];
   });
-  return html`<${Section} title="日別勝率推移">
-    ${daily.max_lose_streak > 0 && html`<p>最大連敗: <strong>${daily.max_lose_streak}</strong>連敗</p>`}
+  return html`<${Section} title="日別勝率">
     <${Table} headers=${['日付', '試合', '勝率', '与被ダメ比', '']} rows=${rows} />
     <${Tips} tips=${daily.tips} />
   <//>`;
@@ -632,17 +656,33 @@ function TableOfContents({ data }) {
     }
   }
 
+  var msEntries = [];
+  if (data.ms_stats) {
+    msEntries = Object.keys(data.ms_stats).sort(function (a, b) {
+      return data.ms_stats[b].matches - data.ms_stats[a].matches;
+    });
+  }
+
   return html`<div class="toc-area">
     <details open>
       <summary><strong>目次</strong></summary>
       <ol>
         <li><a href="#sec-summary">総合アドバイス</a></li>
         <li><a href="#sec-basic">基本データ</a></li>
+        ${msEntries.length > 0 && html`<li><a href=${'#' + msAnchorId(msEntries[0], 0)}>機体別分析</a>
+          <details class="toc-ms-details">
+            <summary>機体一覧</summary>
+            <ul class="toc-ms-list">
+              ${msEntries.map(function (msName, idx) {
+                return html`<li><a href=${'#' + msAnchorId(msName, idx)}>${esc(msName)}</a></li>`;
+              })}
+            </ul>
+          </details>
+        </li>`}
         <li><a href="#sec-fixed">固定相方分析</a></li>
-        <li><a href="#sec-deaths">被撃墜数と勝率</a></li>
         <li><a href="#sec-time">時間帯別の勝率</a></li>
         <li><a href="#sec-dow">曜日別の勝率</a></li>
-        <li><a href="#sec-daily">日別勝率推移</a></li>
+        <li><a href="#sec-daily">日別勝率</a></li>
         <li><a href="#sec-season">シーズン別分析</a></li>
       </ol>
     </details>
@@ -684,12 +724,15 @@ function Report({ data, userKey }) {
     <${TableOfContents} data=${pd} />
     <div key="sec-summary" id="sec-summary"><${SummarySection} summary=${pd.summary} /></div>
     <div key="sec-basic" id="sec-basic"><${Section} title="基本データ">
-      <${BasicStatsSection} stats=${pd.basic_stats} />
-      <${WinLossPatternSection} pattern=${pd.win_loss_pattern} />
+      <${SubSection} title="基本データ" open>
+        <${BasicStatsSection} stats=${pd.basic_stats} />
+      <//>
+      <${SubSection} title="勝利時/敗北時のダメージ傾向">
+        <${WinLossPatternSection} pattern=${pd.win_loss_pattern} />
+      <//>
     <//></div>
     <div key="sec-ms"><${MsStatsSection} msStats=${pd.ms_stats} /></div>
     <div key="sec-fixed" id="sec-fixed"><${FixedPartnersSection} partners=${pd.fixed_partners} /></div>
-    <div key="sec-deaths" id="sec-deaths"><${DeathsImpactSection} deaths=${pd.deaths_impact} /></div>
     <div key="sec-time" id="sec-time"><${TimeOfDaySection} time=${pd.time_of_day} /></div>
     <div key="sec-dow" id="sec-dow"><${DayOfWeekSection} dow=${pd.day_of_week} /></div>
     <div key="sec-daily" id="sec-daily"><${DailyTrendSection} daily=${pd.daily_trend} /></div>

--- a/static/index.html
+++ b/static/index.html
@@ -50,7 +50,12 @@
     .report a { color: #4fc3f7; text-decoration: none; }
     .report a:hover { text-decoration: underline; }
     .report details { margin-bottom: 20px; }
+    .report details details { margin-bottom: 8px; margin-left: 12px; padding-left: 12px; border-left: 2px solid #2a3a4a; }
     .report summary { cursor: pointer; font-weight: bold; color: #4fc3f7; }
+    .report details details > summary { font-size: 0.95em; color: #81d4fa; }
+    .toc-ms-details { display: inline; }
+    .toc-ms-details > summary { font-size: 0.85em; color: #81d4fa; display: inline; cursor: pointer; }
+    .toc-ms-list { list-style: disc; margin: 4px 0 0; padding-left: 20px; }
     .error { background: #3d1f1f; border: 1px solid #ff5252; border-radius: 8px; padding: 15px; color: #ff8a80; margin: 20px 0; }
     .share-area { display: flex; align-items: center; gap: 8px; margin: 20px 0; }
     .share-label { color: #888; font-size: 0.85em; margin-right: 4px; }
@@ -98,13 +103,11 @@
     .time-select { padding: 4px 6px; border: 1px solid #333; border-radius: 4px; background: #0f1923; color: #e0e0e0; font-size: 0.85em; cursor: pointer; }
     .time-select:focus { outline: none; border-color: #4fc3f7; }
     .time-colon { color: #666; }
-    .limit-controls { display: flex; gap: 4px; margin-bottom: 8px; }
-    .limit-btn { padding: 4px 10px; border: 1px solid #333; border-radius: 4px; background: #162029; color: #aaa; font-size: 0.8em; cursor: pointer; transition: all 0.2s; }
-    .limit-btn:hover { border-color: #4fc3f7; color: #e0e0e0; }
-    .limit-btn.active { background: #1e3a4f; color: #4fc3f7; border-color: #4fc3f7; }
     .report th.sortable { cursor: pointer; user-select: none; }
     .report th.sortable:hover { color: #81d4fa; }
-    .show-more { font-size: 0.85em; color: #888; margin: 4px 0; }
+    .show-more-wrap { text-align: center; margin: 8px 0; }
+    .show-more-btn { padding: 6px 16px; border: 1px solid #333; border-radius: 4px; background: #162029; color: #4fc3f7; font-size: 0.85em; cursor: pointer; transition: all 0.2s; }
+    .show-more-btn:hover { border-color: #4fc3f7; background: #1e3a4f; }
     .toc-area { position: relative; }
     .toggle-all { display: flex; gap: 8px; margin-top: 8px; }
     .toggle-btn { padding: 4px 12px; border: 1px solid #333; border-radius: 4px; background: #162029; color: #aaa; font-size: 0.8em; cursor: pointer; transition: all 0.2s; }


### PR DESCRIPTION
## Summary
- 被撃墜数と勝率の関係を独立セクションから機体別分析内に移動し、敗北率→勝率に変更
- 機体別分析のサブ項目をSubSectionで折りたたみ可能にし、情報量を整理
- 5件/10件/全件タブを「もっと見る/折りたたむ」ボタンに置き換え
- ソート可能列に△マーク表示、目次に機体別分析追加、曜日別テーブル分割など

## Test plan
- [ ] レポート表示で被撃墜数と勝率が機体別分析内に表示されることを確認
- [ ] サブセクションの折りたたみ・展開が正しく動作することを確認
- [ ] 「もっと見る/折りたたむ」ボタンの動作確認
- [ ] 目次の機体一覧リンクが正しいセクションにジャンプすることを確認
- [ ] スマホ表示での見え方を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)