### PR TITLE
feat 本番環境のベーシック認証を解除

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -22,7 +22,3 @@ config:
     secure: v1:IgRCxU3FUKAgYFVM:84Vd9wpKbv4aii4ZiSsWCwdpXAEfNtx6l52NGnLzp6b2YZL/t04CeFNJTHSmsEOqGxHRazl1yAnoAUhe0ZfJKWRO
   exvs-analyzer:ownerEmail:
     secure: v1:PPXFgxigyRzBi94p:D9+0MQOCQGmsIsLGmPxFp8LzFnsuwRqgS+2HkAMWIXJR8FkJ
-  exvs-analyzer:basicAuthUser:
-    secure: v1:i7deaJdrREyHHqjv:ayNZz3wcb6PJPBr1POU+n+j0HKjwxfmW
-  exvs-analyzer:basicAuthPass:
-    secure: v1:/WAbyxOy3CdRJkMr:kLv9677cbjr7XzdPo+P/t8PiHbzH5C19pBGiew==

--- a/infra/cloudrun.ts
+++ b/infra/cloudrun.ts
@@ -4,8 +4,6 @@ import * as gcp from "@pulumi/gcp";
 const config = new pulumi.Config();
 const gcsBucket = config.requireSecret("gcsBucket");
 const image = config.requireSecret("image");
-const basicAuthUser = config.requireSecret("basicAuthUser");
-const basicAuthPass = config.requireSecret("basicAuthPass");
 
 export const service = new gcp.cloudrunv2.Service(
   "exvs-analyzer",
@@ -25,14 +23,6 @@ export const service = new gcp.cloudrunv2.Service(
             {
               name: "GCS_BUCKET",
               value: gcsBucket,
-            },
-            {
-              name: "BASIC_AUTH_USER",
-              value: basicAuthUser,
-            },
-            {
-              name: "BASIC_AUTH_PASS",
-              value: basicAuthPass,
             },
           ],
           resources: {


### PR DESCRIPTION
## Summary
- Cloud Runへの`BASIC_AUTH_USER`/`BASIC_AUTH_PASS`環境変数とPulumi configシークレットを削除
- Go側の`basicauth.go`は環境変数未設定で自動スキップするため、コードはそのまま残す
- 将来の検証環境では環境変数を設定するだけで再有効化可能

## Test plan
- [ ] `pulumi preview` で環境変数削除が反映されることを確認
- [ ] デプロイ後、認証なしでアクセスできることを確認