### PR TITLE
fix 403エラー時に途中取得データを保存して分析結果を返す

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -41,6 +41,7 @@ type Job struct {
 	Report             string    `json:"report,omitempty"`
 	PreliminaryReport  string    `json:"preliminary_report,omitempty"`
 	Error              string    `json:"error,omitempty"`
+	PartialData        bool      `json:"partial_data,omitempty"`
 	UserKey            string    `json:"-"`
 	completedAt        time.Time
 }
@@ -55,6 +56,7 @@ type JobSnapshot struct {
 	Report            string
 	PreliminaryReport string
 	Error             string
+	PartialData       bool
 	UserKey           string
 }
 
@@ -97,6 +99,7 @@ func (j *Job) Snapshot() JobSnapshot {
 		Report:            j.Report,
 		PreliminaryReport: j.PreliminaryReport,
 		Error:             j.Error,
+		PartialData:       j.PartialData,
 		UserKey:           j.UserKey,
 	}
 }
@@ -165,7 +168,9 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		jobsMu.Unlock()
 	}
 	datedScores, jar, err := scraper.Scraping(username, password, since, onProgress)
-	if err != nil {
+	// 403の場合でも途中データがあれば保存・分析を続行する
+	is403WithPartialData := errors.Is(err, scraper.ErrAccessDenied) && len(datedScores) > 0
+	if err != nil && !is403WithPartialData {
 		switch {
 		case errors.Is(err, scraper.ErrLoginFailed):
 			setError(j, "ログインに失敗しました。メールアドレスとパスワードを確認してください。", err.Error())
@@ -184,6 +189,12 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 			setError(j, "データの取得に失敗しました。時間をおいて再度お試しいただき、解決しない場合は開発者までお問い合わせください。", err.Error())
 		}
 		return
+	}
+	if is403WithPartialData {
+		log.Printf("[WARN] Job %s: 403 occurred but %d partial scores available, saving partial data", j.ID, len(datedScores))
+		if len(on403) > 0 && on403[0] != nil {
+			on403[0](storage.UserKey(username))
+		}
 	}
 	if len(datedScores) == 0 && !exists {
 		setError(j, "戦績データが見つかりませんでした", "no scores found")
@@ -249,23 +260,30 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		log.Printf("[WARN] Failed to upload CSV to Cloud Storage: %v", err)
 	}
 
-	// タッグ相方名を取得
+	// タッグ相方名を取得（403途中保存時はセッションが無効なのでキャッシュを使用）
 	var tagPartnersPath string
-	tagPartners := scraper.ScrapeTagPartners(jar)
-	if len(tagPartners) > 0 {
-		tagPartnersPath = filepath.Join(tmpDir, "tag_partners.json")
-		if err := saveTagPartners(tagPartners, tagPartnersPath); err != nil {
-			log.Printf("[WARN] Failed to save tag partners: %v", err)
-			tagPartnersPath = ""
-		} else {
-			log.Printf("[INFO] Found %d tag partners", len(tagPartners))
-			// タッグ相方情報をGCSにアップロード
-			if err := storage.UploadTagPartners(username, tagPartnersPath); err != nil {
-				log.Printf("[WARN] Failed to upload tag partners to GCS: %v", err)
-			}
+	if is403WithPartialData {
+		if cachedTagPartnersPath != "" {
+			tagPartnersPath = cachedTagPartnersPath
+			log.Printf("[INFO] Using cached tag partners (403 partial save)")
 		}
 	} else {
-		log.Printf("[INFO] No tag partners found")
+		tagPartners := scraper.ScrapeTagPartners(jar)
+		if len(tagPartners) > 0 {
+			tagPartnersPath = filepath.Join(tmpDir, "tag_partners.json")
+			if err := saveTagPartners(tagPartners, tagPartnersPath); err != nil {
+				log.Printf("[WARN] Failed to save tag partners: %v", err)
+				tagPartnersPath = ""
+			} else {
+				log.Printf("[INFO] Found %d tag partners", len(tagPartners))
+				// タッグ相方情報をGCSにアップロード
+				if err := storage.UploadTagPartners(username, tagPartnersPath); err != nil {
+					log.Printf("[WARN] Failed to upload tag partners to GCS: %v", err)
+				}
+			}
+		} else {
+			log.Printf("[INFO] No tag partners found")
+		}
 	}
 
 	// Python分析実行
@@ -279,9 +297,14 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	jobsMu.Lock()
 	j.Status = StatusDone
 	j.Report = report
+	j.PartialData = is403WithPartialData
 	j.completedAt = time.Now()
 	jobsMu.Unlock()
-	log.Printf("[INFO] Job %s completed", j.ID)
+	if is403WithPartialData {
+		log.Printf("[INFO] Job %s completed with partial data (403 during scraping)", j.ID)
+	} else {
+		log.Printf("[INFO] Job %s completed", j.ID)
+	}
 }
 
 // RunCustomPeriod はカスタム日時範囲で再分析を実行してJSON文字列を返す

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -120,7 +120,12 @@ func Scraping(username, password string, since time.Time, onProgress ...Progress
 	if streamErr != nil {
 		return nil, nil, streamErr
 	}
+	// 403の場合は途中データとエラーを両方返す（呼び出し元で途中保存できるようにする）
 	if detailErr != nil {
+		if errors.Is(detailErr, ErrAccessDenied) && len(scores) > 0 {
+			log.Printf("[INFO] Returning %d partial scores despite 403 error", len(scores))
+			return scores, m.HTTPClient.Jar, detailErr
+		}
 		return nil, nil, detailErr
 	}
 
@@ -325,7 +330,6 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 			// チャネルに残ったエントリを捨てて終了を待つ
 			for range entryCh {
 			}
-			return nil, ErrAccessDenied
 		default:
 			entries = append(entries, entry)
 		}
@@ -404,7 +408,8 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 	wg.Wait()
 
 	if has403 {
-		return nil, ErrAccessDenied
+		log.Printf("[WARN] 403 detected during detail fetch: %d/%d pages completed, returning partial data", processed, total)
+		return scores, ErrAccessDenied
 	}
 	if errorCount > 0 {
 		return nil, fmt.Errorf("詳細ページ取得で%w: %d/%d件がエラー", ErrHTTPRequestFailed, errorCount, total)

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -330,6 +330,8 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 			// チャネルに残ったエントリを捨てて終了を待つ
 			for range entryCh {
 			}
+			// drain完了後、収集済みエントリで詳細取得に進む
+			break
 		default:
 			entries = append(entries, entry)
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,7 +203,7 @@ func handleResult(w http.ResponseWriter, r *http.Request, id string) {
 		return
 	}
 
-	sendRawReport(w, http.StatusOK, snap.Report, "", snap.UserKey, false)
+	sendRawReport(w, http.StatusOK, snap.Report, "", snap.UserKey, false, snap.PartialData)
 }
 
 func handleCustomPeriod(w http.ResponseWriter, r *http.Request, id string) {
@@ -301,17 +301,20 @@ func sendJSON(w http.ResponseWriter, code int, data interface{}) {
 
 // sendRawReport はJSON形式のレポートをレスポンスとして返す。
 // reportJSONはanalyze.pyが生成したJSON文字列。json.RawMessageで二重エンコードを防ぐ。
-func sendRawReport(w http.ResponseWriter, code int, reportJSON, status, userKey string, preliminary bool) {
+func sendRawReport(w http.ResponseWriter, code int, reportJSON, status, userKey string, preliminary bool, partial ...bool) {
 	type reportResponse struct {
 		Report      json.RawMessage `json:"report"`
 		Status      string          `json:"status,omitempty"`
 		Preliminary bool            `json:"preliminary,omitempty"`
+		Partial     bool            `json:"partial,omitempty"`
 		UserKey     string          `json:"user_key,omitempty"`
 	}
+	isPartial := len(partial) > 0 && partial[0]
 	resp := reportResponse{
 		Report:      json.RawMessage(reportJSON),
 		Status:      status,
 		Preliminary: preliminary,
+		Partial:     isPartial,
 		UserKey:     userKey,
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/static/app.js
+++ b/static/app.js
@@ -1329,6 +1329,14 @@ async function analyze() {
         }
 
         renderReport(resultData.report, resultData.user_key);
+        if (resultData.partial) {
+          var warning = document.getElementById('error');
+          warning.style.display = 'block';
+          warning.style.backgroundColor = '#4a3800';
+          warning.style.borderColor = '#d4a017';
+          warning.style.color = '#ffd54f';
+          warning.textContent = 'ガンダムモバイルからアクセスが制限されたため、一部のデータのみで分析しています。時間をおいて再度実行すると続きから取得します。';
+        }
         break;
       }
     }

--- a/static/app.js
+++ b/static/app.js
@@ -1263,6 +1263,9 @@ async function analyze() {
   status.style.display = 'block';
   statusText.textContent = STATUS_MESSAGES.pending;
   error.style.display = 'none';
+  error.style.backgroundColor = '';
+  error.style.borderColor = '';
+  error.style.color = '';
   reportEl.style.display = 'none';
   render(null, reportEl);
 


### PR DESCRIPTION
## Summary
- スクレイピング中に403を受けた場合、取得済みデータを破棄せずCSV保存・GCSアップロード・分析を実行し、途中結果をユーザーに返すよう変更
- 次回実行時は保存済みデータの続きから取得可能に
- 403途中データ時はフロントエンドに黄色の警告バナーを表示

## 変更内容
- `scraper.go`: `fetchDetailPagesStreaming`/`Scraping`で403時に途中データとエラーを両方返す
- `pipeline.go`: 403途中データ時にCSV保存→GCSアップロード→分析を続行、`PartialData`フラグ追加
- `server.go`: APIレスポンスに`partial`フラグを含める
- `app.js`: `partial: true`時に警告メッセージを表示

## Test plan
- [ ] 正常系: 全データ取得完了時に従来通りレポート表示されること
- [ ] 403途中データ: 途中データがCSV保存・GCSアップロードされること
- [ ] 403途中データ: 分析レポートが表示され、黄色の警告バナーが出ること
- [ ] 403途中データ: 再実行時に続きから取得できること
- [ ] 403データなし: 従来通りエラーメッセージが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)