### PR TITLE
feat: 数値の4段階色分け表示

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -169,7 +169,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		if errors.Is(err, scraper.ErrLoginFailed) {
 			setError(j, "ログインに失敗しました。メールアドレスとパスワードを確認してください。", err.Error())
 		} else if errors.Is(err, scraper.ErrAccessDenied) {
-			setError(j, "戦績詳細ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。", err.Error())
+			setError(j, "対戦履歴ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。", err.Error())
 			if len(on403) > 0 && on403[0] != nil {
 				on403[0](storage.UserKey(username))
 			}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -166,14 +166,21 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	}
 	datedScores, jar, err := scraper.Scraping(username, password, since, onProgress)
 	if err != nil {
-		if errors.Is(err, scraper.ErrLoginFailed) {
+		switch {
+		case errors.Is(err, scraper.ErrLoginFailed):
 			setError(j, "ログインに失敗しました。メールアドレスとパスワードを確認してください。", err.Error())
-		} else if errors.Is(err, scraper.ErrAccessDenied) {
+		case errors.Is(err, scraper.ErrAccessDenied):
 			setError(j, "対戦履歴ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。", err.Error())
 			if len(on403) > 0 && on403[0] != nil {
 				on403[0](storage.UserKey(username))
 			}
-		} else {
+		case errors.Is(err, scraper.ErrUnauthorized):
+			setError(j, "認証の有効期限が切れました。再度ログインしてお試しください。", err.Error())
+		case errors.Is(err, scraper.ErrNotFound):
+			setError(j, "対戦履歴ページが見つかりませんでした。サイトの仕様が変更された可能性があります。", err.Error())
+		case errors.Is(err, scraper.ErrServerError):
+			setError(j, "ガンダムモバイルのサーバーでエラーが発生しています。しばらく時間をおいてから再度お試しください。", err.Error())
+		default:
 			setError(j, "データの取得に失敗しました", err.Error())
 		}
 		return

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -181,7 +181,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		case errors.Is(err, scraper.ErrServerError):
 			setError(j, "ガンダムモバイルのサーバーでエラーが発生しています。しばらく時間をおいてから再度お試しください。", err.Error())
 		default:
-			setError(j, "データの取得に失敗しました", err.Error())
+			setError(j, "データの取得に失敗しました。時間をおいて再度お試しいただき、解決しない場合は開発者までお問い合わせください。", err.Error())
 		}
 		return
 	}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -101,8 +101,11 @@ func (j *Job) Snapshot() JobSnapshot {
 	}
 }
 
+// On403Func は403検出時に呼び出されるコールバック型
+type On403Func func(userHash string)
+
 // Run はスクレイピング→分析を実行し、レポートをジョブに保存する
-func Run(j *Job, username, password string) {
+func Run(j *Job, username, password string, on403 ...On403Func) {
 	jobsMu.Lock()
 	j.UserKey = storage.UserKey(username)
 	jobsMu.Unlock()
@@ -166,7 +169,10 @@ func Run(j *Job, username, password string) {
 		if errors.Is(err, scraper.ErrLoginFailed) {
 			setError(j, "ログインに失敗しました。メールアドレスとパスワードを確認してください。", err.Error())
 		} else if errors.Is(err, scraper.ErrAccessDenied) {
-			setError(j, "アクセスが集中しているため、サーバーから拒否されました。しばらく時間をおいてから再度お試しください。", err.Error())
+			setError(j, "戦績詳細ページへのアクセスが拒否されました。ブラウザからプレイヤーズサイト(https://web.vsmobile.jp)にログインし、戦績詳細が閲覧できるか確認してください。", err.Error())
+			if len(on403) > 0 && on403[0] != nil {
+				on403[0](storage.UserKey(username))
+			}
 		} else {
 			setError(j, "データの取得に失敗しました", err.Error())
 		}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -169,7 +169,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		if errors.Is(err, scraper.ErrLoginFailed) {
 			setError(j, "ログインに失敗しました。メールアドレスとパスワードを確認してください。", err.Error())
 		} else if errors.Is(err, scraper.ErrAccessDenied) {
-			setError(j, "戦績詳細ページへのアクセスが拒否されました。ブラウザからプレイヤーズサイト(https://web.vsmobile.jp)にログインし、戦績詳細が閲覧できるか確認してください。", err.Error())
+			setError(j, "戦績詳細ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。", err.Error())
 			if len(on403) > 0 && on403[0] != nil {
 				on403[0](storage.UserKey(username))
 			}

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -1,6 +1,7 @@
 package scraper
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -90,6 +91,10 @@ func Scraping(username, password string, since time.Time, onProgress ...Progress
 		return nil, nil, err
 	}
 
+	// 403検出時に全処理を即座に打ち切るためのcontext
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// Phase 2+3: 日別ページ収集→詳細ページ取得をパイプラインで並行実行
 	// Phase 2で試合エントリが見つかり次第、Phase 3の詳細取得を開始する
 	entryCh := make(chan matchEntry, 50)
@@ -97,10 +102,10 @@ func Scraping(username, password string, since time.Time, onProgress ...Progress
 
 	go func() {
 		defer close(entryCh)
-		streamErr = streamMatchEntries(m.HTTPClient.Jar, dailyLinks, since, entryCh)
+		streamErr = streamMatchEntries(ctx, cancel, m.HTTPClient.Jar, dailyLinks, since, entryCh)
 	}()
 
-	scores, detailErr := fetchDetailPagesStreaming(m.HTTPClient.Jar, entryCh, notify)
+	scores, detailErr := fetchDetailPagesStreaming(ctx, cancel, m.HTTPClient.Jar, entryCh, notify)
 
 	// Phase 2のエラーを優先的に返す（403はより深刻なため）
 	if streamErr != nil {
@@ -159,26 +164,41 @@ func collectDailyLinks(jar http.CookieJar, since time.Time) ([]dailyLink, error)
 }
 
 // streamMatchEntries は複数の日別ページから試合エントリを並列で収集し、チャネルにストリーミングする
-// HTTPエラーが1件でもあればエラーを返す。403の場合はErrAccessDeniedを返す
-func streamMatchEntries(jar http.CookieJar, links []dailyLink, since time.Time, out chan<- matchEntry) error {
+// HTTPエラーが1件でもあればエラーを返す。403の場合はErrAccessDeniedを返し即座にキャンセルする
+func streamMatchEntries(ctx context.Context, cancel context.CancelFunc, jar http.CookieJar, links []dailyLink, since time.Time, out chan<- matchEntry) error {
 	if len(links) == 0 {
 		return nil
 	}
 
 	sem := make(chan struct{}, maxParallelism)
 	var (
-		wg          sync.WaitGroup
-		mu          sync.Mutex
-		totalPages  int
-		errorCount  int
-		has403      bool
+		wg         sync.WaitGroup
+		mu         sync.Mutex
+		totalPages int
+		errorCount int
+		has403     bool
 	)
 
 	for _, dl := range links {
+		// キャンセル済みなら新規goroutineを起動しない
+		select {
+		case <-ctx.Done():
+			break
+		default:
+		}
+		if ctx.Err() != nil {
+			break
+		}
+
 		wg.Add(1)
 		go func(dl dailyLink) {
 			defer wg.Done()
-			sem <- struct{}{}
+
+			select {
+			case <-ctx.Done():
+				return
+			case sem <- struct{}{}:
+			}
 			defer func() { <-sem }()
 
 			entries, err := collectMatchEntries(jar, dl, since)
@@ -188,12 +208,17 @@ func streamMatchEntries(jar http.CookieJar, links []dailyLink, since time.Time, 
 				errorCount++
 				if errors.Is(err, ErrAccessDenied) {
 					has403 = true
+					cancel()
 				}
 			}
 			mu.Unlock()
 
 			for _, e := range entries {
-				out <- e
+				select {
+				case <-ctx.Done():
+					return
+				case out <- e:
+				}
 			}
 			time.Sleep(requestDelay)
 		}(dl)
@@ -281,12 +306,25 @@ func collectMatchEntries(jar http.CookieJar, dl dailyLink, since time.Time) ([]m
 }
 
 // fetchDetailPagesStreaming はチャネルから試合エントリを受信しつつ詳細ページを並列取得する
-// HTTPエラーが1件でもあればエラーを返す。403の場合はErrAccessDeniedを返す
-func fetchDetailPagesStreaming(jar http.CookieJar, entryCh <-chan matchEntry, notify func(int, int)) (model.DatedScores, error) {
-	// まず全エントリを収集してtotalを確定させる
+// HTTPエラーが1件でもあればエラーを返す。403の場合はErrAccessDeniedを返し即座にキャンセルする
+func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, jar http.CookieJar, entryCh <-chan matchEntry, notify func(int, int)) (model.DatedScores, error) {
+	// まず全エントリを収集してtotalを確定させる（キャンセル時はチャネルが閉じるまで待つ）
 	var entries []matchEntry
 	for entry := range entryCh {
-		entries = append(entries, entry)
+		select {
+		case <-ctx.Done():
+			// チャネルに残ったエントリを捨てて終了を待つ
+			for range entryCh {
+			}
+			return nil, ErrAccessDenied
+		default:
+			entries = append(entries, entry)
+		}
+	}
+
+	// streamMatchEntries側で403が発生していた場合
+	if ctx.Err() != nil {
+		return nil, ErrAccessDenied
 	}
 
 	total := len(entries)
@@ -306,13 +344,36 @@ func fetchDetailPagesStreaming(jar http.CookieJar, entryCh <-chan matchEntry, no
 	sem := make(chan struct{}, maxParallelism)
 
 	for _, entry := range entries {
-		sem <- struct{}{}
+		// キャンセル済みなら新規リクエストを発行しない
+		select {
+		case <-ctx.Done():
+			break
+		default:
+		}
+		if ctx.Err() != nil {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			break
+		case sem <- struct{}{}:
+		}
+		if ctx.Err() != nil {
+			break
+		}
+
 		wg.Add(1)
 		go func(e matchEntry) {
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			parsed, err := fetchSingleDetail(jar, e)
+			// キャンセル済みならスキップ
+			if ctx.Err() != nil {
+				return
+			}
+
+			parsed, err := fetchSingleDetail(ctx, jar, e)
 			mu.Lock()
 			scores = append(scores, parsed...)
 			processed++
@@ -320,6 +381,7 @@ func fetchDetailPagesStreaming(jar http.CookieJar, entryCh <-chan matchEntry, no
 				errorCount++
 				if errors.Is(err, ErrAccessDenied) {
 					has403 = true
+					cancel()
 				}
 			}
 			current := processed
@@ -333,7 +395,7 @@ func fetchDetailPagesStreaming(jar http.CookieJar, entryCh <-chan matchEntry, no
 	wg.Wait()
 
 	if has403 {
-		return scores, ErrAccessDenied
+		return nil, ErrAccessDenied
 	}
 	if errorCount > 0 {
 		return scores, fmt.Errorf("詳細ページ取得で%w: %d/%d件がエラー", ErrHTTPRequestFailed, errorCount, total)
@@ -343,10 +405,18 @@ func fetchDetailPagesStreaming(jar http.CookieJar, entryCh <-chan matchEntry, no
 
 // fetchSingleDetail は単一の試合詳細ページをnet/http+goqueryで取得しスコアを返す
 // HTTPエラーが発生した場合はエラーを返す（403の場合はErrAccessDenied）
-func fetchSingleDetail(jar http.CookieJar, e matchEntry) (model.DatedScores, error) {
-	client := &http.Client{Timeout: 30 * time.Second, Jar: jar}
-	resp, err := client.Get(e.detailURL)
+func fetchSingleDetail(ctx context.Context, jar http.CookieJar, e matchEntry) (model.DatedScores, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.detailURL, nil)
 	if err != nil {
+		return nil, fmt.Errorf("リクエスト作成失敗: url=%s: %w", e.detailURL, err)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second, Jar: jar}
+	resp, err := client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		log.Printf("[ERROR] fetchSingleDetail: リクエスト失敗 url=%s err=%v", e.detailURL, err)
 		return nil, fmt.Errorf("リクエスト失敗: url=%s: %w", e.detailURL, err)
 	}

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -208,8 +208,8 @@ func streamMatchEntries(ctx context.Context, cancel context.CancelFunc, jar http
 				errorCount++
 				if errors.Is(err, ErrAccessDenied) {
 					has403 = true
-					cancel()
 				}
+				cancel()
 			}
 			mu.Unlock()
 
@@ -381,8 +381,8 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 				errorCount++
 				if errors.Is(err, ErrAccessDenied) {
 					has403 = true
-					cancel()
 				}
+				cancel()
 			}
 			current := processed
 			mu.Unlock()
@@ -398,7 +398,7 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 		return nil, ErrAccessDenied
 	}
 	if errorCount > 0 {
-		return scores, fmt.Errorf("詳細ページ取得で%w: %d/%d件がエラー", ErrHTTPRequestFailed, errorCount, total)
+		return nil, fmt.Errorf("詳細ページ取得で%w: %d/%d件がエラー", ErrHTTPRequestFailed, errorCount, total)
 	}
 	return scores, nil
 }

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -34,6 +34,15 @@ const (
 // ErrAccessDenied はサーバーからアクセス拒否(403)された場合のエラー
 var ErrAccessDenied = errors.New("サーバーからアクセスが拒否されました")
 
+// ErrUnauthorized はサーバーから認証拒否(401)された場合のエラー
+var ErrUnauthorized = errors.New("認証が無効です")
+
+// ErrServerError はサーバー内部エラー(5xx)の場合のエラー
+var ErrServerError = errors.New("サーバーでエラーが発生しています")
+
+// ErrNotFound はページが見つからない(404)場合のエラー
+var ErrNotFound = errors.New("ページが見つかりません")
+
 // ErrHTTPRequestFailed はHTTPリクエストが失敗した場合のエラー
 var ErrHTTPRequestFailed = errors.New("データ取得中にHTTPエラーが発生しました")
 
@@ -423,12 +432,19 @@ func fetchSingleDetail(ctx context.Context, jar http.CookieJar, e matchEntry) (m
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		if resp.StatusCode == http.StatusForbidden {
-			log.Printf("[ERROR] fetchSingleDetail: 403 Forbidden url=%s", e.detailURL)
-			return nil, ErrAccessDenied
-		}
 		log.Printf("[ERROR] fetchSingleDetail: HTTP %d url=%s", resp.StatusCode, e.detailURL)
-		return nil, fmt.Errorf("HTTPエラー %d: url=%s", resp.StatusCode, e.detailURL)
+		switch {
+		case resp.StatusCode == http.StatusUnauthorized:
+			return nil, ErrUnauthorized
+		case resp.StatusCode == http.StatusForbidden:
+			return nil, ErrAccessDenied
+		case resp.StatusCode == http.StatusNotFound:
+			return nil, ErrNotFound
+		case resp.StatusCode >= 500:
+			return nil, fmt.Errorf("%w: HTTP %d", ErrServerError, resp.StatusCode)
+		default:
+			return nil, fmt.Errorf("HTTPエラー %d: url=%s", resp.StatusCode, e.detailURL)
+		}
 	}
 
 	doc, err := goquery.NewDocumentFromReader(resp.Body)

--- a/internal/server/block403.go
+++ b/internal/server/block403.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"sync"
+	"time"
+)
+
+const block403Duration = 10 * time.Minute
+
+// block403Store は403を受けたユーザーを一時的にブロックするインメモリストア
+type block403Store struct {
+	mu      sync.RWMutex
+	blocked map[string]time.Time // userHash -> blocked until
+}
+
+var forbidden403 = &block403Store{
+	blocked: make(map[string]time.Time),
+}
+
+// Block はユーザーを10分間ブロックする
+func (s *block403Store) Block(userHash string) {
+	s.mu.Lock()
+	s.blocked[userHash] = time.Now().Add(block403Duration)
+	s.mu.Unlock()
+}
+
+// IsBlocked はユーザーがブロック中かを返す
+func (s *block403Store) IsBlocked(userHash string) bool {
+	s.mu.RLock()
+	until, ok := s.blocked[userHash]
+	s.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	if time.Now().After(until) {
+		s.mu.Lock()
+		delete(s.blocked, userHash)
+		s.mu.Unlock()
+		return false
+	}
+	return true
+}

--- a/internal/server/block403_test.go
+++ b/internal/server/block403_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBlock403Store(t *testing.T) {
+	s := &block403Store{
+		blocked: make(map[string]time.Time),
+	}
+
+	userHash := "abc12345"
+
+	// ブロック前はfalse
+	if s.IsBlocked(userHash) {
+		t.Error("should not be blocked initially")
+	}
+
+	// ブロック後はtrue
+	s.Block(userHash)
+	if !s.IsBlocked(userHash) {
+		t.Error("should be blocked after Block()")
+	}
+
+	// 別ユーザーはブロックされない
+	if s.IsBlocked("other_user") {
+		t.Error("other user should not be blocked")
+	}
+}
+
+func TestBlock403StoreExpiry(t *testing.T) {
+	s := &block403Store{
+		blocked: make(map[string]time.Time),
+	}
+
+	userHash := "expired_user"
+
+	// 過去の時刻でブロック（即期限切れ）
+	s.mu.Lock()
+	s.blocked[userHash] = time.Now().Add(-1 * time.Second)
+	s.mu.Unlock()
+
+	// 期限切れなのでブロックされない
+	if s.IsBlocked(userHash) {
+		t.Error("should not be blocked after expiry")
+	}
+
+	// エントリがクリーンアップされている
+	s.mu.RLock()
+	_, exists := s.blocked[userHash]
+	s.mu.RUnlock()
+	if exists {
+		t.Error("expired entry should be cleaned up")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -92,7 +92,7 @@ func StartServer() {
 		// 403ブロックチェック
 		userHash := storage.UserKey(req.Username)
 		if forbidden403.IsBlocked(userHash) {
-			sendJSON(w, http.StatusTooManyRequests, map[string]string{"error": "戦績詳細ページへのアクセスが拒否されました。ブラウザからプレイヤーズサイト(https://web.vsmobile.jp)にログインし、戦績詳細が閲覧できるか確認してください。"})
+			sendJSON(w, http.StatusTooManyRequests, map[string]string{"error": "戦績詳細ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。"})
 			return
 		}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -92,7 +92,7 @@ func StartServer() {
 		// 403ブロックチェック
 		userHash := storage.UserKey(req.Username)
 		if forbidden403.IsBlocked(userHash) {
-			sendJSON(w, http.StatusTooManyRequests, map[string]string{"error": "戦績詳細ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。"})
+			sendJSON(w, http.StatusTooManyRequests, map[string]string{"error": "対戦履歴ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。"})
 			return
 		}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/yuki9431/exvs-analyzer/internal/pipeline"
+	"github.com/yuki9431/exvs-analyzer/internal/storage"
 	"golang.org/x/time/rate"
 )
 
@@ -88,6 +89,13 @@ func StartServer() {
 			return
 		}
 
+		// 403ブロックチェック
+		userHash := storage.UserKey(req.Username)
+		if forbidden403.IsBlocked(userHash) {
+			sendJSON(w, http.StatusTooManyRequests, map[string]string{"error": "戦績詳細ページへのアクセスが拒否されました。ブラウザからプレイヤーズサイト(https://web.vsmobile.jp)にログインし、戦績詳細が閲覧できるか確認してください。"})
+			return
+		}
+
 		// 同時実行数制限
 		select {
 		case requestLimiter <- struct{}{}:
@@ -102,7 +110,7 @@ func StartServer() {
 		// バックグラウンドで実行
 		go func() {
 			defer func() { <-requestLimiter }()
-			pipeline.Run(j, req.Username, req.Password)
+			pipeline.Run(j, req.Username, req.Password, forbidden403.Block)
 		}()
 
 		sendJSON(w, http.StatusAccepted, map[string]string{"id": j.ID})

--- a/static/app.js
+++ b/static/app.js
@@ -20,34 +20,63 @@ function esc(s) {
 function pct(n) { return n != null ? n.toFixed(1) + '%' : '-'; }
 function num(n, d) { return n != null ? n.toFixed(d != null ? d : 0) : '-'; }
 
-function wrClass(n) {
+// --- Color helpers (4段階: great > good > bad > terrible) ---
+// higherIsBetter: true=値が大きいほど良い, false=値が小さいほど良い
+function valClass4(n, great, good, bad, terrible, higherIsBetter) {
   if (n == null) return '';
-  if (n >= 55) return 'wr-high';
-  if (n <= 45) return 'wr-low';
-  return '';
+  if (higherIsBetter) {
+    if (n >= great) return 'val-great';
+    if (n >= good) return 'val-good';
+    if (n <= terrible) return 'val-terrible';
+    return 'val-bad';
+  } else {
+    if (n <= great) return 'val-great';
+    if (n <= good) return 'val-good';
+    if (n >= terrible) return 'val-terrible';
+    return 'val-bad';
+  }
 }
 
+function colorVal(n, great, good, bad, terrible, higherIsBetter, decimals) {
+  if (n == null) return '-';
+  var cls = valClass4(n, great, good, bad, terrible, higherIsBetter);
+  var text = n.toFixed(decimals != null ? decimals : 0);
+  return { sortValue: n, display: html`<span class=${cls}>${text}</span>` };
+}
+
+// 勝率: ≥60=great, ≥50=good, <50=bad, ≤40=terrible
 function colorPct(n) {
   if (n == null) return '-';
-  var cls = wrClass(n);
+  var cls = valClass4(n, 60, 50, 50, 40, true);
   var text = n.toFixed(1) + '%';
-  if (!cls) return text;
   return { sortValue: n, display: html`<span class=${cls}>${text}</span>` };
 }
 
-function deClass(n) {
-  if (n == null) return '';
-  if (n >= 1.0) return 'de-high';
-  if (n < 1.0) return 'de-low';
-  return '';
-}
-
+// 与被ダメ比: ≥1.2=great, ≥1.0=good, <1.0=bad, ≤0.8=terrible
 function colorDE(n, d) {
   if (n == null) return '-';
-  var cls = deClass(n);
+  var cls = valClass4(n, 1.2, 1.0, 1.0, 0.8, true);
   var text = n.toFixed(d != null ? d : 3);
-  if (!cls) return text;
   return { sortValue: n, display: html`<span class=${cls}>${text}</span>` };
+}
+
+// 与ダメ: ≥1100=great, ≥900=good, <900=bad, ≤700=terrible
+function colorDmgGiven(n) { return colorVal(n, 1100, 900, 900, 700, true, 0); }
+// 被ダメ: <700=great, <800=good, ≥800=bad, ≥900=terrible
+function colorDmgTaken(n) { return colorVal(n, 700, 800, 800, 900, false, 0); }
+// 撃墜: ≥1.8=great, ≥1.5=good, <1.5=bad, ≤1.0=terrible
+function colorKills(n) { return colorVal(n, 1.8, 1.5, 1.5, 1.0, true, 2); }
+// 被撃墜: <1.0=great, ≤1.5=good, >1.5=bad, ≥2.5=terrible
+function colorDeaths(n) { return colorVal(n, 1.0, 1.5, 1.5, 2.5, false, 2); }
+// K/D比: ≥1.5=great, ≥1.0=good, <1.0=bad, ≤0.6=terrible
+function colorKD(n) { return colorVal(n, 1.5, 1.0, 1.0, 0.6, true, 2); }
+// EXダメ: ≥200=great, ≥160=good, <160=bad, ≤100=terrible
+function colorExDmg(n) { return colorVal(n, 200, 160, 160, 100, true, 0); }
+// 差分: 色なし
+function colorDiff(n, d) {
+  if (n == null) return '-';
+  var text = (n >= 0 ? '+' : '') + n.toFixed(d != null ? d : 1);
+  return text;
 }
 
 function cellValue(cell) {
@@ -422,13 +451,13 @@ function BasicStatsSection({ stats }) {
   var rows = [
     ['試合数', stats.matches + '戦 (' + stats.wins + '勝' + stats.losses + '敗)'],
     ['勝率', colorPct(stats.win_rate)],
-    ['平均与ダメージ', num(stats.avg_dmg_given)],
-    ['平均被ダメージ', num(stats.avg_dmg_taken)],
+    ['平均与ダメージ', colorDmgGiven(stats.avg_dmg_given)],
+    ['平均被ダメージ', colorDmgTaken(stats.avg_dmg_taken)],
     ['与被ダメ比', colorDE(stats.dmg_efficiency, 3)],
-    ['平均撃墜', num(stats.avg_kills, 2)],
-    ['平均被撃墜', num(stats.avg_deaths, 2)],
-    ['K/D比', num(stats.kd_ratio, 2)],
-    ['平均EXダメージ', num(stats.avg_ex_dmg)],
+    ['平均撃墜', colorKills(stats.avg_kills)],
+    ['平均被撃墜', colorDeaths(stats.avg_deaths)],
+    ['K/D比', colorKD(stats.kd_ratio)],
+    ['平均EXダメージ', colorExDmg(stats.avg_ex_dmg)],
   ];
   return html`<div>
     <${Table} headers=${['項目', '値']} rows=${rows} />
@@ -439,8 +468,7 @@ function BasicStatsSection({ stats }) {
 function WinLossPatternSection({ pattern }) {
   if (!pattern) return null;
   var rows = (pattern.metrics || []).map(function (m) {
-    var diff = m.diff >= 0 ? '+' + num(m.diff, 1) : num(m.diff, 1);
-    return [m.label, num(m.win_avg, 1), num(m.loss_avg, 1), diff];
+    return [m.label, num(m.win_avg, 1), num(m.loss_avg, 1), colorDiff(m.diff, 1)];
   });
   return html`<div>
     <${Table} headers=${['項目', '勝利時', '敗北時', '差分']} rows=${rows} />
@@ -453,7 +481,7 @@ function EnemyMatchupSection({ matchup, msName }) {
   var headers = ['機体名', '試合', '勝率', '与被ダメ比', '与ダメ', '被ダメ'];
   function matchupRows(list) {
     return (list || []).map(function (e) {
-      return [esc(e.ms), e.matches, colorPct(e.win_rate), colorDE(e.dmg_efficiency, 3), num(e.avg_dmg_given, 1), num(e.avg_dmg_taken, 1)];
+      return [esc(e.ms), e.matches, colorPct(e.win_rate), colorDE(e.dmg_efficiency, 3), colorDmgGiven(e.avg_dmg_given), colorDmgTaken(e.avg_dmg_taken)];
     });
   }
   return html`<div>
@@ -570,11 +598,11 @@ function FixedPartnersSection({ partners }) {
     ${partners.notice && html`<p class="notice">${esc(partners.notice)}</p>`}
     ${items.map(function (p) {
       var statsRows = [
-        ['平均与ダメージ', num(p.my_stats.avg_dmg_given), num(p.partner_stats.avg_dmg_given)],
-        ['平均被ダメージ', num(p.my_stats.avg_dmg_taken), num(p.partner_stats.avg_dmg_taken)],
+        ['平均与ダメージ', colorDmgGiven(p.my_stats.avg_dmg_given), colorDmgGiven(p.partner_stats.avg_dmg_given)],
+        ['平均被ダメージ', colorDmgTaken(p.my_stats.avg_dmg_taken), colorDmgTaken(p.partner_stats.avg_dmg_taken)],
         ['与被ダメ比', colorDE(p.my_stats.dmg_efficiency, 3), colorDE(p.partner_stats.dmg_efficiency, 3)],
-        ['平均撃墜', num(p.my_stats.avg_kills, 2), num(p.partner_stats.avg_kills, 2)],
-        ['平均被撃墜', num(p.my_stats.avg_deaths, 2), num(p.partner_stats.avg_deaths, 2)],
+        ['平均撃墜', colorKills(p.my_stats.avg_kills), colorKills(p.partner_stats.avg_kills)],
+        ['平均被撃墜', colorDeaths(p.my_stats.avg_deaths), colorDeaths(p.partner_stats.avg_deaths)],
       ];
       var msRows = (p.partner_ms_breakdown || []).map(function (m) {
         return [esc(m.ms), m.matches, colorPct(m.win_rate)];

--- a/static/index.html
+++ b/static/index.html
@@ -49,10 +49,10 @@
     .report hr { border: none; border-top: 1px solid #333; margin: 20px 0; }
     .report ul, .report ol { padding-left: 20px; }
     .report ul.advice-details { margin-top: 6px; padding-left: 24px; list-style: disc; font-size: 0.92em; opacity: 0.9; }
-    .wr-high { color: #66bb6a; font-weight: bold; }
-    .wr-low { color: #ef5350; font-weight: bold; }
-    .de-high { color: #66bb6a; }
-    .de-low { color: #ef5350; }
+    .val-great { color: #69f0ae; font-weight: bold; }
+    .val-good { color: #a8e6cf; }
+    .val-bad { color: #ff8a65; }
+    .val-terrible { color: #ef5350; }
     .report strong { color: #4fc3f7; }
     .report a { color: #4fc3f7; text-decoration: none; }
     .report a:hover { text-decoration: underline; }


### PR DESCRIPTION
## Summary
- 全数値を4段階で色分け表示（すごく良い/良い/悪い/すごく悪い）
- 項目ごとに方向性を判定（与ダメは高い=良い、被ダメは低い=良い等）
- preview.html用に`window.renderReport`を公開

## 配色
- すごく良い: `#69f0ae`（ミントグリーン）+ 太字
- 良い: `#a8e6cf`（パステルミント）
- 悪い: `#ff8a65`（オレンジ）
- すごく悪い: `#ef5350`（赤）

## 基準値
| 項目 | すごく良い | 良い | 悪い | すごく悪い |
|---|---|---|---|---|
| 勝率 | ≥60% | ≥50% | <50% | ≤40% |
| 与被ダメ比 | ≥1.2 | ≥1.0 | <1.0 | ≤0.8 |
| 平均与ダメージ | ≥1100 | ≥900 | <900 | ≤700 |
| 平均被ダメージ | <700 | <800 | ≥800 | ≥900 |
| 平均撃墜 | ≥1.8 | ≥1.5 | <1.5 | ≤1.0 |
| 平均被撃墜 | <1.0 | ≤1.5 | >1.5 | ≥2.5 |
| K/D比 | ≥1.5 | ≥1.0 | <1.0 | ≤0.6 |
| 平均EXダメージ | ≥200 | ≥160 | <160 | ≤100 |

## Test plan
- [ ] preview.htmlで4色が正しく表示されることを確認
- [ ] ソート機能が色付きセルで正常動作することを確認