### PR TITLE
feat 免責事項の追加とスクレイピング負荷の軽減

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -24,7 +24,10 @@ const (
 	mobileMSUsedRate = "https://web.vsmobile.jp/exvs2ib/ranking/ms_used_rate"
 
 	// maxParallelism はバンナムサーバーへの最大同時リクエスト数
-	maxParallelism = 15
+	maxParallelism = 5
+
+	// requestDelay はリクエスト完了後の待機時間（サーバー負荷軽減用）
+	requestDelay = 100 * time.Millisecond
 )
 
 // ErrAccessDenied はサーバーからアクセス拒否(403)された場合のエラー
@@ -159,6 +162,7 @@ func streamMatchEntries(jar http.CookieJar, links []dailyLink, since time.Time, 
 			for _, e := range entries {
 				out <- e
 			}
+			time.Sleep(requestDelay)
 		}(dl)
 	}
 
@@ -256,6 +260,7 @@ func fetchDetailPagesStreaming(jar http.CookieJar, entryCh <-chan matchEntry, no
 			mu.Unlock()
 
 			notify(current, total)
+			time.Sleep(requestDelay)
 		}(entry)
 	}
 

--- a/static/index.html
+++ b/static/index.html
@@ -114,6 +114,7 @@
     .toggle-btn { padding: 4px 12px; border: 1px solid #333; border-radius: 4px; background: #162029; color: #aaa; font-size: 0.8em; cursor: pointer; transition: all 0.2s; }
     .toggle-btn:hover { border-color: #4fc3f7; color: #e0e0e0; }
     .period-backdrop { display: none; }
+    .disclaimer { margin-top: 40px; padding: 16px 0; border-top: 1px solid #333; text-align: center; font-size: 0.75em; color: #666; line-height: 1.8; }
     @media (max-width: 600px) {
       .container { padding: 10px; }
       h1 { font-size: 1.4em; margin: 20px 0 8px; }
@@ -162,6 +163,11 @@
 
     <div class="error" id="error" style="display:none;"></div>
     <div class="report" id="report" style="display:none;"></div>
+
+    <footer class="disclaimer">
+      <p>本サービスは非公式のファンツールであり、サンライズ、バンダイナムコエクスペリエンス、バンダイナムコエンターテインメントとは一切関係ありません。</p>
+      <p>「機動戦士ガンダム」シリーズの著作権はサンライズおよびサンライズ・MBSに帰属します。ゲームのサービス提供は株式会社バンダイナムコエクスペリエンス、バンダイナムコIDの運営は株式会社バンダイナムコエンターテインメントが行っています。</p>
+    </footer>
   </div>
 
   <script type="module" src="app.js"></script>


### PR DESCRIPTION
## Summary
- フッターに非公式ツールである旨の免責事項を追加（サンライズ、バンダイナムコエクスペリエンス、バンダイナムコエンターテインメントとの無関係を明示）
- スクレイピングの最大並列リクエスト数を15→5に削減し、リクエスト間に100msディレイを追加してサーバー負荷を軽減

## Test plan
- [ ] `make build` が成功すること
- [ ] フッターの免責事項が正しく表示されること
- [ ] スクレイピングが正常に動作すること（速度が極端に低下していないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)