### PR TITLE
feat: GCS既存データをFirestoreに移行するCLIツール

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,8 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 
 - `cmd/server/main.go` — エントリポイント。`internal/server.StartServer()` に委譲
 - `cmd/update-mslist/main.go` — MSリストをスクレイピングして `data/ms_list.json` を更新するCLI
-- `internal/model/` — 型定義のみ（`PlayerScore`, `DatedScore`, `MSInfo`, `AverageScore`, `MatchEvent`, `MatchTimeline`）
+- `cmd/migrate-to-firestore/main.go` — GCS既存データをFirestoreに移行するワンショットCLI
+- `internal/model/` — 型定義のみ（`PlayerScore`, `DatedScore`, `MSInfo`, `MatchEvent`, `MatchTimeline`, `TagPartner`, `JobStatus`, `JobSnapshot`）
 - `internal/mslist/` — MSリストの読み書き・マージ（`LoadMSList`, `SaveMSList`, `MergeMSList`, `BuildMSNameMap`, `FillMsNames`, `CheckUnknownMS`）
 - `internal/gradelist/` — グレードリストの読み込み・未知URL検出（`LoadGradeList`, `BuildGradeMap`, `CheckUnknownGrades`）
 - `internal/scraper/` — Collyベースのスクレイパー（`scraper.go`）+ バンダイナムコID認証（`login.go`）

--- a/cmd/migrate-to-firestore/main.go
+++ b/cmd/migrate-to-firestore/main.go
@@ -64,12 +64,13 @@ func migrateUser(userKey, tmpDir string) error {
 	// scores.csv → Firestore scores
 	csvPath := filepath.Join(userDir, "scores.csv")
 	if found, err := storage.DownloadCSVByKey(userKey, csvPath); err != nil {
-		log.Printf("[WARN] User %s: failed to download CSV: %v", userKey, err)
+		return fmt.Errorf("download CSV: %w", err)
 	} else if found {
 		scores, err := storage.ReadAllScoresCSV(csvPath)
 		if err != nil {
-			log.Printf("[WARN] User %s: failed to parse CSV: %v", userKey, err)
-		} else if len(scores) > 0 {
+			return fmt.Errorf("parse CSV: %w", err)
+		}
+		if len(scores) > 0 {
 			fs.SaveScores(userKey, scores)
 		}
 	}

--- a/cmd/migrate-to-firestore/main.go
+++ b/cmd/migrate-to-firestore/main.go
@@ -22,7 +22,7 @@ func main() {
 		log.Fatal("GCS_BUCKET environment variable is required")
 	}
 
-	if err := fs.Init(context.Background(), projectID); err != nil {
+	if err := fs.InitWithProjectID(context.Background(), projectID); err != nil {
 		log.Fatalf("Failed to initialize Firestore: %v", err)
 	}
 	defer fs.Close()

--- a/cmd/migrate-to-firestore/main.go
+++ b/cmd/migrate-to-firestore/main.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	fs "github.com/yuki9431/exvs-analyzer/internal/firestore"
+	"github.com/yuki9431/exvs-analyzer/internal/model"
+	"github.com/yuki9431/exvs-analyzer/internal/storage"
+)
+
+func main() {
+	projectID := os.Getenv("GCP_PROJECT")
+	if projectID == "" {
+		log.Fatal("GCP_PROJECT environment variable is required")
+	}
+	if storage.BucketName == "" {
+		log.Fatal("GCS_BUCKET environment variable is required")
+	}
+
+	if err := fs.Init(context.Background(), projectID); err != nil {
+		log.Fatalf("Failed to initialize Firestore: %v", err)
+	}
+	defer fs.Close()
+
+	// GCSから全ユーザーキーを取得
+	userKeys, err := storage.ListUserKeys()
+	if err != nil {
+		log.Fatalf("Failed to list user keys: %v", err)
+	}
+	log.Printf("[INFO] Found %d users to migrate", len(userKeys))
+
+	tmpDir, err := os.MkdirTemp("", "exvs-migrate-*")
+	if err != nil {
+		log.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	var succeeded, failed int
+	for i, userKey := range userKeys {
+		log.Printf("[INFO] Migrating user %d/%d: %s", i+1, len(userKeys), userKey)
+		if err := migrateUser(userKey, tmpDir); err != nil {
+			log.Printf("[ERROR] Failed to migrate user %s: %v", userKey, err)
+			failed++
+		} else {
+			succeeded++
+		}
+	}
+
+	log.Printf("[INFO] Migration complete: %d succeeded, %d failed, %d total", succeeded, failed, len(userKeys))
+}
+
+func migrateUser(userKey, tmpDir string) error {
+	userDir := filepath.Join(tmpDir, userKey)
+	if err := os.MkdirAll(userDir, 0755); err != nil {
+		return fmt.Errorf("create user dir: %w", err)
+	}
+	defer os.RemoveAll(userDir)
+
+	// scores.csv → Firestore scores
+	csvPath := filepath.Join(userDir, "scores.csv")
+	if found, err := storage.DownloadCSVByKey(userKey, csvPath); err != nil {
+		log.Printf("[WARN] User %s: failed to download CSV: %v", userKey, err)
+	} else if found {
+		scores, err := storage.ReadAllScoresCSV(csvPath)
+		if err != nil {
+			log.Printf("[WARN] User %s: failed to parse CSV: %v", userKey, err)
+		} else if len(scores) > 0 {
+			fs.SaveScores(userKey, scores)
+		}
+	}
+
+	// timelines.json → Firestore timelines
+	timelinesPath := filepath.Join(userDir, "timelines.json")
+	if found, err := downloadByKey(userKey, "timelines.json", timelinesPath); err != nil {
+		log.Printf("[WARN] User %s: failed to download timelines: %v", userKey, err)
+	} else if found {
+		var entries []fs.TimelineEntry
+		data, err := os.ReadFile(timelinesPath)
+		if err == nil {
+			if err := json.Unmarshal(data, &entries); err != nil {
+				log.Printf("[WARN] User %s: failed to parse timelines: %v", userKey, err)
+			} else if len(entries) > 0 {
+				fs.SaveTimelineEntries(userKey, entries)
+			}
+		}
+	}
+
+	// tag_partners.json → Firestore tag_partners
+	tagPartnersPath := filepath.Join(userDir, "tag_partners.json")
+	if found, err := downloadByKey(userKey, "tag_partners.json", tagPartnersPath); err != nil {
+		log.Printf("[WARN] User %s: failed to download tag partners: %v", userKey, err)
+	} else if found {
+		type tagPartnerJSON struct {
+			TeamName   string `json:"team_name"`
+			PlayerName string `json:"player_name"`
+		}
+		var raw []tagPartnerJSON
+		data, err := os.ReadFile(tagPartnersPath)
+		if err == nil {
+			if err := json.Unmarshal(data, &raw); err != nil {
+				log.Printf("[WARN] User %s: failed to parse tag partners: %v", userKey, err)
+			} else if len(raw) > 0 {
+				partners := make([]model.TagPartner, len(raw))
+				for i, r := range raw {
+					partners[i] = model.TagPartner{TeamName: r.TeamName, PlayerName: r.PlayerName}
+				}
+				fs.SaveTagPartners(userKey, partners)
+			}
+		}
+	}
+
+	return nil
+}
+
+// downloadByKey はuserKeyを使ってGCSからファイルをダウンロードする
+func downloadByKey(userKey, filename, localPath string) (bool, error) {
+	objPath := fmt.Sprintf("users/%s/%s", userKey, filename)
+	return storage.DownloadByObjectPath(objPath, localPath)
+}

--- a/internal/firestore/client.go
+++ b/internal/firestore/client.go
@@ -21,16 +21,25 @@ var (
 
 // Init はFirestoreクライアントを初期化する。
 // 環境変数 FIRESTORE_DATABASE でデータベースIDを指定する。
-// プロジェクトIDはCloud Run上では自動検出される。
+// プロジェクトIDはCloud Runのメタデータサーバーから自動検出される。
 func Init(ctx context.Context) error {
-	dbID := os.Getenv("FIRESTORE_DATABASE")
-	if dbID == "" {
-		return fmt.Errorf("FIRESTORE_DATABASE environment variable is required")
-	}
-
 	projectID, err := metadata.ProjectIDWithContext(ctx)
 	if err != nil {
 		return fmt.Errorf("detect project ID: %w", err)
+	}
+	return initClient(ctx, projectID)
+}
+
+// InitWithProjectID はプロジェクトIDを指定してFirestoreクライアントを初期化する。
+// メタデータサーバーが利用できないローカル環境やCLIツールから使用する。
+func InitWithProjectID(ctx context.Context, projectID string) error {
+	return initClient(ctx, projectID)
+}
+
+func initClient(ctx context.Context, projectID string) error {
+	dbID := os.Getenv("FIRESTORE_DATABASE")
+	if dbID == "" {
+		return fmt.Errorf("FIRESTORE_DATABASE environment variable is required")
 	}
 
 	c, err := firestore.NewClientWithDatabase(ctx, projectID, dbID)

--- a/internal/firestore/timelines.go
+++ b/internal/firestore/timelines.go
@@ -89,6 +89,72 @@ func SaveTimelines(userKey string, scores model.DatedScores) {
 	log.Printf("[INFO] Firestore: saved %d timelines for user %s", len(docs), userKey)
 }
 
+// TimelineEntry はGCS timelines.jsonのエントリ（移行ツール用）
+type TimelineEntry struct {
+	Datetime string              `json:"datetime"`
+	Timeline *model.MatchTimeline `json:"timeline"`
+}
+
+// SaveTimelineEntries はtimelines.jsonのエントリをFirestoreに書き込む。
+func SaveTimelineEntries(userKey string, entries []TimelineEntry) {
+	c := getClient()
+	if c == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	userRef := c.Collection("users").Doc(userKey)
+	timelinesCol := userRef.Collection("timelines")
+
+	const batchLimit = 500
+	var docs []struct {
+		id  string
+		doc timelineDoc
+	}
+
+	for _, e := range entries {
+		if e.Timeline == nil {
+			continue
+		}
+		dt, err := time.Parse("2006-01-02 15:04", e.Datetime)
+		if err != nil {
+			continue
+		}
+		docID := dt.Format("2006-01-02T1504")
+		doc := toTimelineDoc(dt, e.Timeline)
+		docs = append(docs, struct {
+			id  string
+			doc timelineDoc
+		}{docID, doc})
+	}
+
+	if len(docs) == 0 {
+		return
+	}
+
+	for i := 0; i < len(docs); i += batchLimit {
+		end := i + batchLimit
+		if end > len(docs) {
+			end = len(docs)
+		}
+
+		batch := c.Batch()
+		for _, d := range docs[i:end] {
+			ref := timelinesCol.Doc(d.id)
+			batch.Set(ref, d.doc)
+		}
+
+		if _, err := batch.Commit(ctx); err != nil {
+			log.Printf("[WARN] Firestore: failed to save timeline entries batch (%d-%d of %d, partial write): %v", i, end, len(docs), err)
+			return
+		}
+	}
+
+	log.Printf("[INFO] Firestore: saved %d timeline entries for user %s", len(docs), userKey)
+}
+
 // toTimelineDoc はMatchTimelineをFirestoreドキュメント用の構造体に変換する。
 // Events内のgroupをプレイヤー番号(1-4)に変換し、playersマップにまとめる。
 func toTimelineDoc(datetime time.Time, mt *model.MatchTimeline) timelineDoc {

--- a/internal/storage/cloud_storage.go
+++ b/internal/storage/cloud_storage.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
 )
 
 // BucketName は環境変数 GCS_BUCKET から取得するCloud Storageのバケット名
@@ -173,4 +175,44 @@ func UploadTimeline(username, localPath string) error {
 	}
 	log.Printf("[INFO] Uploaded timelines to GCS")
 	return nil
+}
+
+// DownloadByObjectPath はGCSオブジェクトパスを直接指定してダウンロードする
+func DownloadByObjectPath(objPath, localPath string) (bool, error) {
+	return downloadObject(objPath, localPath)
+}
+
+// ListUserKeys はGCSバケットの users/ 配下からユーザーキー一覧を取得する
+func ListUserKeys() ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create storage client: %w", err)
+	}
+	defer client.Close()
+
+	seen := make(map[string]bool)
+	it := client.Bucket(BucketName).Objects(ctx, &storage.Query{Prefix: "users/"})
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to list objects: %w", err)
+		}
+		// "users/{userKey}/scores.csv" → userKey を抽出
+		parts := strings.SplitN(attrs.Name, "/", 3)
+		if len(parts) >= 2 && parts[1] != "" {
+			seen[parts[1]] = true
+		}
+	}
+
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	return keys, nil
 }


### PR DESCRIPTION
## Summary
- `cmd/migrate-to-firestore/` を新規作成（ワンショット移行CLIツール）
- GCSバケットから全ユーザーキーを列挙し、scores.csv / timelines.json / tag_partners.json をFirestoreに移行
- `storage.ListUserKeys()`, `storage.DownloadByObjectPath()` を追加
- `firestore.SaveTimelineEntries()` を追加（JSON形式のタイムライン移行用）

## 実行方法

```bash
docker run --rm \
  -v $(pwd):/app -w /app \
  -e GCP_PROJECT=<project-id> \
  -e GCS_BUCKET=<bucket-name> \
  -e FIRESTORE_DATABASE=exvs-analyzer \
  -v /path/to/credentials.json:/creds.json \
  -e GOOGLE_APPLICATION_CREDENTIALS=/creds.json \
  golang:1.26-alpine \
  go run ./cmd/migrate-to-firestore/
```

## Test plan
- [x] `make test` 全テストパス
- [x] `go build ./cmd/migrate-to-firestore/` ビルド成功
- [ ] ステージング環境のGCSデータでFirestoreへの移行が正常に行われること

Closes #227