### PR TITLE
feat: preview.html用にrenderReportをwindowに公開

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -904,3 +904,6 @@ if (document.getElementById('analyzeBtn')) {
     if (e.key === 'Enter') analyze();
   });
 }
+
+// preview.html用: windowにrenderReportを公開
+window.renderReport = renderReport;


### PR DESCRIPTION
## Summary
- app.jsの`renderReport`関数を`window.renderReport`として公開
- preview.htmlからダミーデータでレポートを描画可能にする

## Test plan
- [ ] `python3 -m http.server 8888 --directory static` → http://localhost:8888/preview.html で表示確認