### PR TITLE
fix: メタデータサーバーからFirestoreのプロジェクトIDを取得

### DIFF
--- a/internal/firestore/client.go
+++ b/internal/firestore/client.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/firestore"
 )
 
@@ -27,7 +28,12 @@ func Init(ctx context.Context) error {
 		return fmt.Errorf("FIRESTORE_DATABASE environment variable is required")
 	}
 
-	c, err := firestore.NewClientWithDatabase(ctx, "", dbID)
+	projectID, err := metadata.ProjectIDWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("detect project ID: %w", err)
+	}
+
+	c, err := firestore.NewClientWithDatabase(ctx, projectID, dbID)
 	if err != nil {
 		return fmt.Errorf("firestore client init: %w", err)
 	}
@@ -36,7 +42,7 @@ func Init(ctx context.Context) error {
 	client = c
 	clientMu.Unlock()
 
-	log.Printf("[INFO] Firestore client initialized (database: %s)", dbID)
+	log.Printf("[INFO] Firestore client initialized (project: %s, database: %s)", projectID, dbID)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- `firestore.NewClientWithDatabase` に空文字を渡してもプロジェクトIDが自動検出されない問題を修正
- `cloud.google.com/go/compute/metadata` を使用してCloud RunのメタデータサーバーからプロジェクトIDを取得

## 背景
#230 で空文字によるプロジェクトID自動検出を試みたが、Firestoreクライアントは空文字を受け付けず `projectID was empty` エラーになった。

## Test plan
- [x] `make test` 全テストパス
- [x] `make build` ビルド成功
- [ ] デプロイ後、Cloud Runのログに `Firestore client initialized (project: ..., database: ...)` が出力されること