### PR TITLE
feat: UI改善（マーク列削除・目次修正・アドバイス文言リニューアル）

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -212,11 +212,11 @@ def data_basic_stats(data_list):
 
     tips = []
     if eff < 1.0:
-        tips.append(f"与被ダメ比が{eff:.3f}で1.0未満です。被ダメが与ダメを上回っており、被弾を減らす立ち回りが必要です。")
+        tips.append(f"与被ダメ比 **{eff:.3f}** → 被ダメ超過。被弾を減らす立ち回りを意識")
     elif eff >= 1.2:
-        tips.append(f"与被ダメ比{eff:.3f}は優秀です。この調子を維持しましょう。")
+        tips.append(f"与被ダメ比 **{eff:.3f}** → 優秀。この調子を維持")
     if kd < 1.0:
-        tips.append(f"K/D比が{kd:.2f}で1.0未満です。撃墜数を増やすか、被撃墜を減らすことを意識しましょう。")
+        tips.append(f"K/D比 **{kd:.2f}** → 1.0未満。撃墜↑ or 被撃墜↓を意識")
 
     return {
         "matches": n,
@@ -264,9 +264,9 @@ def data_win_loss_pattern(data_list):
     l_deaths = avg([d["deaths"] for d in losses]) if losses else 0
     l_taken = avg([d["dmg_taken"] for d in losses]) if losses else 0
     if l_deaths >= 1.5:
-        tips.append(f"負け試合の平均被撃墜が{l_deaths:.1f}と高いです。耐久管理を意識しましょう。")
+        tips.append(f"敗北時の平均被撃墜 **{l_deaths:.1f}回** → 耐久管理を意識")
     if l_taken >= 1100:
-        tips.append(f"負け試合の被ダメージが平均{l_taken:.0f}と高いです。無駄な被弾を減らすことが改善の鍵です。")
+        tips.append(f"敗北時の平均被ダメ **{l_taken:.0f}** → 無駄な被弾を減らすのが改善の鍵")
 
     # コスト帯別
     cost_groups = defaultdict(list)
@@ -357,13 +357,13 @@ def data_enemy_matchup(data_list, min_matches=3):
     if weak:
         high_dmg_taken = [r for r in weak if r["avg_dmg_taken"] >= 1200]
         if high_dmg_taken:
-            tip = {"text": "以下の機体戦で被ダメが特に多いです。距離管理を見直しましょう。",
-                   "details": [f"{r['ms']}（被ダメ {r['avg_dmg_taken']:.0f}）" for r in high_dmg_taken[:3]]}
+            tip = {"text": "被ダメが多い相手 → 距離管理を見直し",
+                   "details": [f"**{r['ms']}** 被ダメ {r['avg_dmg_taken']:.0f}" for r in high_dmg_taken[:3]]}
             tips.append(tip)
         low_dmg_given = [r for r in weak if r["avg_dmg_given"] <= 900]
         if low_dmg_given:
-            tip = {"text": "以下の機体戦で与ダメが低いです。攻撃の手数や当て方を工夫しましょう。",
-                   "details": [f"{r['ms']}（与ダメ {r['avg_dmg_given']:.0f}）" for r in low_dmg_given[:3]]}
+            tip = {"text": "与ダメが低い相手 → 手数や当て方を工夫",
+                   "details": [f"**{r['ms']}** 与ダメ {r['avg_dmg_given']:.0f}" for r in low_dmg_given[:3]]}
             tips.append(tip)
 
     return {
@@ -563,18 +563,18 @@ def data_fixed_partners(all_data, tag_partners=None):
 
         tips = []
         if p_eff < 0.8:
-            tips.append(f"相方の与被ダメ比が{p_eff:.3f}と低めです。相方が狙われやすい展開になっている可能性があります。カットやラインを意識しましょう。")
+            tips.append(f"相方の与被ダメ比 **{p_eff:.3f}** → カットやライン維持を意識")
         if wr < 45 and n >= 5:
-            tips.append(f"勝率が{wr:.0f}%と低調です。連携や機体の組み合わせを見直してみましょう。")
+            tips.append(f"勝率 **{wr:.0f}%** → 連携や機体の組み合わせを見直し")
         if n >= 5:
             if wr >= 90:
-                tips.append(f"驚異的！勝率{wr:.0f}%は全国大会優勝レベルです。何も言うことがありません！")
+                tips.append(f"勝率 **{wr:.0f}%** → 驚異的！全国大会優勝レベル")
             elif wr >= 80:
-                tips.append(f"圧巻！勝率{wr:.0f}%は全国大会上位クラスです。勝ちパターンを分析して再現性を高めましょう。")
+                tips.append(f"勝率 **{wr:.0f}%** → 圧巻！勝ちパターンの再現性を高めよう")
             elif wr >= 70:
-                tips.append(f"素晴らしい相性です！勝率{wr:.0f}%は上位プレイヤーに匹敵する勝率です。この相方との連携を軸に、苦手な機体への対策を詰めていきましょう。")
+                tips.append(f"勝率 **{wr:.0f}%** → 素晴らしい相性。この相方を軸に苦手機体の対策を")
             elif wr >= 60:
-                tips.append(f"好調です！勝率{wr:.0f}%、安定した連携ができています。さらに勝率を伸ばすために相方との役割分担を意識してみましょう。")
+                tips.append(f"勝率 **{wr:.0f}%** → 好調。役割分担を意識してさらに上へ")
 
         entry = {
             "partner_name": partner_name,
@@ -658,9 +658,9 @@ def data_deaths_impact(data_list):
 
         tips = []
         if fatal_count > 0 and len(data) > 0:
-            tips.append(f"負け確定({fatal}落ち以上)に達した試合は{fatal_count}/{len(data)}戦({fatal_count/len(data)*100:.0f}%)。")
+            tips.append(f"{fatal}落ち以上 **{fatal_count}/{len(data)}戦**（{fatal_count/len(data)*100:.0f}%）")
         if safe_data:
-            tips.append(f"{fatal-1}落ち以内に抑えた場合の勝率は{safe_wr:.1f}%。")
+            tips.append(f"{fatal-1}落ち以内の勝率 **{safe_wr:.1f}%**")
 
         results.append({
             "cost": cost,
@@ -698,9 +698,9 @@ def data_time_of_day(data_list):
     good = [h for h, m in hourly.items() if len(m) >= 5 and win_rate(m) >= 70]
     bad = [h for h, m in hourly.items() if len(m) >= 5 and win_rate(m) <= 40]
     if good:
-        tips.append(f"{'、'.join(f'{h}時台' for h in sorted(good))}が好調です。")
+        tips.append(f"好調 → **{'、'.join(f'{h}時台' for h in sorted(good))}**")
     if bad:
-        tips.append(f"{'、'.join(f'{h}時台' for h in sorted(bad))}は不調です。強い相手が多い時間帯か、疲労の影響かもしれません。")
+        tips.append(f"不調 → **{'、'.join(f'{h}時台' for h in sorted(bad))}**（強豪が多い or 疲労の影響）")
 
     return {"hours": results, "tips": tips}
 
@@ -735,7 +735,7 @@ def data_day_of_week(data_list):
     if diff >= 10:
         better = "平日" if wd_wr > we_wr else "土日"
         worse = "土日" if wd_wr > we_wr else "平日"
-        tips.append(f"{better}の方が{worse}より勝率が{diff:.0f}%高いです。{worse}は対戦相手の質が変わる可能性があります。")
+        tips.append(f"**{better}**が{worse}より勝率 **{diff:.0f}%** 高い")
 
     return {
         "weekday": {
@@ -779,7 +779,7 @@ def data_daily_trend(data_list):
     tips = []
     bad_days = [ds for ds in sorted(daily.keys()) if win_rate(daily[ds]) <= 40 and len(daily[ds]) >= 5]
     if bad_days:
-        tips.append(f"勝率40%以下の日: {', '.join(bad_days)}。不調時は早めに切り上げましょう。")
+        tips.append(f"不調日（勝率40%以下）→ **{', '.join(bad_days)}**。早めの切り上げが有効")
 
     return {
         "days": results,
@@ -810,9 +810,9 @@ def data_season(data_list):
             diff = s_wr - f_wr
             if abs(diff) >= 5:
                 if diff > 0:
-                    tips.append(f"後半の方が勝率が{diff:.0f}%高く、シーズンが進むにつれて安定しています。")
+                    tips.append(f"後半が **+{diff:.0f}%** → シーズン後半に安定")
                 else:
-                    tips.append(f"前半の方が勝率が{-diff:.0f}%高いです。後半は対戦相手のレベルが上がっている可能性があります。")
+                    tips.append(f"前半が **+{-diff:.0f}%** → 後半は対戦環境が厳しくなった可能性")
 
         entry = {
             "name": season_name,
@@ -856,7 +856,7 @@ def data_advice(all_data, ms_data, tag_partners=None):
             rate = len(fatal_losses) / len(data) * 100
             advices.append({
                 "category": "survival",
-                "text": f"{label}機体で{fatal}落ち敗北: {rate:.0f}%（{len(fatal_losses)}/{len(data)}戦）。耐久管理を意識しましょう。",
+                "text": f"{label}機体の{fatal}落ち敗北 **{rate:.0f}%**（{len(fatal_losses)}/{len(data)}戦）→ 耐久管理を意識",
             })
 
     for ms_name, data in ms_data.items():
@@ -866,7 +866,7 @@ def data_advice(all_data, ms_data, tag_partners=None):
         if eff < 1.0:
             advices.append({
                 "category": "ms",
-                "text": f"{ms_name}: 与被ダメ比 {eff:.3f}（1.0未満）。被ダメが与ダメを上回っています。立ち回りの改善を検討しましょう。",
+                "text": f"{ms_name}: 与被ダメ比 **{eff:.3f}** → 被ダメ超過。立ち回りの改善を",
             })
 
     hourly = defaultdict(list)
@@ -884,17 +884,17 @@ def data_advice(all_data, ms_data, tag_partners=None):
                 good_hours.append((hour, wr))
 
     if bad_hours:
-        details = [f"{h}時台: 勝率 {wr:.0f}%" for h, wr in bad_hours]
+        details = [f"**{h}時台** 勝率 {wr:.0f}%" for h, wr in bad_hours]
         advices.append({
             "category": "time",
-            "text": "勝率が低い時間帯があります。この時間帯を避けるか、意識的にプレイしましょう。",
+            "text": "不調な時間帯 → 避けるか意識的にプレイ",
             "details": details,
         })
     if good_hours:
-        details = [f"{h}時台: 勝率 {wr:.0f}%" for h, wr in good_hours]
+        details = [f"**{h}時台** 勝率 {wr:.0f}%" for h, wr in good_hours]
         advices.append({
             "category": "time",
-            "text": "勝率が高い時間帯があります。積極的に活用しましょう。",
+            "text": "好調な時間帯 → 積極的に活用",
             "details": details,
         })
 
@@ -909,12 +909,12 @@ def data_advice(all_data, ms_data, tag_partners=None):
         weak_enemies = []
         for ems, matches in enemy_stats.items():
             if len(matches) >= 3 and win_rate(matches) <= 30:
-                weak_enemies.append(f"{ems}({win_rate(matches):.0f}%)")
+                weak_enemies.append(f"**{ems}** {win_rate(matches):.0f}%")
 
         if weak_enemies:
             advices.append({
                 "category": "ms",
-                "text": f"{ms_name} の苦手機体（対策を練るか、別の機体での対応を検討しましょう）",
+                "text": f"{ms_name} の苦手機体 → 対策 or 別機体で対応",
                 "details": weak_enemies,
             })
 
@@ -929,7 +929,7 @@ def data_advice(all_data, ms_data, tag_partners=None):
             worse = "土日" if wd_wr > we_wr else "平日"
             advices.append({
                 "category": "time",
-                "text": f"曜日による勝率差: {better} {max(wd_wr, we_wr):.0f}% ／ {worse} {min(wd_wr, we_wr):.0f}%（{diff:.0f}%差）",
+                "text": f"**{better}** {max(wd_wr, we_wr):.0f}% ／ {worse} {min(wd_wr, we_wr):.0f}%（**{diff:.0f}%差**）",
             })
 
     fixed = detect_fixed_partners(all_data, tag_partners)
@@ -940,10 +940,10 @@ def data_advice(all_data, ms_data, tag_partners=None):
             best = partner_wrs[0]
             worst = partner_wrs[-1]
             if best[1] - worst[1] >= 15:
-                details = [f"{name}: 勝率 {wr:.0f}%（{cnt}戦）" for name, wr, cnt in partner_wrs]
+                details = [f"**{name}** 勝率 {wr:.0f}%（{cnt}戦）" for name, wr, cnt in partner_wrs]
                 advices.append({
                     "category": "partner",
-                    "text": f"固定相方の勝率差が{best[1]-worst[1]:.0f}%あります。相方ごとに戦い方を変えるか、相性の良い相方との試合を増やしましょう。",
+                    "text": f"固定相方で勝率差 **{best[1]-worst[1]:.0f}%** → 相性の良い相方を軸に",
                     "details": details,
                 })
 
@@ -959,7 +959,7 @@ def data_advice(all_data, ms_data, tag_partners=None):
     if max_lose_streak >= 4:
         advices.append({
             "category": "mental",
-            "text": f"最大連敗数: {max_lose_streak}連敗。3連敗したら休憩を挟みましょう。メンタル管理も勝率に直結します。",
+            "text": f"最大 **{max_lose_streak}連敗** → 3連敗で休憩を。メンタル管理も勝率に直結",
         })
 
     season_data_map = defaultdict(list)
@@ -981,12 +981,12 @@ def data_advice(all_data, ms_data, tag_partners=None):
                 if diff > 0:
                     advices.append({
                         "category": "season",
-                        "text": f"{season_name}: 後半の勝率が前半より{diff:.0f}%高く、シーズン後半に安定する傾向があります。",
+                        "text": f"**{season_name}**: 後半が **+{diff:.0f}%** → 後半に安定",
                     })
                 else:
                     advices.append({
                         "category": "season",
-                        "text": f"{season_name}: 前半の勝率が後半より{-diff:.0f}%高いです。後半は対戦環境が厳しくなっている可能性があります。",
+                        "text": f"**{season_name}**: 前半が **+{-diff:.0f}%** → 後半は対戦環境が厳しくなった可能性",
                     })
 
     # カテゴリ順序

--- a/static/app.js
+++ b/static/app.js
@@ -848,14 +848,13 @@ function TimeOfDayChart({ hours }) {
 function TimeOfDaySection({ time }) {
   if (!time || !time.hours || !time.hours.length) return null;
   var rows = time.hours.map(function (h) {
-    var mark = h.mark === 'good' ? '◎' : h.mark === 'bad' ? '△' : '';
-    return [{ sortValue: h.hour, display: h.hour + '時' }, h.matches, colorPct(h.win_rate), colorDE(h.dmg_efficiency, 3), mark];
+    return [{ sortValue: h.hour, display: h.hour + '時' }, h.matches, colorPct(h.win_rate), colorDE(h.dmg_efficiency, 3)];
   });
   return html`<${Section} title="時間帯別の勝率">
     <${TimeOfDayChart} hours=${time.hours} />
     <${Tips} tips=${time.tips} />
     <${SubSection} title="テーブルで詳細を見る">
-      <${SortableTable} headers=${['時間帯', '試合', '勝率', '与被ダメ比', '']} rows=${rows} />
+      <${SortableTable} headers=${['時間帯', '試合', '勝率', '与被ダメ比']} rows=${rows} />
     <//>
   <//>`;
 }
@@ -1064,14 +1063,13 @@ function DailyTrendChart({ days }) {
 function DailyTrendSection({ daily }) {
   if (!daily || !daily.days || !daily.days.length) return null;
   var rows = daily.days.map(function (d) {
-    var mark = d.mark === 'good' ? '◎' : d.mark === 'bad' ? '△' : '';
-    return [{ sortValue: d.date, display: d.date + ' (' + d.dow_name + ')' }, d.matches, colorPct(d.win_rate), colorDE(d.dmg_efficiency, 3), mark];
+    return [{ sortValue: d.date, display: d.date + ' (' + d.dow_name + ')' }, d.matches, colorPct(d.win_rate), colorDE(d.dmg_efficiency, 3)];
   });
   return html`<${Section} title="日別勝率">
     <${DailyTrendChart} days=${daily.days} />
     <${Tips} tips=${daily.tips} />
     <${SubSection} title="テーブルで詳細を見る">
-      <${SortableTable} headers=${['日付', '試合', '勝率', '与被ダメ比', '']} rows=${rows} />
+      <${SortableTable} headers=${['日付', '試合', '勝率', '与被ダメ比']} rows=${rows} />
     <//>
   <//>`;
 }

--- a/static/app.js
+++ b/static/app.js
@@ -441,9 +441,9 @@ function PeriodSelector({ periods, selected, onSelect, userKey, onCustomReport }
 function formatMsAdvice(text) {
   var m = text.match(/^(.+?)([:：] | の)/);
   if (m) {
-    return html`<strong class="ms-name">${m[1]}</strong>${text.slice(m[1].length)}`;
+    return html`<strong class="ms-name">${m[1]}</strong>${boldText(text.slice(m[1].length))}`;
   }
-  return text;
+  return boldText(text);
 }
 
 function SummarySection({ summary }) {

--- a/static/app.js
+++ b/static/app.js
@@ -428,17 +428,27 @@ function PeriodSelector({ periods, selected, onSelect, userKey, onCustomReport }
 
 // --- Report sections ---
 
+function formatMsAdvice(text) {
+  var m = text.match(/^(.+?)([:：] | の)/);
+  if (m) {
+    return html`<strong class="ms-name">${m[1]}</strong>${text.slice(m[1].length)}`;
+  }
+  return text;
+}
+
 function SummarySection({ summary }) {
   if (!summary || !summary.categories || !summary.categories.length) return null;
   return html`<${Section} title="総合アドバイス" open>
     ${summary.categories.map(function (cat) {
+      var isMsCat = cat.key === 'ms';
       return html`<div>
         <strong>${esc(cat.title)}</strong>
         <ul>${cat.items.map(function (item) {
           var text = typeof item === 'string' ? item : item.text;
           var details = typeof item === 'object' && item.details ? item.details : null;
+          var display = isMsCat ? formatMsAdvice(text) : text;
           return html`<li>
-            ${text}
+            ${display}
             ${details && html`<ul class="advice-details">${details.map(function (d) { return html`<li>${d}</li>`; })}</ul>`}
           </li>`;
         })}</ul>

--- a/static/app.js
+++ b/static/app.js
@@ -17,6 +17,16 @@ function esc(s) {
   return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
+// **太字** をパースして html`<strong>太字</strong>` に変換
+function boldText(s) {
+  if (s == null) return '';
+  var parts = String(s).split(/\*\*(.+?)\*\*/g);
+  if (parts.length === 1) return s;
+  return parts.map(function (part, i) {
+    return i % 2 === 1 ? html`<strong class="tip-bold">${part}</strong>` : part;
+  });
+}
+
 function pct(n) { return n != null ? n.toFixed(1) + '%' : '-'; }
 function num(n, d) { return n != null ? n.toFixed(d != null ? d : 0) : '-'; }
 
@@ -122,8 +132,8 @@ function Tips({ tips }) {
   return html`<blockquote><strong>💡アドバイス:</strong><br />${tips.map(function (t, i) {
     var text = typeof t === 'string' ? t : t.text;
     var details = typeof t === 'object' && t.details ? t.details : null;
-    return html`${i > 0 && html`<br />`}${text}
-      ${details && html`<ul class="advice-details">${details.map(function (d) { return html`<li>${d}</li>`; })}</ul>`}`;
+    return html`${i > 0 && html`<br />`}${boldText(text)}
+      ${details && html`<ul class="advice-details">${details.map(function (d) { return html`<li>${boldText(d)}</li>`; })}</ul>`}`;
   })}</blockquote>`;
 }
 
@@ -446,10 +456,10 @@ function SummarySection({ summary }) {
         <ul>${cat.items.map(function (item) {
           var text = typeof item === 'string' ? item : item.text;
           var details = typeof item === 'object' && item.details ? item.details : null;
-          var display = isMsCat ? formatMsAdvice(text) : text;
+          var display = isMsCat ? formatMsAdvice(text) : boldText(text);
           return html`<li>
             ${display}
-            ${details && html`<ul class="advice-details">${details.map(function (d) { return html`<li>${d}</li>`; })}</ul>`}
+            ${details && html`<ul class="advice-details">${details.map(function (d) { return html`<li>${boldText(d)}</li>`; })}</ul>`}
           </li>`;
         })}</ul>
       </div>`;

--- a/static/index.html
+++ b/static/index.html
@@ -55,6 +55,7 @@
     .val-terrible { color: #ef5350; }
     .report strong { color: #4fc3f7; }
     .report .ms-name { color: #e0e0e0; }
+    .report .tip-bold { color: #e0e0e0; }
     .report a { color: #4fc3f7; text-decoration: none; }
     .report a:hover { text-decoration: underline; }
     @keyframes fadeSlideIn { from { opacity: 0; transform: translateY(-8px); } to { opacity: 1; transform: translateY(0); } }

--- a/static/index.html
+++ b/static/index.html
@@ -54,6 +54,7 @@
     .val-bad { color: #ff8a65; }
     .val-terrible { color: #ef5350; }
     .report strong { color: #4fc3f7; }
+    .report .ms-name { color: #e0e0e0; }
     .report a { color: #4fc3f7; text-decoration: none; }
     .report a:hover { text-decoration: underline; }
     @keyframes fadeSlideIn { from { opacity: 0; transform: translateY(-8px); } to { opacity: 1; transform: translateY(0); } }

--- a/static/index.html
+++ b/static/index.html
@@ -64,7 +64,10 @@
     .report summary:hover { color: #81d4fa; }
     .report details details > summary { font-size: 0.95em; color: #81d4fa; }
     .toc-ms-details { display: inline; }
-    .toc-ms-details > summary { font-size: 0.85em; color: #81d4fa; display: inline; cursor: pointer; }
+    .report .toc-ms-details > summary { font-size: 0.85em; color: #4fc3f7; display: inline; cursor: pointer; list-style: none; }
+    .toc-ms-details > summary::-webkit-details-marker { display: none; }
+    .toc-ms-details > summary::after { content: ' ▼'; font-size: 0.7em; }
+    .toc-ms-details[open] > summary::after { content: ' ▲'; }
     .toc-ms-list { list-style: disc; margin: 4px 0 0; padding-left: 20px; }
     .error { background: #3d1f1f; border: 1px solid #ff5252; border-radius: 8px; padding: 15px; color: #ff8a80; margin: 20px 0; }
     .share-area { display: flex; align-items: center; gap: 8px; margin: 20px 0; }


### PR DESCRIPTION
## Summary
- 時間帯別・日別テーブルから◎△マーク列を削除（#197 の変更が #198 で再混入していたのを修正）
- 目次の「機体一覧」の色を他の目次項目と統一（`#4fc3f7`）、開閉インジケータ（▼/▲）を追加
- 総合アドバイスの機体カテゴリで機体名を太字表示
- 全アドバイス文言を短文化、`**太字**`マーカーによる数値・キーワード強調に対応
  - 「数値 → 結論」フォーマットに統一（スマホでの可読性向上）

## Test plan
- [ ] 時間帯別・日別テーブルにマーク列がないことを確認
- [ ] 目次の「機体一覧」が他の項目と同じ色（水色）で表示されること
- [ ] 「機体一覧」に▼/▲インジケータが表示されること
- [ ] 総合アドバイスの機体カテゴリで機体名が太字になっていること
- [ ] 各セクションのアドバイスで数値が太字表示されること
- [ ] スマホサイズでアドバイス文言が読みやすいことを確認

Refs #153