### PR TITLE
ci: stgとprodのデプロイフローを分離

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,16 +6,8 @@ on:
     paths-ignore:
       - "infra/app/Pulumi.*.yaml"
       - ".github/workflows/deploy.yml"
+      - ".github/workflows/deploy-prod.yml"
   workflow_dispatch:
-    inputs:
-      environment:
-        description: "Target environment to update image"
-        required: true
-        default: "stg"
-        type: choice
-        options:
-          - stg
-          - prod
 
 jobs:
   check-deploy-label:
@@ -87,20 +79,12 @@ jobs:
           gcloud builds submit --tag "$IMAGE"
           echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
 
-      - name: Determine target environment
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "DEPLOY_ENV=${{ inputs.environment }}" >> "$GITHUB_ENV"
-          else
-            echo "DEPLOY_ENV=stg" >> "$GITHUB_ENV"
-          fi
-
       - name: Update Pulumi config with new image
         working-directory: infra/app
         run: |
           npm install -g @pulumi/pulumi 2>/dev/null || true
           pulumi login gs://${{ secrets.PULUMI_STATE_BUCKET }}
-          pulumi stack select "$DEPLOY_ENV"
+          pulumi stack select stg
           pulumi config set exvs-app:image "$IMAGE" --secret
         env:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
@@ -109,12 +93,13 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add infra/app/Pulumi.*.yaml
+          git add infra/app/Pulumi.stg.yaml
           if git diff --cached --quiet; then
             echo "No changes to commit"
             echo "CHANGED=false" >> "$GITHUB_ENV"
           else
-            git commit -m "ci: update $DEPLOY_ENV image to ${{ github.sha }}"
+            git commit -m "ci: update stg image to ${{ github.sha }}"
+            git pull --rebase
             git push
             echo "CHANGED=true" >> "$GITHUB_ENV"
           fi
@@ -123,6 +108,6 @@ jobs:
         if: env.CHANGED == 'true'
         run: |
           gh workflow run deploy.yml \
-            -f environment="$DEPLOY_ENV"
+            -f environment="stg"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -28,8 +28,6 @@ jobs:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
-      - uses: google-github-actions/setup-gcloud@v3
-
       - name: Get stg image and set to prod
         working-directory: infra/app
         run: |
@@ -38,6 +36,7 @@ jobs:
 
           pulumi stack select stg
           IMAGE=$(pulumi config get exvs-app:image)
+          echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
 
           pulumi stack select prod
           pulumi config set exvs-app:image "$IMAGE" --secret
@@ -46,6 +45,7 @@ jobs:
 
       - name: Commit updated Pulumi config
         run: |
+          IMAGE_TAG=$(echo "$IMAGE" | awk -F: '{print $NF}')
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add infra/app/Pulumi.prod.yaml
@@ -53,7 +53,7 @@ jobs:
             echo "No changes to commit (prod already has the same image)"
             echo "CHANGED=false" >> "$GITHUB_ENV"
           else
-            git commit -m "ci: update prod image from stg"
+            git commit -m "ci: update prod image to $IMAGE_TAG"
             git pull --rebase
             git push
             echo "CHANGED=true" >> "$GITHUB_ENV"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,68 @@
+name: Deploy to Prod
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-prod:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        working-directory: infra/app
+        run: npm ci
+
+      - id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v3
+
+      - name: Get stg image and set to prod
+        working-directory: infra/app
+        run: |
+          npm install -g @pulumi/pulumi 2>/dev/null || true
+          pulumi login gs://${{ secrets.PULUMI_STATE_BUCKET }}
+
+          pulumi stack select stg
+          IMAGE=$(pulumi config get exvs-app:image)
+
+          pulumi stack select prod
+          pulumi config set exvs-app:image "$IMAGE" --secret
+        env:
+          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+
+      - name: Commit updated Pulumi config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add infra/app/Pulumi.prod.yaml
+          if git diff --cached --quiet; then
+            echo "No changes to commit (prod already has the same image)"
+            echo "CHANGED=false" >> "$GITHUB_ENV"
+          else
+            git commit -m "ci: update prod image from stg"
+            git pull --rebase
+            git push
+            echo "CHANGED=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Trigger deploy workflow
+        if: env.CHANGED == 'true'
+        run: |
+          gh workflow run deploy.yml \
+            -f environment="prod"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,9 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 ## GitHub Actions
 
 - CI: `ci.yml`（PRのみ。Docker build, go vet, py_compile。ラベル `skip-ci` でスキップ）
-- Build: `build.yml`（mainマージ時 → イメージビルド&プッシュ → Pulumi yaml の image 更新 → コミット → deploy.yml 呼び出し。ラベル `no-deploy` でスキップ。手動実行で環境選択可）
-- Deploy: `deploy.yml`（`infra/app/Pulumi.*.yaml` 変更トリガー or build.yml からの `workflow_dispatch` → `pulumi up`）
+- Build: `build.yml`（mainマージ時 → イメージビルド&プッシュ → **stgのみ**Pulumi yaml の image 更新 → コミット → deploy.yml 呼び出し。ラベル `no-deploy` でスキップ。手動実行可）
+- Deploy to Prod: `deploy-prod.yml`（**手動実行のみ**。stgのイメージをprodに適用 → コミット → deploy.yml 呼び出し）
+- Deploy: `deploy.yml`（`infra/app/Pulumi.*.yaml` 変更トリガー or build.yml/deploy-prod.yml からの `workflow_dispatch` → `pulumi up`）
 - Infra CI: `infra-ci.yml`（infra/配下の変更時にshared + app(prod/staging)のPulumi preview）
 - MSリスト更新: `update-mslist.yml`（毎日03:00-06:00 JST、ランダムスリープ。変更時にPR自動作成）
 - **サードパーティアクションを追加・変更する際は、GitHubリポジトリのリリースページで最新メジャーバージョンを確認すること。** 古いバージョンを指定するとNode.js非推奨警告やエラーが発生する（過去に複数回発生）。


### PR DESCRIPTION
## Summary
- `build.yml` をstg専用に変更（mainマージ時は自動でstgのみデプロイ）
- `deploy-prod.yml` を新規作成（手動実行でstgのイメージをprodに適用）
- `git push` 前に `git pull --rebase` を追加して競合を防止

## 背景
stgとprodのデプロイが同一ジョブで処理されており、同時実行時に `git push` が競合してエラーになっていた（[run #25454199825](https://github.com/yuki9431/exvs-analyzer/actions/runs/25454199825)）

## prodデプロイ手順
```
gh workflow run deploy-prod.yml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)