### PR TITLE
feat: 順位バッジURLをスコア順位(1-4)に変更

### DIFF
--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -29,7 +29,7 @@ type PlayerScore struct {
 	ProfileLink    string // プロフィールページURL
 	ShuffleGrade   string // シャッフル階級画像URL
 	TeamGrade      string // チーム(固定)階級画像URL
-	RankingImage   string // スコア順位バッジ画像URL
+	ScoreRanking   int    // 試合内スコア順位(1-4)
 	ShopName       string // プレイ店舗名
 }
 

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -538,7 +538,7 @@ func parseDetailPage(s *goquery.Selection, date, hour string, wins []string, sho
 	titleBadges := attrsFromSelection(s, "#panel1 img.title-plv-badge", "src")
 	profileLinks := attrsFromSelection(s, "#panel1 li.item > a.right-arrow", "href")
 	gradeImages := attrsFromSelection(s, "#panel1 img.class-img", "data-original")
-	rankingImages := attrsFromSelection(s, "#panel3 img.ranking-img", "src")
+	scoreRankings := parseScoreRankings(s)
 
 	// 試合経過タブ(panel2)からのタイムラインデータ
 	timeline := parseMatchTimeline(s)
@@ -601,10 +601,9 @@ func parseDetailPage(s *goquery.Selection, date, hour string, wins []string, sho
 		if gradeIdx+1 < len(gradeImages) {
 			teamGrade = stripQueryParam(gradeImages[gradeIdx+1])
 		}
-		// スコア順位バッジ (4位はテキスト表示のため画像がない場合あり)
-		rankingImage := ""
-		if i < len(rankingImages) {
-			rankingImage = rankingImages[i]
+		scoreRanking := 0
+		if i < len(scoreRankings) {
+			scoreRanking = scoreRankings[i]
 		}
 
 		result := model.DatedScore{
@@ -629,7 +628,7 @@ func parseDetailPage(s *goquery.Selection, date, hour string, wins []string, sho
 				ProfileLink:    profileLink,
 				ShuffleGrade:   shuffleGrade,
 				TeamGrade:      teamGrade,
-				RankingImage:   rankingImage,
+				ScoreRanking:   scoreRanking,
 				ShopName:       shopName,
 			},
 		}
@@ -675,6 +674,29 @@ func parseTeamNames(s *goquery.Selection) []string {
 		names = append(names, strings.TrimSpace(el.Text()))
 	})
 	return names
+}
+
+// parseScoreRankings はスコアタブからrank-bandクラスを読み取り、各プレイヤーの試合内順位を返す
+func parseScoreRankings(s *goquery.Selection) []int {
+	var rankings []int
+	s.Find("#panel3 li.item").Each(func(_ int, el *goquery.Selection) {
+		classes, _ := el.Attr("class")
+		rank := 0
+		for _, c := range strings.Fields(classes) {
+			switch c {
+			case "rank-band1":
+				rank = 1
+			case "rank-band2":
+				rank = 2
+			case "rank-band3":
+				rank = 3
+			case "rank-band4":
+				rank = 4
+			}
+		}
+		rankings = append(rankings, rank)
+	})
+	return rankings
 }
 
 // vis.js DataSetパーサー用の正規表現

--- a/internal/storage/csv_export.go
+++ b/internal/storage/csv_export.go
@@ -129,7 +129,7 @@ func exportAllScoresCSV(ds model.DatedScores, w io.Writer) error {
 	csvw := csv.NewWriter(w)
 	defer csvw.Flush()
 
-	header := []string{"試合日時", "プレイヤーNo.", "地域", "プレイヤー名", "勝利判定", "機体名", "機体画像URL", "スコア", "撃墜数", "被撃墜数", "与ダメージ", "被ダメージ", "EXダメージ", "ランク", "チーム名", "称号画像URL", "称号バッジURL", "プロフィールURL", "シャッフルグレード画像URL", "チームグレード画像URL", "順位バッジURL", "店舗名"}
+	header := []string{"試合日時", "プレイヤーNo.", "地域", "プレイヤー名", "勝利判定", "機体名", "機体画像URL", "スコア", "撃墜数", "被撃墜数", "与ダメージ", "被ダメージ", "EXダメージ", "ランク", "チーム名", "称号画像URL", "称号バッジURL", "プロフィールURL", "シャッフルグレード画像URL", "チームグレード画像URL", "スコア順位", "店舗名"}
 	if err := csvw.Write(header); err != nil {
 		return err
 	}
@@ -166,9 +166,14 @@ func scoreToRow(d model.DatedScore) []string {
 		d.PlayerScore.ProfileLink,
 		d.PlayerScore.ShuffleGrade,
 		d.PlayerScore.TeamGrade,
-		d.PlayerScore.RankingImage,
+		strconv.Itoa(d.PlayerScore.ScoreRanking),
 		d.PlayerScore.ShopName,
 	}
+}
+
+func atoiOrZero(s string) int {
+	v, _ := strconv.Atoi(s)
+	return v
 }
 
 // ReadAllScoresCSV は既存CSVから全レコードを読み込む。
@@ -235,7 +240,7 @@ func ReadAllScoresCSV(path string) (model.DatedScores, error) {
 				ProfileLink:    col(17),
 				ShuffleGrade:   col(18),
 				TeamGrade:      col(19),
-				RankingImage:   col(20),
+				ScoreRanking:   atoiOrZero(col(20)),
 				ShopName:       col(21),
 			},
 		})

--- a/internal/storage/csv_export_test.go
+++ b/internal/storage/csv_export_test.go
@@ -47,7 +47,7 @@ func TestScoreToRow(t *testing.T) {
 			ProfileLink:    "https://web.vsmobile.jp/exvs2ib/profile?param=abc123",
 			ShuffleGrade:   "https://example.com/grade1.png",
 			TeamGrade:      "https://example.com/grade2.png",
-			RankingImage:   "https://example.com/ranking.png",
+			ScoreRanking:   1,
 			ShopName:       "テストゲームセンター",
 		},
 	}
@@ -87,8 +87,8 @@ func TestScoreToRow(t *testing.T) {
 	if row[19] != "https://example.com/grade2.png" {
 		t.Errorf("teamGrade: got %q, want %q", row[19], "https://example.com/grade2.png")
 	}
-	if row[20] != "https://example.com/ranking.png" {
-		t.Errorf("rankingImage: got %q, want %q", row[20], "https://example.com/ranking.png")
+	if row[20] != "1" {
+		t.Errorf("scoreRanking: got %q, want %q", row[20], "1")
 	}
 	if row[21] != "テストゲームセンター" {
 		t.Errorf("shopName: got %q, want %q", row[21], "テストゲームセンター")


### PR DESCRIPTION
## Summary
- `RankingImage`(画像URL) → `ScoreRanking`(int 1-4)に変更
- `rank-band1`〜`rank-band4`のCSSクラスから順位を直接取得
- 画像URLのマッピングテーブルが不要になり、バンナムのURL変更に影響されない

## 既存データへの影響
- 旧CSVに順位バッジURLが入っている場合、`atoiOrZero`で0になる
- 直近30日分はバックフィルで正しい順位(1-4)に更新される

## Test plan
- [x] `make build` 成功
- [x] `make test` 全パス