### PR TITLE
fix GCR_IMAGE secretをIMAGE_URIにリネーム

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Build and push image
         run: |
-          IMAGE="${{ secrets.GCR_IMAGE }}:${{ github.sha }}"
+          IMAGE="${{ secrets.IMAGE_URI }}:${{ github.sha }}"
           gcloud builds submit --tag "$IMAGE"
           echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -102,6 +102,6 @@ STACK=stg make pulumi-app-shell    # → pulumi up
 |--------|------|
 | `PULUMI_STATE_BUCKET` | Pulumiステート保存用GCSバケット名 |
 | `PULUMI_CONFIG_PASSPHRASE` | Pulumiスタックの暗号化パスフレーズ |
-| `GCR_IMAGE` | Artifact RegistryのイメージURIベース |
+| `IMAGE_URI` | コンテナイメージURIベース |
 | `WIF_PROVIDER` | Workload Identity Provider |
 | `WIF_SERVICE_ACCOUNT` | GitHub Actions用サービスアカウント |


### PR DESCRIPTION
## Summary
- CDワークフローの `GCR_IMAGE` secretを `IMAGE_URI` にリネーム
- Container Registry（gcr.io）は2025年に終了済みのため、レジストリサービス名に依存しない汎用的な名前に変更
- infra/README.mdのsecret一覧も更新

## 関連issue
#188

## Test plan
- [ ] GitHub Secretに `IMAGE_URI` が設定済みであること（対応済み）
- [ ] 古い `GCR_IMAGE` secretが削除済みであること（対応済み）
- [ ] 次回デプロイ時にCDワークフローが正常動作すること