### PR TITLE
fix: deploy.ymlのjq出力をコンパクトモードに修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,10 +39,10 @@ jobs:
           CHANGED=$(git diff --name-only HEAD~1 HEAD -- infra/app/Pulumi.*.yaml || echo "")
 
           if echo "$CHANGED" | grep -q "Pulumi.stg.yaml"; then
-            ENVS=$(echo "$ENVS" | jq '. + ["stg"]')
+            ENVS=$(echo "$ENVS" | jq -c '. + ["stg"]')
           fi
           if echo "$CHANGED" | grep -q "Pulumi.prod.yaml"; then
-            ENVS=$(echo "$ENVS" | jq '. + ["prod"]')
+            ENVS=$(echo "$ENVS" | jq -c '. + ["prod"]')
           fi
 
           echo "environments=$ENVS" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- `deploy.yml` の環境検出ステップで `jq` → `jq -c` に変更
- 複数環境（stg + prod）が同時に検出された場合、jqの複数行JSON出力が `GITHUB_OUTPUT` でパースエラーになる問題を修正

## 背景
#229 のマージで `Pulumi.stg.yaml` と `Pulumi.prod.yaml` の両方が変更され、deploy.yml がトリガーされたが、jq出力が複数行になり `Invalid format` エラーで失敗した。
https://github.com/yuki9431/exvs-analyzer/actions/runs/25613030853

## Test plan
- [ ] stgとprodの両方のPulumi yamlを変更するPRをマージし、デプロイが正常に実行されること