### PR TITLE
fix: MSリスト自動更新のauto-mergeエラー修正と本番デプロイ追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,6 @@ jobs:
             echo "CHANGED=false" >> "$GITHUB_ENV"
           else
             git commit -m "ci: update stg image to ${{ github.sha }}"
-            git pull --rebase
             git push
             echo "CHANGED=true" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -54,7 +54,6 @@ jobs:
             echo "CHANGED=false" >> "$GITHUB_ENV"
           else
             git commit -m "ci: update prod image to $IMAGE_TAG"
-            git pull --rebase
             git push
             echo "CHANGED=true" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/update-mslist.yml
+++ b/.github/workflows/update-mslist.yml
@@ -63,6 +63,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_URL="${{ steps.create-pr.outputs.pr_url }}"
+          # CIがトリガーされるまで待つ
+          sleep 30
           # CIチェック（validate-mslist等）の完了を待つ
           gh pr checks "$PR_URL" --watch --fail-fast
           gh pr merge --merge "$PR_URL"
@@ -77,6 +79,6 @@ jobs:
           sleep 15
           STG_RUN_ID=$(gh run list --workflow=build.yml --branch=main --limit=1 --json databaseId --jq '.[0].databaseId')
           if [ -n "$STG_RUN_ID" ]; then
-            gh run watch "$STG_RUN_ID" --exit-status || true
+            gh run watch "$STG_RUN_ID" --exit-status
           fi
           gh workflow run deploy-prod.yml

--- a/.github/workflows/update-mslist.yml
+++ b/.github/workflows/update-mslist.yml
@@ -63,9 +63,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_URL="${{ steps.create-pr.outputs.pr_url }}"
-          # CIがトリガーされるまで待つ
-          sleep 30
-          # CIチェック（validate-mslist等）の完了を待つ
+          # CIチェックが登録されるまでポーリング（最大5分）
+          for i in $(seq 1 30); do
+            if gh pr checks "$PR_URL" 2>/dev/null | grep -q .; then
+              echo "CI checks detected"
+              break
+            fi
+            echo "Waiting for CI checks to be registered... ($i/30)"
+            sleep 10
+          done
+          # CIチェックの完了を待つ
           gh pr checks "$PR_URL" --watch --fail-fast
           gh pr merge --merge "$PR_URL"
 
@@ -76,9 +83,19 @@ jobs:
         run: |
           # push to main で stg build（build.yml）は自動トリガーされる
           # stg build 完了を待ってから deploy-prod.yml で本番昇格
-          sleep 15
-          STG_RUN_ID=$(gh run list --workflow=build.yml --branch=main --limit=1 --json databaseId --jq '.[0].databaseId')
-          if [ -n "$STG_RUN_ID" ]; then
-            gh run watch "$STG_RUN_ID" --exit-status
+          MERGE_SHA=$(gh pr view "${{ steps.create-pr.outputs.pr_url }}" --json mergeCommit --jq '.mergeCommit.oid')
+          for i in $(seq 1 30); do
+            STG_RUN_ID=$(gh run list --workflow=build.yml --branch=main --commit="$MERGE_SHA" --limit=1 --json databaseId --jq '.[0].databaseId' 2>/dev/null)
+            if [ -n "$STG_RUN_ID" ] && [ "$STG_RUN_ID" != "null" ]; then
+              echo "stg build detected: $STG_RUN_ID"
+              break
+            fi
+            echo "Waiting for stg build to start... ($i/30)"
+            sleep 10
+          done
+          if [ -z "$STG_RUN_ID" ] || [ "$STG_RUN_ID" = "null" ]; then
+            echo "::error::stg build not found"
+            exit 1
           fi
+          gh run watch "$STG_RUN_ID" --exit-status
           gh workflow run deploy-prod.yml

--- a/.github/workflows/update-mslist.yml
+++ b/.github/workflows/update-mslist.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
 
     steps:
       - name: Random delay (0-180 min)
@@ -56,8 +57,26 @@ jobs:
             --body "GitHub Actionsによる自動更新です。CIのバリデーション通過後に自動マージされます。")
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
 
-      - name: Enable auto-merge
+      - name: Wait for checks and merge
         if: steps.create-pr.outputs.pr_url
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --auto --merge "${{ steps.create-pr.outputs.pr_url }}"
+        run: |
+          PR_URL="${{ steps.create-pr.outputs.pr_url }}"
+          # CIチェック（validate-mslist等）の完了を待つ
+          gh pr checks "$PR_URL" --watch --fail-fast
+          gh pr merge --merge "$PR_URL"
+
+      - name: Trigger prod deploy
+        if: steps.create-pr.outputs.pr_url
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # push to main で stg build は自動トリガーされる
+          # stg の build 完了を待ってから prod をトリガー（git push 競合を防止）
+          sleep 15
+          STG_RUN_ID=$(gh run list --workflow=build.yml --branch=main --limit=1 --json databaseId --jq '.[0].databaseId')
+          if [ -n "$STG_RUN_ID" ]; then
+            gh run watch "$STG_RUN_ID" --exit-status || true
+          fi
+          gh workflow run build.yml -f environment=prod

--- a/.github/workflows/update-mslist.yml
+++ b/.github/workflows/update-mslist.yml
@@ -64,14 +64,20 @@ jobs:
         run: |
           PR_URL="${{ steps.create-pr.outputs.pr_url }}"
           # CIチェックが登録されるまでポーリング（最大5分）
+          CI_DETECTED=false
           for i in $(seq 1 30); do
             if gh pr checks "$PR_URL" 2>/dev/null | grep -q .; then
               echo "CI checks detected"
+              CI_DETECTED=true
               break
             fi
             echo "Waiting for CI checks to be registered... ($i/30)"
             sleep 10
           done
+          if [ "$CI_DETECTED" = "false" ]; then
+            echo "::error::CI checks not detected after 5 minutes"
+            exit 1
+          fi
           # CIチェックの完了を待つ
           gh pr checks "$PR_URL" --watch --fail-fast
           gh pr merge --merge "$PR_URL"

--- a/.github/workflows/update-mslist.yml
+++ b/.github/workflows/update-mslist.yml
@@ -72,11 +72,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # push to main で stg build は自動トリガーされる
-          # stg の build 完了を待ってから prod をトリガー（git push 競合を防止）
+          # push to main で stg build（build.yml）は自動トリガーされる
+          # stg build 完了を待ってから deploy-prod.yml で本番昇格
           sleep 15
           STG_RUN_ID=$(gh run list --workflow=build.yml --branch=main --limit=1 --json databaseId --jq '.[0].databaseId')
           if [ -n "$STG_RUN_ID" ]; then
             gh run watch "$STG_RUN_ID" --exit-status || true
           fi
-          gh workflow run build.yml -f environment=prod
+          gh workflow run deploy-prod.yml


### PR DESCRIPTION
## Summary
- `gh pr merge --auto` がrequired status checks未設定で失敗する問題を修正（CIチェック完了待ち→直接マージに変更）
- MSリスト更新時にstg/prod両方へ自動デプロイされるようにした（deploy-prod.yml経由）
- build.yml/deploy-prod.ymlから不要な`git pull --rebase`を削除

## Test plan
- [ ] update-mslist.yml を手動実行して、PR作成→CI待ち→マージ→stg build→prod buildの一連のフローを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)