### PR TITLE
fix: Cloud RunにGCP_PROJECT環境変数を追加してFirestoreを有効化

### DIFF
--- a/infra/app/index.ts
+++ b/infra/app/index.ts
@@ -36,6 +36,10 @@ export const service = new gcp.cloudrunv2.Service(
               name: "GCS_BUCKET",
               value: gcsBucket,
             },
+            {
+              name: "GCP_PROJECT",
+              value: gcp.config.project!,
+            },
           ],
           resources: {
             cpuIdle: true,


### PR DESCRIPTION
## Summary
- Cloud RunサービスのコンテナにGCP_PROJECT環境変数を追加
- これにより`StartServer()`内のFirestore初期化が有効になる

## 背景
#226 でFirestore二重書き込みを統合したが、Cloud RunにGCP_PROJECT環境変数が設定されていないため、Firestoreが無効のままだった。

## Test plan
- [ ] `pulumi preview` で環境変数追加が確認できること
- [ ] デプロイ後、Cloud Runのログに `Firestore client initialized` が出力されること