### PR TITLE
FirestoreデータベースIDをexvs-analyzerに変更

### DIFF
--- a/infra/shared/firestore.ts
+++ b/infra/shared/firestore.ts
@@ -5,7 +5,7 @@ import { services } from "./apis";
 export const firestoreDb = new gcp.firestore.Database(
   "firestore-db",
   {
-    name: "(default)",
+    name: "exvs-analyzer",
     locationId: gcp.config.region!,
     type: "FIRESTORE_NATIVE",
   },


### PR DESCRIPTION
## Summary
- FirestoreデータベースIDを`(default)`から`exvs-analyzer`に変更

ref #220
depends on #221

## Test plan
- [x] `pulumi preview`でデータベース名が`exvs-analyzer`になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)