### PR TITLE
feat タッグ相方デバッグログ追加、ソート三角表示修正

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -374,9 +374,18 @@ func ScrapeTagPartners(jar http.CookieJar) []TagPartner {
 	c := colly.NewCollector(colly.AllowedDomains(vsmobile))
 	c.SetCookieJar(jar)
 
+	c.OnResponse(func(r *colly.Response) {
+		fmt.Printf("[DEBUG] ScrapeTagPartners status=%d url=%s bodyLen=%d\n", r.StatusCode, r.Request.URL, len(r.Body))
+	})
+
+	c.OnError(func(r *colly.Response, err error) {
+		fmt.Printf("[DEBUG] ScrapeTagPartners error: %v, status=%d\n", err, r.StatusCode)
+	})
+
 	c.OnHTML("li.item", func(e *colly.HTMLElement) {
 		teamName := strings.TrimSpace(e.ChildText("p.tag-name"))
 		playerName := strings.TrimSpace(e.ChildText("p.ml-ss"))
+		fmt.Printf("[DEBUG] ScrapeTagPartners item: team=%q player=%q\n", teamName, playerName)
 
 		if playerName != "" {
 			partners = append(partners, TagPartner{
@@ -387,6 +396,7 @@ func ScrapeTagPartners(jar http.CookieJar) []TagPartner {
 	})
 
 	c.Visit(mobileTagPage)
+	fmt.Printf("[DEBUG] ScrapeTagPartners result: %d partners found\n", len(partners))
 	return partners
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -106,7 +106,7 @@ function SortableTable({ headers, rows, sortableColumns, defaultLimit }) {
         if (i === 0) {
           return html`<th class="sortable" onClick=${function () { handleSort(0); }}>${h}</th>`;
         }
-        var indicator = sortState.col === i ? (sortState.asc ? ' ▲' : ' ▼') : (isSortable ? ' △' : '');
+        var indicator = sortState.col === i ? (sortState.asc ? ' ▲' : ' ▼') : (isSortable ? ' ▽' : '');
         return html`<th class=${isSortable ? 'sortable' : ''} onClick=${isSortable ? function () { handleSort(i); } : undefined}>${h}${indicator}</th>`;
       })}</tr></thead>
       <tbody>${displayRows.map(function (row) {


### PR DESCRIPTION
## Summary
- `ScrapeTagPartners` にHTTPステータス・レスポンスのデバッグログを追加（本番で相方取得できない問題の調査用）
- テーブル未選択列の三角を△→▽に変更

## Test plan
- [ ] デプロイ後にタッグ相方取得のログを確認