### PR TITLE
feat タッグ相方情報をGCSに永続化し速報レポートで使用

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -123,6 +123,16 @@ func Run(j *Job, username, password string) {
 	if err != nil {
 		log.Printf("[WARN] Failed to download existing CSV: %v", err)
 	}
+	// GCSから既存タッグ相方情報をダウンロード（速報レポートで使用）
+	cachedTagPartnersPath := filepath.Join(tmpDir, "cached_tag_partners.json")
+	tagPartnersExists, err := storage.DownloadTagPartners(username, cachedTagPartnersPath)
+	if err != nil {
+		log.Printf("[WARN] Failed to download existing tag partners: %v", err)
+	}
+	if !tagPartnersExists {
+		cachedTagPartnersPath = ""
+	}
+
 	if exists {
 		since, err = storage.GetLatestDatetime(csvPath)
 		if err != nil {
@@ -132,8 +142,8 @@ func Run(j *Job, username, password string) {
 			log.Printf("[INFO] Fetching scores after %s", since.Format("2006-01-02 15:04"))
 		}
 
-		// 前回データで即座に分析（速報レポート、タッグ情報なし）
-		prelimReport := runAnalysis(csvPath, tmpDir, "")
+		// 前回データで即座に分析（速報レポート、キャッシュ済みタッグ情報付き）
+		prelimReport := runAnalysis(csvPath, tmpDir, cachedTagPartnersPath)
 		if prelimReport != "" {
 			jobsMu.Lock()
 			j.PreliminaryReport = prelimReport
@@ -178,6 +188,10 @@ func Run(j *Job, username, password string) {
 				tagPartnersPath = ""
 			} else {
 				log.Printf("[INFO] Found %d tag partners (no new data path)", len(tagPartners))
+				// タッグ相方情報をGCSにアップロード
+				if err := storage.UploadTagPartners(username, tagPartnersPath); err != nil {
+					log.Printf("[WARN] Failed to upload tag partners to GCS: %v", err)
+				}
 			}
 		} else {
 			log.Printf("[INFO] No tag partners found (no new data path)")
@@ -232,6 +246,10 @@ func Run(j *Job, username, password string) {
 			tagPartnersPath = ""
 		} else {
 			log.Printf("[INFO] Found %d tag partners", len(tagPartners))
+			// タッグ相方情報をGCSにアップロード
+			if err := storage.UploadTagPartners(username, tagPartnersPath); err != nil {
+				log.Printf("[WARN] Failed to upload tag partners to GCS: %v", err)
+			}
 		}
 	} else {
 		log.Printf("[INFO] No tag partners found")

--- a/internal/storage/cloud_storage.go
+++ b/internal/storage/cloud_storage.go
@@ -26,9 +26,9 @@ func CSVObjectPath(email string) string {
 	return fmt.Sprintf("users/%s/scores.csv", UserKey(email))
 }
 
-// DownloadCSV はCloud StorageからCSVをローカルファイルにダウンロードする
-// ファイルが存在しない場合はfalseを返す
-func DownloadCSV(email, localPath string) (bool, error) {
+// downloadObject はGCSからオブジェクトをローカルファイルにダウンロードする
+// オブジェクトが存在しない場合はfalseを返す
+func downloadObject(objPath, localPath string) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -38,11 +38,9 @@ func DownloadCSV(email, localPath string) (bool, error) {
 	}
 	defer client.Close()
 
-	objPath := CSVObjectPath(email)
 	reader, err := client.Bucket(BucketName).Object(objPath).NewReader(ctx)
 	if err != nil {
 		if err == storage.ErrObjectNotExist {
-			log.Printf("[INFO] No existing CSV found for user")
 			return false, nil
 		}
 		return false, fmt.Errorf("failed to read from GCS: %w", err)
@@ -56,45 +54,61 @@ func DownloadCSV(email, localPath string) (bool, error) {
 	defer f.Close()
 
 	if _, err := io.Copy(f, reader); err != nil {
-		return false, fmt.Errorf("failed to download CSV: %w", err)
+		return false, fmt.Errorf("failed to download from GCS: %w", err)
 	}
 
-	log.Printf("[INFO] Downloaded existing CSV from GCS")
 	return true, nil
+}
+
+// uploadObject はローカルファイルをGCSにアップロードする
+func uploadObject(objPath, localPath, contentType string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create storage client: %w", err)
+	}
+	defer client.Close()
+
+	f, err := os.Open(localPath)
+	if err != nil {
+		return fmt.Errorf("failed to open local file: %w", err)
+	}
+	defer f.Close()
+
+	writer := client.Bucket(BucketName).Object(objPath).NewWriter(ctx)
+	writer.ContentType = contentType
+
+	if _, err := io.Copy(writer, f); err != nil {
+		return fmt.Errorf("failed to upload to GCS: %w", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("failed to finalize upload: %w", err)
+	}
+
+	return nil
+}
+
+// DownloadCSV はCloud StorageからCSVをローカルファイルにダウンロードする
+// ファイルが存在しない場合はfalseを返す
+func DownloadCSV(email, localPath string) (bool, error) {
+	found, err := downloadObject(CSVObjectPath(email), localPath)
+	if err != nil {
+		return false, err
+	}
+	if found {
+		log.Printf("[INFO] Downloaded existing CSV from GCS")
+	} else {
+		log.Printf("[INFO] No existing CSV found for user")
+	}
+	return found, nil
 }
 
 // DownloadCSVByKey はユーザーキーを使ってCloud StorageからCSVをダウンロードする
 func DownloadCSVByKey(userKey, localPath string) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		return false, fmt.Errorf("failed to create storage client: %w", err)
-	}
-	defer client.Close()
-
-	objPath := fmt.Sprintf("users/%s/scores.csv", userKey)
-	reader, err := client.Bucket(BucketName).Object(objPath).NewReader(ctx)
-	if err != nil {
-		if err == storage.ErrObjectNotExist {
-			return false, nil
-		}
-		return false, fmt.Errorf("failed to read from GCS: %w", err)
-	}
-	defer reader.Close()
-
-	f, err := os.Create(localPath)
-	if err != nil {
-		return false, fmt.Errorf("failed to create local file: %w", err)
-	}
-	defer f.Close()
-
-	if _, err := io.Copy(f, reader); err != nil {
-		return false, fmt.Errorf("failed to download CSV: %w", err)
-	}
-
-	return true, nil
+	return downloadObject(fmt.Sprintf("users/%s/scores.csv", userKey), localPath)
 }
 
 // TagPartnersObjectPath はユーザーのタッグ相方JSONオブジェクトパスを返す
@@ -105,102 +119,32 @@ func TagPartnersObjectPath(email string) string {
 // DownloadTagPartners はCloud Storageからタッグ相方JSONをローカルファイルにダウンロードする
 // ファイルが存在しない場合はfalseを返す
 func DownloadTagPartners(email, localPath string) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	client, err := storage.NewClient(ctx)
+	found, err := downloadObject(TagPartnersObjectPath(email), localPath)
 	if err != nil {
-		return false, fmt.Errorf("failed to create storage client: %w", err)
+		return false, err
 	}
-	defer client.Close()
-
-	objPath := TagPartnersObjectPath(email)
-	reader, err := client.Bucket(BucketName).Object(objPath).NewReader(ctx)
-	if err != nil {
-		if err == storage.ErrObjectNotExist {
-			log.Printf("[INFO] No existing tag partners found for user")
-			return false, nil
-		}
-		return false, fmt.Errorf("failed to read tag partners from GCS: %w", err)
+	if found {
+		log.Printf("[INFO] Downloaded existing tag partners from GCS")
+	} else {
+		log.Printf("[INFO] No existing tag partners found for user")
 	}
-	defer reader.Close()
-
-	f, err := os.Create(localPath)
-	if err != nil {
-		return false, fmt.Errorf("failed to create local file: %w", err)
-	}
-	defer f.Close()
-
-	if _, err := io.Copy(f, reader); err != nil {
-		return false, fmt.Errorf("failed to download tag partners: %w", err)
-	}
-
-	log.Printf("[INFO] Downloaded existing tag partners from GCS")
-	return true, nil
-}
-
-// UploadTagPartners はローカルのタッグ相方JSONファイルをCloud Storageにアップロードする
-func UploadTagPartners(email, localPath string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to create storage client: %w", err)
-	}
-	defer client.Close()
-
-	f, err := os.Open(localPath)
-	if err != nil {
-		return fmt.Errorf("failed to open local file: %w", err)
-	}
-	defer f.Close()
-
-	objPath := TagPartnersObjectPath(email)
-	writer := client.Bucket(BucketName).Object(objPath).NewWriter(ctx)
-	writer.ContentType = "application/json"
-
-	if _, err := io.Copy(writer, f); err != nil {
-		return fmt.Errorf("failed to upload tag partners: %w", err)
-	}
-
-	if err := writer.Close(); err != nil {
-		return fmt.Errorf("failed to finalize tag partners upload: %w", err)
-	}
-
-	log.Printf("[INFO] Uploaded tag partners to GCS")
-	return nil
+	return found, nil
 }
 
 // UploadCSV はローカルのCSVファイルをCloud Storageにアップロードする
 func UploadCSV(email, localPath string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to create storage client: %w", err)
+	if err := uploadObject(CSVObjectPath(email), localPath, "text/csv"); err != nil {
+		return err
 	}
-	defer client.Close()
-
-	f, err := os.Open(localPath)
-	if err != nil {
-		return fmt.Errorf("failed to open local file: %w", err)
-	}
-	defer f.Close()
-
-	objPath := CSVObjectPath(email)
-	writer := client.Bucket(BucketName).Object(objPath).NewWriter(ctx)
-	writer.ContentType = "text/csv"
-
-	if _, err := io.Copy(writer, f); err != nil {
-		return fmt.Errorf("failed to upload CSV: %w", err)
-	}
-
-	if err := writer.Close(); err != nil {
-		return fmt.Errorf("failed to finalize upload: %w", err)
-	}
-
 	log.Printf("[INFO] Uploaded CSV to GCS")
+	return nil
+}
+
+// UploadTagPartners はローカルのタッグ相方JSONファイルをCloud Storageにアップロードする
+func UploadTagPartners(email, localPath string) error {
+	if err := uploadObject(TagPartnersObjectPath(email), localPath, "application/json"); err != nil {
+		return err
+	}
+	log.Printf("[INFO] Uploaded tag partners to GCS")
 	return nil
 }

--- a/internal/storage/cloud_storage.go
+++ b/internal/storage/cloud_storage.go
@@ -97,6 +97,81 @@ func DownloadCSVByKey(userKey, localPath string) (bool, error) {
 	return true, nil
 }
 
+// TagPartnersObjectPath はユーザーのタッグ相方JSONオブジェクトパスを返す
+func TagPartnersObjectPath(email string) string {
+	return fmt.Sprintf("users/%s/tag_partners.json", UserKey(email))
+}
+
+// DownloadTagPartners はCloud Storageからタッグ相方JSONをローカルファイルにダウンロードする
+// ファイルが存在しない場合はfalseを返す
+func DownloadTagPartners(email, localPath string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to create storage client: %w", err)
+	}
+	defer client.Close()
+
+	objPath := TagPartnersObjectPath(email)
+	reader, err := client.Bucket(BucketName).Object(objPath).NewReader(ctx)
+	if err != nil {
+		if err == storage.ErrObjectNotExist {
+			log.Printf("[INFO] No existing tag partners found for user")
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to read tag partners from GCS: %w", err)
+	}
+	defer reader.Close()
+
+	f, err := os.Create(localPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to create local file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, reader); err != nil {
+		return false, fmt.Errorf("failed to download tag partners: %w", err)
+	}
+
+	log.Printf("[INFO] Downloaded existing tag partners from GCS")
+	return true, nil
+}
+
+// UploadTagPartners はローカルのタッグ相方JSONファイルをCloud Storageにアップロードする
+func UploadTagPartners(email, localPath string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create storage client: %w", err)
+	}
+	defer client.Close()
+
+	f, err := os.Open(localPath)
+	if err != nil {
+		return fmt.Errorf("failed to open local file: %w", err)
+	}
+	defer f.Close()
+
+	objPath := TagPartnersObjectPath(email)
+	writer := client.Bucket(BucketName).Object(objPath).NewWriter(ctx)
+	writer.ContentType = "application/json"
+
+	if _, err := io.Copy(writer, f); err != nil {
+		return fmt.Errorf("failed to upload tag partners: %w", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("failed to finalize tag partners upload: %w", err)
+	}
+
+	log.Printf("[INFO] Uploaded tag partners to GCS")
+	return nil
+}
+
 // UploadCSV はローカルのCSVファイルをCloud Storageにアップロードする
 func UploadCSV(email, localPath string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/storage/cloud_storage.go
+++ b/internal/storage/cloud_storage.go
@@ -112,14 +112,14 @@ func DownloadCSVByKey(userKey, localPath string) (bool, error) {
 }
 
 // TagPartnersObjectPath はユーザーのタッグ相方JSONオブジェクトパスを返す
-func TagPartnersObjectPath(email string) string {
-	return fmt.Sprintf("users/%s/tag_partners.json", UserKey(email))
+func TagPartnersObjectPath(username string) string {
+	return fmt.Sprintf("users/%s/tag_partners.json", UserKey(username))
 }
 
 // DownloadTagPartners はCloud Storageからタッグ相方JSONをローカルファイルにダウンロードする
 // ファイルが存在しない場合はfalseを返す
-func DownloadTagPartners(email, localPath string) (bool, error) {
-	found, err := downloadObject(TagPartnersObjectPath(email), localPath)
+func DownloadTagPartners(username, localPath string) (bool, error) {
+	found, err := downloadObject(TagPartnersObjectPath(username), localPath)
 	if err != nil {
 		return false, err
 	}
@@ -141,8 +141,8 @@ func UploadCSV(email, localPath string) error {
 }
 
 // UploadTagPartners はローカルのタッグ相方JSONファイルをCloud Storageにアップロードする
-func UploadTagPartners(email, localPath string) error {
-	if err := uploadObject(TagPartnersObjectPath(email), localPath, "application/json"); err != nil {
+func UploadTagPartners(username, localPath string) error {
+	if err := uploadObject(TagPartnersObjectPath(username), localPath, "application/json"); err != nil {
 		return err
 	}
 	log.Printf("[INFO] Uploaded tag partners to GCS")


### PR DESCRIPTION
## Summary
- タッグ相方（tag partners）情報をGCSに永続化し、速報レポートでも固定相方を表示できるようにした
- storage層の重複コードを汎用ヘルパー（downloadObject/uploadObject）に抽出

## Note
- 速報レポートではGCSにキャッシュされた前回のタッグ情報を使用します。最終レポートではスクレイピングで取得した最新のタッグ情報に更新されます。相方が変わっている場合、速報→最終で表示が変わることがあります。

## Test plan
- [ ] `make build` が成功すること
- [ ] 速報レポートに固定相方情報が表示されること
- [ ] 最終レポートで最新のタッグ情報に更新されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)