### PR TITLE
fix 固定相方分析の対戦数表記を整理

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -536,8 +536,8 @@ function FixedPartnersSection({ partners }) {
       });
       var title = p.team_name ? esc(p.partner_name) + '【' + esc(p.team_name) + '】' : esc(p.partner_name);
       return html`<div>
-        <h3>${title} (${p.matches}戦)</h3>
-        <p>${p.wins}勝${p.losses}敗 (勝率 ${pct(p.win_rate)})</p>
+        <h3>${title}</h3>
+        <p>${p.matches}戦${p.wins}勝 (勝率 ${pct(p.win_rate)})</p>
         <${Table} headers=${['項目', '自分', '相方']} rows=${statsRows} />
         ${msRows.length > 0 && html`<p><strong>相方の使用機体:</strong></p><${Table} headers=${['機体', '試合', '勝率']} rows=${msRows} />`}
         <${Tips} tips=${p.tips} />


### PR DESCRIPTION
## Summary
- 固定相方分析のチーム名横の対戦数表示 `(N戦)` を削除
- 勝敗表記を `N勝N敗` から `N戦N勝` に変更し、情報の重複を解消

## Test plan
- [ ] 固定相方分析セクションでチーム名横に対戦数が表示されないことを確認
- [ ] pタグに `N戦N勝 (勝率 XX.X%)` の形式で表示されることを確認