### PR TITLE
fix 403検出時の早期終了・ブロック機能

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -169,7 +169,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		if errors.Is(err, scraper.ErrLoginFailed) {
 			setError(j, "ログインに失敗しました。メールアドレスとパスワードを確認してください。", err.Error())
 		} else if errors.Is(err, scraper.ErrAccessDenied) {
-			setError(j, "戦績詳細ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。", err.Error())
+			setError(j, "対戦履歴ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。", err.Error())
 			if len(on403) > 0 && on403[0] != nil {
 				on403[0](storage.UserKey(username))
 			}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -166,14 +166,21 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	}
 	datedScores, jar, err := scraper.Scraping(username, password, since, onProgress)
 	if err != nil {
-		if errors.Is(err, scraper.ErrLoginFailed) {
+		switch {
+		case errors.Is(err, scraper.ErrLoginFailed):
 			setError(j, "ログインに失敗しました。メールアドレスとパスワードを確認してください。", err.Error())
-		} else if errors.Is(err, scraper.ErrAccessDenied) {
+		case errors.Is(err, scraper.ErrAccessDenied):
 			setError(j, "対戦履歴ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。", err.Error())
 			if len(on403) > 0 && on403[0] != nil {
 				on403[0](storage.UserKey(username))
 			}
-		} else {
+		case errors.Is(err, scraper.ErrUnauthorized):
+			setError(j, "認証の有効期限が切れました。再度ログインしてお試しください。", err.Error())
+		case errors.Is(err, scraper.ErrNotFound):
+			setError(j, "対戦履歴ページが見つかりませんでした。サイトの仕様が変更された可能性があります。", err.Error())
+		case errors.Is(err, scraper.ErrServerError):
+			setError(j, "ガンダムモバイルのサーバーでエラーが発生しています。しばらく時間をおいてから再度お試しください。", err.Error())
+		default:
 			setError(j, "データの取得に失敗しました", err.Error())
 		}
 		return

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -181,7 +181,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		case errors.Is(err, scraper.ErrServerError):
 			setError(j, "ガンダムモバイルのサーバーでエラーが発生しています。しばらく時間をおいてから再度お試しください。", err.Error())
 		default:
-			setError(j, "データの取得に失敗しました", err.Error())
+			setError(j, "データの取得に失敗しました。時間をおいて再度お試しいただき、解決しない場合は開発者までお問い合わせください。", err.Error())
 		}
 		return
 	}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -101,8 +101,11 @@ func (j *Job) Snapshot() JobSnapshot {
 	}
 }
 
+// On403Func は403検出時に呼び出されるコールバック型
+type On403Func func(userHash string)
+
 // Run はスクレイピング→分析を実行し、レポートをジョブに保存する
-func Run(j *Job, username, password string) {
+func Run(j *Job, username, password string, on403 ...On403Func) {
 	jobsMu.Lock()
 	j.UserKey = storage.UserKey(username)
 	jobsMu.Unlock()
@@ -166,7 +169,10 @@ func Run(j *Job, username, password string) {
 		if errors.Is(err, scraper.ErrLoginFailed) {
 			setError(j, "ログインに失敗しました。メールアドレスとパスワードを確認してください。", err.Error())
 		} else if errors.Is(err, scraper.ErrAccessDenied) {
-			setError(j, "アクセスが集中しているため、サーバーから拒否されました。しばらく時間をおいてから再度お試しください。", err.Error())
+			setError(j, "戦績詳細ページへのアクセスが拒否されました。ブラウザからプレイヤーズサイト(https://web.vsmobile.jp)にログインし、戦績詳細が閲覧できるか確認してください。", err.Error())
+			if len(on403) > 0 && on403[0] != nil {
+				on403[0](storage.UserKey(username))
+			}
 		} else {
 			setError(j, "データの取得に失敗しました", err.Error())
 		}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -169,7 +169,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		if errors.Is(err, scraper.ErrLoginFailed) {
 			setError(j, "ログインに失敗しました。メールアドレスとパスワードを確認してください。", err.Error())
 		} else if errors.Is(err, scraper.ErrAccessDenied) {
-			setError(j, "戦績詳細ページへのアクセスが拒否されました。ブラウザからプレイヤーズサイト(https://web.vsmobile.jp)にログインし、戦績詳細が閲覧できるか確認してください。", err.Error())
+			setError(j, "戦績詳細ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。", err.Error())
 			if len(on403) > 0 && on403[0] != nil {
 				on403[0](storage.UserKey(username))
 			}

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -1,6 +1,7 @@
 package scraper
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -90,6 +91,10 @@ func Scraping(username, password string, since time.Time, onProgress ...Progress
 		return nil, nil, err
 	}
 
+	// 403検出時に全処理を即座に打ち切るためのcontext
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// Phase 2+3: 日別ページ収集→詳細ページ取得をパイプラインで並行実行
 	// Phase 2で試合エントリが見つかり次第、Phase 3の詳細取得を開始する
 	entryCh := make(chan matchEntry, 50)
@@ -97,10 +102,10 @@ func Scraping(username, password string, since time.Time, onProgress ...Progress
 
 	go func() {
 		defer close(entryCh)
-		streamErr = streamMatchEntries(m.HTTPClient.Jar, dailyLinks, since, entryCh)
+		streamErr = streamMatchEntries(ctx, cancel, m.HTTPClient.Jar, dailyLinks, since, entryCh)
 	}()
 
-	scores, detailErr := fetchDetailPagesStreaming(m.HTTPClient.Jar, entryCh, notify)
+	scores, detailErr := fetchDetailPagesStreaming(ctx, cancel, m.HTTPClient.Jar, entryCh, notify)
 
 	// Phase 2のエラーを優先的に返す（403はより深刻なため）
 	if streamErr != nil {
@@ -159,26 +164,41 @@ func collectDailyLinks(jar http.CookieJar, since time.Time) ([]dailyLink, error)
 }
 
 // streamMatchEntries は複数の日別ページから試合エントリを並列で収集し、チャネルにストリーミングする
-// HTTPエラーが1件でもあればエラーを返す。403の場合はErrAccessDeniedを返す
-func streamMatchEntries(jar http.CookieJar, links []dailyLink, since time.Time, out chan<- matchEntry) error {
+// HTTPエラーが1件でもあればエラーを返す。403の場合はErrAccessDeniedを返し即座にキャンセルする
+func streamMatchEntries(ctx context.Context, cancel context.CancelFunc, jar http.CookieJar, links []dailyLink, since time.Time, out chan<- matchEntry) error {
 	if len(links) == 0 {
 		return nil
 	}
 
 	sem := make(chan struct{}, maxParallelism)
 	var (
-		wg          sync.WaitGroup
-		mu          sync.Mutex
-		totalPages  int
-		errorCount  int
-		has403      bool
+		wg         sync.WaitGroup
+		mu         sync.Mutex
+		totalPages int
+		errorCount int
+		has403     bool
 	)
 
 	for _, dl := range links {
+		// キャンセル済みなら新規goroutineを起動しない
+		select {
+		case <-ctx.Done():
+			break
+		default:
+		}
+		if ctx.Err() != nil {
+			break
+		}
+
 		wg.Add(1)
 		go func(dl dailyLink) {
 			defer wg.Done()
-			sem <- struct{}{}
+
+			select {
+			case <-ctx.Done():
+				return
+			case sem <- struct{}{}:
+			}
 			defer func() { <-sem }()
 
 			entries, err := collectMatchEntries(jar, dl, since)
@@ -188,12 +208,17 @@ func streamMatchEntries(jar http.CookieJar, links []dailyLink, since time.Time, 
 				errorCount++
 				if errors.Is(err, ErrAccessDenied) {
 					has403 = true
+					cancel()
 				}
 			}
 			mu.Unlock()
 
 			for _, e := range entries {
-				out <- e
+				select {
+				case <-ctx.Done():
+					return
+				case out <- e:
+				}
 			}
 			time.Sleep(requestDelay)
 		}(dl)
@@ -281,12 +306,25 @@ func collectMatchEntries(jar http.CookieJar, dl dailyLink, since time.Time) ([]m
 }
 
 // fetchDetailPagesStreaming はチャネルから試合エントリを受信しつつ詳細ページを並列取得する
-// HTTPエラーが1件でもあればエラーを返す。403の場合はErrAccessDeniedを返す
-func fetchDetailPagesStreaming(jar http.CookieJar, entryCh <-chan matchEntry, notify func(int, int)) (model.DatedScores, error) {
-	// まず全エントリを収集してtotalを確定させる
+// HTTPエラーが1件でもあればエラーを返す。403の場合はErrAccessDeniedを返し即座にキャンセルする
+func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, jar http.CookieJar, entryCh <-chan matchEntry, notify func(int, int)) (model.DatedScores, error) {
+	// まず全エントリを収集してtotalを確定させる（キャンセル時はチャネルが閉じるまで待つ）
 	var entries []matchEntry
 	for entry := range entryCh {
-		entries = append(entries, entry)
+		select {
+		case <-ctx.Done():
+			// チャネルに残ったエントリを捨てて終了を待つ
+			for range entryCh {
+			}
+			return nil, ErrAccessDenied
+		default:
+			entries = append(entries, entry)
+		}
+	}
+
+	// streamMatchEntries側で403が発生していた場合
+	if ctx.Err() != nil {
+		return nil, ErrAccessDenied
 	}
 
 	total := len(entries)
@@ -306,13 +344,36 @@ func fetchDetailPagesStreaming(jar http.CookieJar, entryCh <-chan matchEntry, no
 	sem := make(chan struct{}, maxParallelism)
 
 	for _, entry := range entries {
-		sem <- struct{}{}
+		// キャンセル済みなら新規リクエストを発行しない
+		select {
+		case <-ctx.Done():
+			break
+		default:
+		}
+		if ctx.Err() != nil {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			break
+		case sem <- struct{}{}:
+		}
+		if ctx.Err() != nil {
+			break
+		}
+
 		wg.Add(1)
 		go func(e matchEntry) {
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			parsed, err := fetchSingleDetail(jar, e)
+			// キャンセル済みならスキップ
+			if ctx.Err() != nil {
+				return
+			}
+
+			parsed, err := fetchSingleDetail(ctx, jar, e)
 			mu.Lock()
 			scores = append(scores, parsed...)
 			processed++
@@ -320,6 +381,7 @@ func fetchDetailPagesStreaming(jar http.CookieJar, entryCh <-chan matchEntry, no
 				errorCount++
 				if errors.Is(err, ErrAccessDenied) {
 					has403 = true
+					cancel()
 				}
 			}
 			current := processed
@@ -333,7 +395,7 @@ func fetchDetailPagesStreaming(jar http.CookieJar, entryCh <-chan matchEntry, no
 	wg.Wait()
 
 	if has403 {
-		return scores, ErrAccessDenied
+		return nil, ErrAccessDenied
 	}
 	if errorCount > 0 {
 		return scores, fmt.Errorf("詳細ページ取得で%w: %d/%d件がエラー", ErrHTTPRequestFailed, errorCount, total)
@@ -343,10 +405,18 @@ func fetchDetailPagesStreaming(jar http.CookieJar, entryCh <-chan matchEntry, no
 
 // fetchSingleDetail は単一の試合詳細ページをnet/http+goqueryで取得しスコアを返す
 // HTTPエラーが発生した場合はエラーを返す（403の場合はErrAccessDenied）
-func fetchSingleDetail(jar http.CookieJar, e matchEntry) (model.DatedScores, error) {
-	client := &http.Client{Timeout: 30 * time.Second, Jar: jar}
-	resp, err := client.Get(e.detailURL)
+func fetchSingleDetail(ctx context.Context, jar http.CookieJar, e matchEntry) (model.DatedScores, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.detailURL, nil)
 	if err != nil {
+		return nil, fmt.Errorf("リクエスト作成失敗: url=%s: %w", e.detailURL, err)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second, Jar: jar}
+	resp, err := client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		log.Printf("[ERROR] fetchSingleDetail: リクエスト失敗 url=%s err=%v", e.detailURL, err)
 		return nil, fmt.Errorf("リクエスト失敗: url=%s: %w", e.detailURL, err)
 	}

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -208,8 +208,8 @@ func streamMatchEntries(ctx context.Context, cancel context.CancelFunc, jar http
 				errorCount++
 				if errors.Is(err, ErrAccessDenied) {
 					has403 = true
-					cancel()
 				}
+				cancel()
 			}
 			mu.Unlock()
 
@@ -381,8 +381,8 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 				errorCount++
 				if errors.Is(err, ErrAccessDenied) {
 					has403 = true
-					cancel()
 				}
+				cancel()
 			}
 			current := processed
 			mu.Unlock()
@@ -398,7 +398,7 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 		return nil, ErrAccessDenied
 	}
 	if errorCount > 0 {
-		return scores, fmt.Errorf("詳細ページ取得で%w: %d/%d件がエラー", ErrHTTPRequestFailed, errorCount, total)
+		return nil, fmt.Errorf("詳細ページ取得で%w: %d/%d件がエラー", ErrHTTPRequestFailed, errorCount, total)
 	}
 	return scores, nil
 }

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -34,6 +34,15 @@ const (
 // ErrAccessDenied はサーバーからアクセス拒否(403)された場合のエラー
 var ErrAccessDenied = errors.New("サーバーからアクセスが拒否されました")
 
+// ErrUnauthorized はサーバーから認証拒否(401)された場合のエラー
+var ErrUnauthorized = errors.New("認証が無効です")
+
+// ErrServerError はサーバー内部エラー(5xx)の場合のエラー
+var ErrServerError = errors.New("サーバーでエラーが発生しています")
+
+// ErrNotFound はページが見つからない(404)場合のエラー
+var ErrNotFound = errors.New("ページが見つかりません")
+
 // ErrHTTPRequestFailed はHTTPリクエストが失敗した場合のエラー
 var ErrHTTPRequestFailed = errors.New("データ取得中にHTTPエラーが発生しました")
 
@@ -423,12 +432,19 @@ func fetchSingleDetail(ctx context.Context, jar http.CookieJar, e matchEntry) (m
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		if resp.StatusCode == http.StatusForbidden {
-			log.Printf("[ERROR] fetchSingleDetail: 403 Forbidden url=%s", e.detailURL)
-			return nil, ErrAccessDenied
-		}
 		log.Printf("[ERROR] fetchSingleDetail: HTTP %d url=%s", resp.StatusCode, e.detailURL)
-		return nil, fmt.Errorf("HTTPエラー %d: url=%s", resp.StatusCode, e.detailURL)
+		switch {
+		case resp.StatusCode == http.StatusUnauthorized:
+			return nil, ErrUnauthorized
+		case resp.StatusCode == http.StatusForbidden:
+			return nil, ErrAccessDenied
+		case resp.StatusCode == http.StatusNotFound:
+			return nil, ErrNotFound
+		case resp.StatusCode >= 500:
+			return nil, fmt.Errorf("%w: HTTP %d", ErrServerError, resp.StatusCode)
+		default:
+			return nil, fmt.Errorf("HTTPエラー %d: url=%s", resp.StatusCode, e.detailURL)
+		}
 	}
 
 	doc, err := goquery.NewDocumentFromReader(resp.Body)

--- a/internal/server/block403.go
+++ b/internal/server/block403.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"sync"
+	"time"
+)
+
+const block403Duration = 10 * time.Minute
+
+// block403Store は403を受けたユーザーを一時的にブロックするインメモリストア
+type block403Store struct {
+	mu      sync.RWMutex
+	blocked map[string]time.Time // userHash -> blocked until
+}
+
+var forbidden403 = &block403Store{
+	blocked: make(map[string]time.Time),
+}
+
+// Block はユーザーを10分間ブロックする
+func (s *block403Store) Block(userHash string) {
+	s.mu.Lock()
+	s.blocked[userHash] = time.Now().Add(block403Duration)
+	s.mu.Unlock()
+}
+
+// IsBlocked はユーザーがブロック中かを返す
+func (s *block403Store) IsBlocked(userHash string) bool {
+	s.mu.RLock()
+	until, ok := s.blocked[userHash]
+	s.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	if time.Now().After(until) {
+		s.mu.Lock()
+		delete(s.blocked, userHash)
+		s.mu.Unlock()
+		return false
+	}
+	return true
+}

--- a/internal/server/block403_test.go
+++ b/internal/server/block403_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBlock403Store(t *testing.T) {
+	s := &block403Store{
+		blocked: make(map[string]time.Time),
+	}
+
+	userHash := "abc12345"
+
+	// ブロック前はfalse
+	if s.IsBlocked(userHash) {
+		t.Error("should not be blocked initially")
+	}
+
+	// ブロック後はtrue
+	s.Block(userHash)
+	if !s.IsBlocked(userHash) {
+		t.Error("should be blocked after Block()")
+	}
+
+	// 別ユーザーはブロックされない
+	if s.IsBlocked("other_user") {
+		t.Error("other user should not be blocked")
+	}
+}
+
+func TestBlock403StoreExpiry(t *testing.T) {
+	s := &block403Store{
+		blocked: make(map[string]time.Time),
+	}
+
+	userHash := "expired_user"
+
+	// 過去の時刻でブロック（即期限切れ）
+	s.mu.Lock()
+	s.blocked[userHash] = time.Now().Add(-1 * time.Second)
+	s.mu.Unlock()
+
+	// 期限切れなのでブロックされない
+	if s.IsBlocked(userHash) {
+		t.Error("should not be blocked after expiry")
+	}
+
+	// エントリがクリーンアップされている
+	s.mu.RLock()
+	_, exists := s.blocked[userHash]
+	s.mu.RUnlock()
+	if exists {
+		t.Error("expired entry should be cleaned up")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -92,7 +92,7 @@ func StartServer() {
 		// 403ブロックチェック
 		userHash := storage.UserKey(req.Username)
 		if forbidden403.IsBlocked(userHash) {
-			sendJSON(w, http.StatusTooManyRequests, map[string]string{"error": "戦績詳細ページへのアクセスが拒否されました。ブラウザからプレイヤーズサイト(https://web.vsmobile.jp)にログインし、戦績詳細が閲覧できるか確認してください。"})
+			sendJSON(w, http.StatusTooManyRequests, map[string]string{"error": "戦績詳細ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。"})
 			return
 		}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -92,7 +92,7 @@ func StartServer() {
 		// 403ブロックチェック
 		userHash := storage.UserKey(req.Username)
 		if forbidden403.IsBlocked(userHash) {
-			sendJSON(w, http.StatusTooManyRequests, map[string]string{"error": "戦績詳細ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。"})
+			sendJSON(w, http.StatusTooManyRequests, map[string]string{"error": "対戦履歴ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。"})
 			return
 		}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/yuki9431/exvs-analyzer/internal/pipeline"
+	"github.com/yuki9431/exvs-analyzer/internal/storage"
 	"golang.org/x/time/rate"
 )
 
@@ -88,6 +89,13 @@ func StartServer() {
 			return
 		}
 
+		// 403ブロックチェック
+		userHash := storage.UserKey(req.Username)
+		if forbidden403.IsBlocked(userHash) {
+			sendJSON(w, http.StatusTooManyRequests, map[string]string{"error": "戦績詳細ページへのアクセスが拒否されました。ブラウザからプレイヤーズサイト(https://web.vsmobile.jp)にログインし、戦績詳細が閲覧できるか確認してください。"})
+			return
+		}
+
 		// 同時実行数制限
 		select {
 		case requestLimiter <- struct{}{}:
@@ -102,7 +110,7 @@ func StartServer() {
 		// バックグラウンドで実行
 		go func() {
 			defer func() { <-requestLimiter }()
-			pipeline.Run(j, req.Username, req.Password)
+			pipeline.Run(j, req.Username, req.Password, forbidden403.Block)
 		}()
 
 		sendJSON(w, http.StatusAccepted, map[string]string{"id": j.ID})


### PR DESCRIPTION
## Summary
- 403検出時に`context.WithCancel`で全並列リクエストを即座に打ち切り（従来: 390件の無駄なリクエスト → 0件に）
- 403を受けたユーザーを10分間インメモリでブロックし、再リクエストを即拒否（Cloud Run稼働コスト削減）
- エラーメッセージを「プレイヤーズサイトで確認してください」に改善

## Test plan
- [x] `make build` 成功
- [x] `make test` 全テスト通過
- [x] `block403_test.go` でブロック/期限切れの動作確認
- [ ] ステージング環境で403シナリオの動作確認

Closes #194