### PR TITLE
fix: スクレイピング並列数を5→3、間隔を100ms→300msに変更

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -25,10 +25,10 @@ const (
 	mobileMSUsedRate = "https://web.vsmobile.jp/exvs2ib/ranking/ms_used_rate"
 
 	// maxParallelism はバンナムサーバーへの最大同時リクエスト数
-	maxParallelism = 5
+	maxParallelism = 3
 
 	// requestDelay はリクエスト完了後の待機時間（サーバー負荷軽減用）
-	requestDelay = 100 * time.Millisecond
+	requestDelay = 300 * time.Millisecond
 )
 
 // ErrAccessDenied はサーバーからアクセス拒否(403)された場合のエラー


### PR DESCRIPTION
## Summary
- スクレイピング並列数を5→3に削減（バースト時の同時接続を抑制）
- リクエスト間隔を100ms→300msに拡大
- 3ジョブ同時実行時の最大並列リクエスト数: 15→9

ref #200

## Test plan
- [x] `make build` 成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)