### PR TITLE
fix: グラフの勝率バー色分け基準を60%に変更

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -810,9 +810,8 @@ function TimeOfDayChart({ hours }) {
           {
             label: '勝率 (%)',
             data: winRates,
-            backgroundColor: winRates.map(function (v) { return v >= 50 ? 'rgba(76, 175, 80, 0.7)' : 'rgba(239, 83, 80, 0.7)'; }),
-            borderColor: winRates.map(function (v) { return v >= 50 ? '#4caf50' : '#ef5350'; }),
-            borderWidth: 1,
+            backgroundColor: winRates.map(function (v) { return v >= 60 ? 'rgba(76, 175, 80, 0.7)' : v < 50 ? 'rgba(239, 83, 80, 0.7)' : 'rgba(129, 212, 250, 0.3)'; }),
+            borderWidth: 0,
             yAxisID: 'y',
           },
           {
@@ -901,9 +900,8 @@ function DayOfWeekChart({ days }) {
           {
             label: '勝率 (%)',
             data: winRates,
-            backgroundColor: winRates.map(function (v) { return v >= 50 ? 'rgba(76, 175, 80, 0.7)' : 'rgba(239, 83, 80, 0.7)'; }),
-            borderColor: winRates.map(function (v) { return v >= 50 ? '#4caf50' : '#ef5350'; }),
-            borderWidth: 1,
+            backgroundColor: winRates.map(function (v) { return v >= 60 ? 'rgba(76, 175, 80, 0.7)' : v < 50 ? 'rgba(239, 83, 80, 0.7)' : 'rgba(129, 212, 250, 0.3)'; }),
+            borderWidth: 0,
             yAxisID: 'y',
           },
           {
@@ -1006,9 +1004,8 @@ function DailyTrendChart({ days }) {
           {
             label: '勝率 (%)',
             data: winRates,
-            backgroundColor: winRates.map(function (v) { return v >= 50 ? 'rgba(76, 175, 80, 0.7)' : 'rgba(239, 83, 80, 0.7)'; }),
-            borderColor: winRates.map(function (v) { return v >= 50 ? '#4caf50' : '#ef5350'; }),
-            borderWidth: 1,
+            backgroundColor: winRates.map(function (v) { return v >= 60 ? 'rgba(76, 175, 80, 0.7)' : v < 50 ? 'rgba(239, 83, 80, 0.7)' : 'rgba(129, 212, 250, 0.3)'; }),
+            borderWidth: 0,
             yAxisID: 'y',
           },
           {


### PR DESCRIPTION
## Summary
- 勝率バーの色分け基準を変更: 60%以上=緑、50%未満=赤、50〜60%=水色（デフォルト）
- バーのボーダー（縁線）を削除して見た目を統一
- 50%基準線はそのまま維持

## Test plan
- [x] preview.htmlで時間帯別・曜日別・日別グラフの色分けを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)