### PR TITLE
fix: 403途中保存の改善・バックフィル最適化・analyze.py修正

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -141,16 +142,18 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		cachedTagPartnersPath = ""
 	}
 
-	// 旧CSVフォーマット検出: 新フィールド追加後の初回は全件再スクレイプ
+	// バックフィル判定: 新フィールドが空のレコードがある日付を特定
 	needsBackfill := exists && storage.NeedsBackfill(csvPath)
+	var backfillDates map[string]bool
 	if needsBackfill {
-		log.Printf("[INFO] Old CSV format detected, will re-scrape all available data for backfill")
+		backfillDates = storage.BackfillDates(csvPath)
+		log.Printf("[INFO] Backfill needed: %d dates with missing data", len(backfillDates))
 	}
 
 	if exists {
 		if needsBackfill {
-			// 旧フォーマット: since=ゼロで全件再スクレイプ（サイト保持期間内のデータに新フィールドを付与）
-			log.Printf("[INFO] Backfill mode: ignoring existing latest datetime")
+			// バックフィル: since=ゼロで対象日付のみ再スクレイプ
+			log.Printf("[INFO] Backfill mode: targeting specific dates")
 		} else {
 			since, err = storage.GetLatestDatetime(csvPath)
 			if err != nil {
@@ -180,7 +183,17 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		j.ProgressTotal = total
 		jobsMu.Unlock()
 	}
-	datedScores, jar, err := scraper.Scraping(username, password, since, onProgress)
+
+	var datedScores model.DatedScores
+	var jar http.CookieJar
+	if needsBackfill {
+		datedScores, jar, err = scraper.ScrapingWithOption(username, password, since, scraper.ScrapingOption{
+			OnProgress:    onProgress,
+			BackfillDates: backfillDates,
+		})
+	} else {
+		datedScores, jar, err = scraper.Scraping(username, password, since, onProgress)
+	}
 	// 403の場合でも途中データがあれば保存・分析を続行する
 	is403WithPartialData := errors.Is(err, scraper.ErrAccessDenied) && len(datedScores) > 0
 	if err != nil && !is403WithPartialData {

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -90,12 +90,32 @@ func parseNumber(s string) int {
 // ProgressFunc はスクレイピングの進捗を通知するコールバック型
 type ProgressFunc func(current, total int)
 
+// ScrapingOption はスクレイピングのオプション
+type ScrapingOption struct {
+	OnProgress     ProgressFunc
+	BackfillDates  map[string]bool // バックフィル対象日付セット（"2006/01/02"形式）。nilなら全日付対象
+}
+
 // Scraping はスクレイピング処理を実行し、DatedScoresとログイン済みCookieJarを返す
 // 日別ページ収集と詳細ページ取得をパイプラインで並行実行し、高速化を図る
 func Scraping(username, password string, since time.Time, onProgress ...ProgressFunc) (model.DatedScores, http.CookieJar, error) {
+	return ScrapingWithOption(username, password, since, ScrapingOption{
+		OnProgress: firstOrNil(onProgress),
+	})
+}
+
+func firstOrNil(fns []ProgressFunc) ProgressFunc {
+	if len(fns) > 0 {
+		return fns[0]
+	}
+	return nil
+}
+
+// ScrapingWithOption はオプション付きでスクレイピング処理を実行する
+func ScrapingWithOption(username, password string, since time.Time, opt ScrapingOption) (model.DatedScores, http.CookieJar, error) {
 	notify := func(current, total int) {
-		if len(onProgress) > 0 && onProgress[0] != nil {
-			onProgress[0](current, total)
+		if opt.OnProgress != nil {
+			opt.OnProgress(current, total)
 		}
 	}
 
@@ -108,6 +128,18 @@ func Scraping(username, password string, since time.Time, onProgress ...Progress
 	dailyLinks, err := collectDailyLinks(m.HTTPClient.Jar, since)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// バックフィル対象日付が指定されている場合はフィルタリング
+	if opt.BackfillDates != nil {
+		var filtered []dailyLink
+		for _, dl := range dailyLinks {
+			if opt.BackfillDates[dl.date] {
+				filtered = append(filtered, dl)
+			}
+		}
+		log.Printf("[INFO] Backfill: filtered %d/%d daily links to target dates", len(filtered), len(dailyLinks))
+		dailyLinks = filtered
 	}
 
 	// 403検出時に全処理を即座に打ち切るためのcontext

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -126,15 +126,18 @@ func Scraping(username, password string, since time.Time, onProgress ...Progress
 
 	scores, detailErr := fetchDetailPagesStreaming(ctx, cancel, m.HTTPClient.Jar, entryCh, notify)
 
-	// Phase 2のエラーを優先的に返す（403はより深刻なため）
-	if streamErr != nil {
-		return nil, nil, streamErr
-	}
-	// 403の場合は途中データとエラーを両方返す（呼び出し元で途中保存できるようにする）
-	if detailErr != nil {
-		if errors.Is(detailErr, ErrAccessDenied) && len(scores) > 0 {
+	// 403の場合は途中データがあればエラーと一緒に返す（呼び出し元で途中保存できるようにする）
+	if streamErr != nil || detailErr != nil {
+		err := streamErr
+		if err == nil {
+			err = detailErr
+		}
+		if errors.Is(err, ErrAccessDenied) && len(scores) > 0 {
 			log.Printf("[INFO] Returning %d partial scores despite 403 error", len(scores))
-			return scores, m.HTTPClient.Jar, detailErr
+			return scores, m.HTTPClient.Jar, err
+		}
+		if streamErr != nil {
+			return nil, nil, streamErr
 		}
 		return nil, nil, detailErr
 	}

--- a/internal/storage/csv_export.go
+++ b/internal/storage/csv_export.go
@@ -53,6 +53,41 @@ func NeedsBackfill(path string) bool {
 	return false
 }
 
+// BackfillDates は直近30日以内で新フィールドが空のレコードの日付セットを返す。
+// 日付は "2006/01/02" 形式（スクレイパーのdailyLink.dateと同じ形式）。
+func BackfillDates(path string) map[string]bool {
+	dates := make(map[string]bool)
+
+	f, err := os.Open(path)
+	if err != nil {
+		return dates
+	}
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	r.FieldsPerRecord = -1
+	records, err := r.ReadAll()
+	if err != nil {
+		return dates
+	}
+
+	layout := "2006-01-02 15:04"
+	cutoff := time.Now().AddDate(0, 0, -30)
+	for i, row := range records {
+		if i == 0 {
+			continue
+		}
+		dt, err := time.Parse(layout, row[0])
+		if err != nil {
+			continue
+		}
+		if dt.After(cutoff) && (len(row) < currentCSVColumnCount || row[13] == "") {
+			dates[dt.Format("2006/01/02")] = true
+		}
+	}
+	return dates
+}
+
 // GetLatestDatetime は既存CSVファイルから最新の試合日時を取得する。
 // ファイルが存在しない場合はゼロ値のtimeを返す。
 func GetLatestDatetime(path string) (time.Time, error) {

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1183,6 +1183,7 @@ def main():
     parser.add_argument("--start", help="開始日時 (YYYY-MM-DD HH:MM)")
     parser.add_argument("--end", help="終了日時 (YYYY-MM-DD HH:MM)")
     parser.add_argument("--tag-partners", help="タッグ相方JSONファイルパス", default=None)
+    parser.add_argument("--timeline", help="タイムラインJSONファイルパス（将来の覚醒分析用）", default=None)
     args = parser.parse_args()
 
     matches = load_csv(args.csv_path)


### PR DESCRIPTION
## Summary
- Phase2/Phase3どちらの403でも途中取得データを返すように修正
- バックフィルを全件再スクレイプから対象日付のみに最適化（403リスク軽減）
- analyze.pyに`--timeline`オプション定義を追加（未定義でargparseエラーになっていた）

## 変更内容
1. **403途中保存の改善**: `streamErr`(Phase2)が先に返されると途中scoresが破棄されていた問題を修正
2. **バックフィル最適化**: CSVから新フィールドが空の日付を特定し、その日付のdailyLinkだけスクレイプ。`ScrapingOption`構造体で拡張性も確保
3. **analyze.py**: `--timeline`引数を受け取るよう追加（実際の覚醒分析は#205で実装予定）

## Test plan
- [x] `make build` 成功
- [x] `make test` 全パス
- [ ] 403発生時に途中データが保存・分析されることを確認
- [ ] バックフィル時に対象日付のみスクレイプされることをログで確認