### PR TITLE
fix 新規データなし時にタッグ相方情報が取得されない問題を修正

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -167,14 +167,37 @@ func Run(j *Job, username, password string) {
 		return
 	}
 
-	// 新規データがない場合は速報レポートをそのまま最終結果にする
+	// 新規データがない場合はタッグ情報を付与して最終レポートにする
 	if len(datedScores) == 0 && j.PreliminaryReport != "" {
+		var tagPartnersPath string
+		tagPartners := scraper.ScrapeTagPartners(jar)
+		if len(tagPartners) > 0 {
+			tagPartnersPath = filepath.Join(tmpDir, "tag_partners.json")
+			if err := saveTagPartners(tagPartners, tagPartnersPath); err != nil {
+				log.Printf("[WARN] Failed to save tag partners: %v", err)
+				tagPartnersPath = ""
+			} else {
+				log.Printf("[INFO] Found %d tag partners (no new data path)", len(tagPartners))
+			}
+		} else {
+			log.Printf("[INFO] No tag partners found (no new data path)")
+		}
+
+		// タッグ情報がある場合は再分析、なければ速報レポートをそのまま使う
+		finalReport := j.PreliminaryReport
+		if tagPartnersPath != "" {
+			report := runAnalysis(csvPath, tmpDir, tagPartnersPath)
+			if report != "" {
+				finalReport = report
+			}
+		}
+
 		jobsMu.Lock()
 		j.Status = StatusDone
-		j.Report = j.PreliminaryReport
+		j.Report = finalReport
 		j.completedAt = time.Now()
 		jobsMu.Unlock()
-		log.Printf("[INFO] Job %s completed (no new data, using preliminary report)", j.ID)
+		log.Printf("[INFO] Job %s completed (no new data)", j.ID)
 		return
 	}
 

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -3,6 +3,7 @@ package scraper
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"regexp"
 	"sort"
@@ -375,17 +376,17 @@ func ScrapeTagPartners(jar http.CookieJar) []TagPartner {
 	c.SetCookieJar(jar)
 
 	c.OnResponse(func(r *colly.Response) {
-		fmt.Printf("[DEBUG] ScrapeTagPartners status=%d url=%s bodyLen=%d\n", r.StatusCode, r.Request.URL, len(r.Body))
+		log.Printf("[DEBUG] ScrapeTagPartners status=%d url=%s bodyLen=%d", r.StatusCode, r.Request.URL, len(r.Body))
 	})
 
 	c.OnError(func(r *colly.Response, err error) {
-		fmt.Printf("[DEBUG] ScrapeTagPartners error: %v, status=%d\n", err, r.StatusCode)
+		log.Printf("[DEBUG] ScrapeTagPartners error: %v, status=%d", err, r.StatusCode)
 	})
 
 	c.OnHTML("li.item", func(e *colly.HTMLElement) {
 		teamName := strings.TrimSpace(e.ChildText("p.tag-name"))
 		playerName := strings.TrimSpace(e.ChildText("p.ml-ss"))
-		fmt.Printf("[DEBUG] ScrapeTagPartners item: team=%q player=%q\n", teamName, playerName)
+		log.Printf("[DEBUG] ScrapeTagPartners item: team=%q player=%q", teamName, playerName)
 
 		if playerName != "" {
 			partners = append(partners, TagPartner{
@@ -396,7 +397,7 @@ func ScrapeTagPartners(jar http.CookieJar) []TagPartner {
 	})
 
 	c.Visit(mobileTagPage)
-	fmt.Printf("[DEBUG] ScrapeTagPartners result: %d partners found\n", len(partners))
+	log.Printf("[DEBUG] ScrapeTagPartners result: %d partners found", len(partners))
 	return partners
 }
 


### PR DESCRIPTION
## Summary
- 新規スコアが0件の場合、速報レポートで早期リターンしていたためタッグ相方取得コードに到達しなかった
- 早期リターン前にもタッグ情報を取得し、存在すれば再分析するよう修正
- デバッグログを `fmt.Printf` → `log.Printf` に変更（Cloud Runで確実にログ出力されるように）

## Test plan
- [ ] デプロイ後、既存データのみ（新規データなし）の状態でタッグ相方情報が表示されることを確認
- [ ] Cloud Runログに `[DEBUG] ScrapeTagPartners` と `[INFO] Found N tag partners` が出力されることを確認