### PR TITLE
feat: ビルドとデプロイのワークフロー分離 (GitOps)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,15 @@
-name: CD
+name: Build
 
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "infra/app/Pulumi.*.yaml"
+      - ".github/workflows/deploy.yml"
   workflow_dispatch:
     inputs:
       environment:
-        description: "Deploy target environment"
+        description: "Target environment to update image"
         required: true
         default: "stg"
         type: choice
@@ -25,7 +28,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # マージコミットに関連するPRを取得
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "no-deploy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           PR_NUMBER=$(gh api \
             "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
             --jq '.[0].number' 2>/dev/null || echo "")
@@ -41,18 +48,19 @@ jobs:
 
           if echo "$LABELS" | grep -q "^no-deploy$"; then
             echo "no-deploy=true" >> "$GITHUB_OUTPUT"
-            echo "Skipping deploy: no-deploy label found on PR #${PR_NUMBER}"
+            echo "Skipping build: no-deploy label found on PR #${PR_NUMBER}"
           else
             echo "no-deploy=false" >> "$GITHUB_OUTPUT"
           fi
 
-  deploy:
+  build:
     needs: check-deploy-label
-    if: github.event_name == 'workflow_dispatch' || needs.check-deploy-label.outputs.no-deploy != 'true'
+    if: needs.check-deploy-label.outputs.no-deploy != 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
+      actions: write
 
     steps:
       - uses: actions/checkout@v6
@@ -87,13 +95,34 @@ jobs:
             echo "DEPLOY_ENV=stg" >> "$GITHUB_ENV"
           fi
 
-      - name: Deploy with Pulumi
+      - name: Update Pulumi config with new image
         working-directory: infra/app
         run: |
           npm install -g @pulumi/pulumi 2>/dev/null || true
           pulumi login gs://${{ secrets.PULUMI_STATE_BUCKET }}
           pulumi stack select "$DEPLOY_ENV"
           pulumi config set exvs-app:image "$IMAGE" --secret
-          pulumi up --yes
         env:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+
+      - name: Commit updated Pulumi config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add infra/app/Pulumi.*.yaml
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            echo "CHANGED=false" >> "$GITHUB_ENV"
+          else
+            git commit -m "ci: update $DEPLOY_ENV image to ${{ github.sha }}"
+            git push
+            echo "CHANGED=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Trigger deploy workflow
+        if: env.CHANGED == 'true'
+        run: |
+          gh workflow run deploy.yml \
+            -f environment="$DEPLOY_ENV"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,90 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "infra/app/Pulumi.prod.yaml"
+      - "infra/app/Pulumi.stg.yaml"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deploy target environment"
+        required: true
+        default: "stg"
+        type: choice
+        options:
+          - stg
+          - prod
+
+jobs:
+  detect-environment:
+    runs-on: ubuntu-latest
+    outputs:
+      environments: ${{ steps.detect.outputs.environments }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Detect changed environments
+        id: detect
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo 'environments=["${{ inputs.environment }}"]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          ENVS="[]"
+          CHANGED=$(git diff --name-only HEAD~1 HEAD -- infra/app/Pulumi.*.yaml || echo "")
+
+          if echo "$CHANGED" | grep -q "Pulumi.stg.yaml"; then
+            ENVS=$(echo "$ENVS" | jq '. + ["stg"]')
+          fi
+          if echo "$CHANGED" | grep -q "Pulumi.prod.yaml"; then
+            ENVS=$(echo "$ENVS" | jq '. + ["prod"]')
+          fi
+
+          echo "environments=$ENVS" >> "$GITHUB_OUTPUT"
+          echo "Detected environments: $ENVS"
+
+  deploy:
+    needs: detect-environment
+    if: needs.detect-environment.outputs.environments != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      matrix:
+        environment: ${{ fromJson(needs.detect-environment.outputs.environments) }}
+      max-parallel: 1
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        working-directory: infra/app
+        run: npm ci
+
+      - id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v3
+
+      - name: Deploy with Pulumi
+        working-directory: infra/app
+        run: |
+          npm install -g @pulumi/pulumi 2>/dev/null || true
+          pulumi login gs://${{ secrets.PULUMI_STATE_BUCKET }}
+          pulumi stack select "${{ matrix.environment }}"
+          pulumi up --yes
+        env:
+          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,8 +77,6 @@ jobs:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
-      - uses: google-github-actions/setup-gcloud@v3
-
       - name: Deploy with Pulumi
         working-directory: infra/app
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,8 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 ## GitHub Actions
 
 - CI: `ci.yml`（PRのみ。Docker build, go vet, py_compile。ラベル `skip-ci` でスキップ）
-- CD: `cd.yml`（mainマージ時 → stagingデプロイ、手動実行 → 環境選択可。ラベル `no-deploy` でスキップ）
+- Build: `build.yml`（mainマージ時 → イメージビルド&プッシュ → Pulumi yaml の image 更新 → コミット → deploy.yml 呼び出し。ラベル `no-deploy` でスキップ。手動実行で環境選択可）
+- Deploy: `deploy.yml`（`infra/app/Pulumi.*.yaml` 変更トリガー or build.yml からの `workflow_dispatch` → `pulumi up`）
 - Infra CI: `infra-ci.yml`（infra/配下の変更時にshared + app(prod/staging)のPulumi preview）
 - MSリスト更新: `update-mslist.yml`（毎日03:00-06:00 JST、ランダムスリープ。変更時にPR自動作成）
 - **サードパーティアクションを追加・変更する際は、GitHubリポジトリのリリースページで最新メジャーバージョンを確認すること。** 古いバージョンを指定するとNode.js非推奨警告やエラーが発生する（過去に複数回発生）。
@@ -98,7 +99,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 
 - PRには基本的に `no-deploy` ラベルを付ける（デプロイはまとめて行う）
 - Go/Docker以外の軽微な変更には `skip-ci` ラベルを付ける
-- デプロイは `gh workflow run cd.yml` で手動実行、または `no-deploy` なしでPRをマージ
+- デプロイは `gh workflow run build.yml` で手動実行（環境選択可）、または `no-deploy` なしでPRをマージ
 - **コード構成やディレクトリ構造に変更があった場合は、CLAUDE.mdの「コード構成」セクションとREADME.mdのプロジェクト構成も合わせて更新すること**
 
 ## 主要な技術情報


### PR DESCRIPTION
## Summary
- `cd.yml` を廃止し、`build.yml` + `deploy.yml` に分離
- **build.yml**: イメージビルド&プッシュ → Pulumi yaml の image 更新 → main にコミット → deploy.yml を `workflow_dispatch` で呼び出し
- **deploy.yml**: `infra/app/Pulumi.*.yaml` 変更トリガー or `workflow_dispatch` → 変更された環境を検出して `pulumi up`

## メリット
- `pulumi preview` がローカル/CI で常に正確（image の差分が出ない）
- Git の内容 = デプロイされている状態
- ロールバック = `git revert` するだけ

## 設計ポイント
- `GITHUB_TOKEN` の push では他ワークフローがトリガーされないため、build.yml → deploy.yml は `workflow_dispatch` で連携
- deploy.yml は path トリガーも持つため、手動で yaml を編集・push した場合も自動デプロイ
- matrix strategy で stg/prod 両方変更時も対応（max-parallel: 1 で順次実行）

## Test plan
- [ ] build.yml の workflow_dispatch で stg を指定して実行 → イメージビルド＆yaml更新＆deploy呼び出しを確認
- [ ] deploy.yml の workflow_dispatch で stg を指定して実行 → pulumi up が成功することを確認
- [ ] no-deploy ラベル付きPRマージ時にビルドがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)