### PR TITLE
feat: 分析パイプラインの入力元をGCS CSVからFirestoreに変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,10 +56,11 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 
 ```
 ブラウザ → POST /analyze → ジョブ作成（pending）
-  → GCSから既存CSVをダウンロード
+  → Firestoreから既存scoresを読み取り → 速報レポート生成
   → Collyで新規戦績をスクレイピング（状態: scraping）
-  → CSVをマージし、data/ms_list.jsonからMS名・コストを補完
-  → CSVをGCSにアップロード
+  → data/ms_list.jsonからMS名・コストを補完
+  → Firestoreにscores/timelines/tag_partners書き込み
+  → Firestoreから全scores読み取り → CSV生成 → GCSにアップロード（二重書き込み）
   → scripts/analyze.py でCSVを分析（状態: analyzing）
   → JSONレポートを返却（状態: done）
 クライアントは GET /status/{id} でポーリング後、GET /result/{id} で結果取得
@@ -76,7 +77,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 - `internal/mslist/` — MSリストの読み書き・マージ（`LoadMSList`, `SaveMSList`, `MergeMSList`, `BuildMSNameMap`, `FillMsNames`, `CheckUnknownMS`）
 - `internal/gradelist/` — グレードリストの読み込み・未知URL検出（`LoadGradeList`, `BuildGradeMap`, `CheckUnknownGrades`）
 - `internal/scraper/` — Collyベースのスクレイパー（`scraper.go`）+ バンダイナムコID認証（`login.go`）
-- `internal/firestore/` — Firestoreクライアント初期化（`client.go`）+ scores/timelines/tag_partners書き込み
+- `internal/firestore/` — Firestoreクライアント初期化（`client.go`）+ scores/timelines/tag_partnersの読み書き
 - `internal/pipeline/` — 分析パイプライン（`Job`型、ジョブストア、`Run`関数）
 - `internal/server/` — HTTPハンドラ（`server.go`）+ IPベースレート制限（`ratelimit.go`）+ Basic認証（`basicauth.go`）+ 403一時ブロック（`block403.go`）
 - `internal/storage/` — CSV読み書き（`csv_export.go`）+ GCSアップロード/ダウンロード（`cloud_storage.go`）

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@
 | `internal/mslist/` | MSリストの読み書き・マージ |
 | `internal/gradelist/` | グレードリストの読み込み・未知URL検出 |
 | `internal/scraper/` | スクレイピング・ログイン処理 |
-| `internal/firestore/` | Firestoreクライアント・データ書き込み |
+| `internal/firestore/` | Firestoreクライアント・データの読み書き |
 | `internal/pipeline/` | 分析パイプライン（ジョブ管理・実行） |
 | `internal/server/` | HTTPハンドラ・レート制限・Basic認証・403ブロック |
 | `internal/storage/` | CSV・Cloud Storageの読み書き |

--- a/internal/firestore/scores.go
+++ b/internal/firestore/scores.go
@@ -84,6 +84,9 @@ func SaveScores(userKey string, scores model.DatedScores) {
 	log.Printf("[INFO] Firestore: saved %d scores for user %s", len(scores), userKey)
 }
 
+// loadScoresTimeout はLoadScores用のタイムアウト（全量読み取りのため長めに設定）
+const loadScoresTimeout = 120 * time.Second
+
 // LoadScores はFirestoreからユーザーの全scoresを読み取り、datetime昇順で返す。
 func LoadScores(userKey string) (model.DatedScores, error) {
 	c := getClient()
@@ -91,7 +94,7 @@ func LoadScores(userKey string) (model.DatedScores, error) {
 		return nil, fmt.Errorf("firestore client not initialized")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), loadScoresTimeout)
 	defer cancel()
 
 	userRef := c.Collection("users").Doc(userKey)
@@ -138,36 +141,6 @@ func GetLatestDatetime(userKey string) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("parse latest score: %w", err)
 	}
 	return sd.Datetime, nil
-}
-
-// NeedsBackfill は直近30日以内のscoresにms_proficiencyが空のドキュメントがあるか判定する。
-func NeedsBackfill(userKey string) bool {
-	c := getClient()
-	if c == nil {
-		return false
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
-
-	cutoff := time.Now().AddDate(0, 0, -30)
-	userRef := c.Collection("users").Doc(userKey)
-	docs, err := userRef.Collection("scores").Where("datetime", ">=", cutoff).Documents(ctx).GetAll()
-	if err != nil {
-		log.Printf("[WARN] Firestore: failed to check backfill: %v", err)
-		return false
-	}
-
-	for _, doc := range docs {
-		var sd scoreDoc
-		if err := doc.DataTo(&sd); err != nil {
-			continue
-		}
-		if sd.MsProficiency == "" {
-			return true
-		}
-	}
-	return false
 }
 
 // BackfillDates は直近30日以内でms_proficiencyが空のscoresの日付セットを返す。

--- a/internal/firestore/scores.go
+++ b/internal/firestore/scores.go
@@ -84,6 +84,155 @@ func SaveScores(userKey string, scores model.DatedScores) {
 	log.Printf("[INFO] Firestore: saved %d scores for user %s", len(scores), userKey)
 }
 
+// LoadScores はFirestoreからユーザーの全scoresを読み取り、datetime昇順で返す。
+func LoadScores(userKey string) (model.DatedScores, error) {
+	c := getClient()
+	if c == nil {
+		return nil, fmt.Errorf("firestore client not initialized")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	userRef := c.Collection("users").Doc(userKey)
+	docs, err := userRef.Collection("scores").OrderBy("datetime", firestore.Asc).Documents(ctx).GetAll()
+	if err != nil {
+		return nil, fmt.Errorf("query scores: %w", err)
+	}
+
+	scores := make(model.DatedScores, 0, len(docs))
+	for _, doc := range docs {
+		var sd scoreDoc
+		if err := doc.DataTo(&sd); err != nil {
+			log.Printf("[WARN] Firestore: failed to parse score doc %s: %v", doc.Ref.ID, err)
+			continue
+		}
+		scores = append(scores, fromScoreDoc(sd))
+	}
+
+	return scores, nil
+}
+
+// GetLatestDatetime はFirestoreからユーザーの最新試合日時を取得する。
+// データがない場合はゼロ値のtimeを返す。
+func GetLatestDatetime(userKey string) (time.Time, error) {
+	c := getClient()
+	if c == nil {
+		return time.Time{}, fmt.Errorf("firestore client not initialized")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	userRef := c.Collection("users").Doc(userKey)
+	docs, err := userRef.Collection("scores").OrderBy("datetime", firestore.Desc).Limit(1).Documents(ctx).GetAll()
+	if err != nil {
+		return time.Time{}, fmt.Errorf("query latest datetime: %w", err)
+	}
+	if len(docs) == 0 {
+		return time.Time{}, nil
+	}
+
+	var sd scoreDoc
+	if err := docs[0].DataTo(&sd); err != nil {
+		return time.Time{}, fmt.Errorf("parse latest score: %w", err)
+	}
+	return sd.Datetime, nil
+}
+
+// NeedsBackfill は直近30日以内のscoresにms_proficiencyが空のドキュメントがあるか判定する。
+func NeedsBackfill(userKey string) bool {
+	c := getClient()
+	if c == nil {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	cutoff := time.Now().AddDate(0, 0, -30)
+	userRef := c.Collection("users").Doc(userKey)
+	docs, err := userRef.Collection("scores").Where("datetime", ">=", cutoff).Documents(ctx).GetAll()
+	if err != nil {
+		log.Printf("[WARN] Firestore: failed to check backfill: %v", err)
+		return false
+	}
+
+	for _, doc := range docs {
+		var sd scoreDoc
+		if err := doc.DataTo(&sd); err != nil {
+			continue
+		}
+		if sd.MsProficiency == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// BackfillDates は直近30日以内でms_proficiencyが空のscoresの日付セットを返す。
+// 日付は "2006/01/02" 形式（スクレイパーのdailyLink.dateと同じ形式）。
+func BackfillDates(userKey string) map[string]bool {
+	dates := make(map[string]bool)
+
+	c := getClient()
+	if c == nil {
+		return dates
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	cutoff := time.Now().AddDate(0, 0, -30)
+	userRef := c.Collection("users").Doc(userKey)
+	docs, err := userRef.Collection("scores").Where("datetime", ">=", cutoff).Documents(ctx).GetAll()
+	if err != nil {
+		log.Printf("[WARN] Firestore: failed to get backfill dates: %v", err)
+		return dates
+	}
+
+	for _, doc := range docs {
+		var sd scoreDoc
+		if err := doc.DataTo(&sd); err != nil {
+			continue
+		}
+		if sd.MsProficiency == "" {
+			dates[sd.Datetime.Format("2006/01/02")] = true
+		}
+	}
+	return dates
+}
+
+// fromScoreDoc はFirestoreドキュメントをDatedScoreに変換する。
+func fromScoreDoc(sd scoreDoc) model.DatedScore {
+	return model.DatedScore{
+		PlayerNo: sd.PlayerNo,
+		Datetime: sd.Datetime,
+		PlayerScore: model.PlayerScore{
+			City:            sd.City,
+			Name:            sd.Name,
+			Win:             sd.Win,
+			MsName:          sd.MsName,
+			MsImageURL:      sd.MsImageURL,
+			Score:           sd.Score,
+			Kills:           sd.Kills,
+			Deaths:          sd.Deaths,
+			GiveDamage:      sd.GiveDamage,
+			ReceiveDamage:   sd.ReceiveDamage,
+			ExDamage:        sd.ExDamage,
+			MsProficiency:   sd.MsProficiency,
+			TeamName:        sd.TeamName,
+			PlayerLevelURL:  sd.PlayerLevelURL,
+			RankBadgeURL:    sd.RankBadgeURL,
+			ProfileURL:      sd.ProfileURL,
+			ShuffleGradeURL: sd.ShuffleGradeURL,
+			TeamGradeURL:    sd.TeamGradeURL,
+			ScoreRanking:    sd.ScoreRanking,
+			ArcadeName:      sd.ArcadeName,
+		},
+	}
+}
+
 // scoreDocID はscoresドキュメントのIDを生成する（{datetime}_{playerNo}）
 func scoreDocID(s model.DatedScore) string {
 	return fmt.Sprintf("%s_%d", s.Datetime.Format("2006-01-02T1504"), s.PlayerNo)

--- a/internal/firestore/tag_partners.go
+++ b/internal/firestore/tag_partners.go
@@ -15,6 +15,38 @@ type tagPartnerDoc struct {
 	PlayerName string `firestore:"player_name"`
 }
 
+// LoadTagPartners はFirestoreからユーザーのタッグ相方情報を読み取る。
+func LoadTagPartners(userKey string) ([]model.TagPartner, error) {
+	c := getClient()
+	if c == nil {
+		return nil, fmt.Errorf("firestore client not initialized")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	userRef := c.Collection("users").Doc(userKey)
+	docs, err := userRef.Collection("tag_partners").Documents(ctx).GetAll()
+	if err != nil {
+		return nil, fmt.Errorf("query tag partners: %w", err)
+	}
+
+	partners := make([]model.TagPartner, 0, len(docs))
+	for _, doc := range docs {
+		var td tagPartnerDoc
+		if err := doc.DataTo(&td); err != nil {
+			log.Printf("[WARN] Firestore: failed to parse tag partner doc %s: %v", doc.Ref.ID, err)
+			continue
+		}
+		partners = append(partners, model.TagPartner{
+			TeamName:   td.TeamName,
+			PlayerName: td.PlayerName,
+		})
+	}
+
+	return partners, nil
+}
+
 // SaveTagPartners はタッグ相方情報をFirestoreのtag_partnersサブコレクションに書き込む。
 func SaveTagPartners(userKey string, partners []model.TagPartner) {
 	c := getClient()

--- a/internal/firestore/timelines.go
+++ b/internal/firestore/timelines.go
@@ -2,10 +2,12 @@ package firestore
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"time"
 
+	"cloud.google.com/go/firestore"
 	"github.com/yuki9431/exvs-analyzer/internal/model"
 )
 
@@ -31,6 +33,95 @@ type actionDoc struct {
 	Action        string  `firestore:"action"`
 	ActionStartSec float64 `firestore:"action_start_sec"`
 	ActionEndSec  float64 `firestore:"action_end_sec"`
+}
+
+// LoadTimelines はFirestoreからユーザーのタイムラインデータを読み取り、TimelineEntryのスライスで返す。
+func LoadTimelines(userKey string) ([]TimelineEntry, error) {
+	c := getClient()
+	if c == nil {
+		return nil, fmt.Errorf("firestore client not initialized")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	userRef := c.Collection("users").Doc(userKey)
+	docs, err := userRef.Collection("timelines").OrderBy("datetime", firestore.Asc).Documents(ctx).GetAll()
+	if err != nil {
+		return nil, fmt.Errorf("query timelines: %w", err)
+	}
+
+	entries := make([]TimelineEntry, 0, len(docs))
+	for _, doc := range docs {
+		var td timelineDoc
+		if err := doc.DataTo(&td); err != nil {
+			log.Printf("[WARN] Firestore: failed to parse timeline doc %s: %v", doc.Ref.ID, err)
+			continue
+		}
+		entries = append(entries, fromTimelineDoc(td))
+	}
+
+	return entries, nil
+}
+
+// fromTimelineDoc はFirestoreドキュメントをTimelineEntryに変換する。
+func fromTimelineDoc(td timelineDoc) TimelineEntry {
+	// Firestoreのplayers mapをMatchTimelineのEvents形式に戻す
+	var events []model.MatchEvent
+	for playerNo, actions := range td.Players {
+		group := playerNoToGroup(playerNo)
+		if group == "" {
+			continue
+		}
+		for _, a := range actions {
+			className, isPoint := reverseActionName(a.Action)
+			events = append(events, model.MatchEvent{
+				Group:     group,
+				StartSec:  a.ActionStartSec,
+				EndSec:    a.ActionEndSec,
+				ClassName: className,
+				IsPoint:   isPoint,
+			})
+		}
+	}
+
+	return TimelineEntry{
+		Datetime: td.Datetime.Format("2006-01-02 15:04"),
+		Timeline: &model.MatchTimeline{
+			Events:     events,
+			GameEndSec: td.GameEndSec,
+		},
+	}
+}
+
+// playerNoToGroup はプレイヤー番号をvis.jsのgroup名に変換する。
+func playerNoToGroup(playerNo string) string {
+	switch playerNo {
+	case "1":
+		return "team1-1"
+	case "2":
+		return "team1-2"
+	case "3":
+		return "team2-1"
+	case "4":
+		return "team2-2"
+	default:
+		return ""
+	}
+}
+
+// reverseActionName はFirestoreのaction名をHTMLクラス名とisPointフラグに変換する。
+func reverseActionName(action string) (className string, isPoint bool) {
+	if action == "death" {
+		return "", true
+	}
+	// actionMappingの逆引き
+	for k, v := range actionMapping {
+		if v == action {
+			return k, false
+		}
+	}
+	return action, false
 }
 
 // SaveTimelines はDatedScoresからタイムラインを抽出し、Firestoreに書き込む。

--- a/internal/firestore/timelines.go
+++ b/internal/firestore/timelines.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -84,6 +85,11 @@ func fromTimelineDoc(td timelineDoc) TimelineEntry {
 			})
 		}
 	}
+
+	// mapイテレーション順序が不定のため、ActionStartSecでソート
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].StartSec < events[j].StartSec
+	})
 
 	return TimelineEntry{
 		Datetime: td.Datetime.Format("2006-01-02 15:04"),

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -128,15 +128,16 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	}
 
 	// バックフィル判定: Firestoreから新フィールドが空のレコードがある日付を特定
-	needsBackfill := exists && fs.NeedsBackfill(j.UserKey)
 	var backfillDates map[string]bool
-	if needsBackfill {
+	if exists {
 		backfillDates = fs.BackfillDates(j.UserKey)
-		log.Printf("[INFO] Backfill needed: %d dates with missing data", len(backfillDates))
+		if len(backfillDates) > 0 {
+			log.Printf("[INFO] Backfill needed: %d dates with missing data", len(backfillDates))
+		}
 	}
 
 	if exists {
-		if needsBackfill {
+		if len(backfillDates) > 0 {
 			// バックフィル: since=ゼロで対象日付のみ再スクレイプ
 			log.Printf("[INFO] Backfill mode: targeting specific dates")
 		} else {
@@ -175,7 +176,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 
 	var datedScores model.DatedScores
 	var jar http.CookieJar
-	if needsBackfill {
+	if len(backfillDates) > 0 {
 		datedScores, jar, err = scraper.ScrapingWithOption(username, password, since, scraper.ScrapingOption{
 			OnProgress:    onProgress,
 			BackfillDates: backfillDates,
@@ -217,6 +218,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	}
 
 	// 新規データがない場合はタッグ情報を付与して最終レポートにする
+	// csvPathには速報レポート用に生成したCSVが残っており、ここでそのまま再利用する
 	if len(datedScores) == 0 && j.PreliminaryReport != "" {
 		var tagPartnersPath string
 		tagPartners := scraper.ScrapeTagPartners(jar)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"sync"
 	"time"
 
@@ -106,27 +105,33 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 
 	csvPath := filepath.Join(tmpDir, "scores.csv")
 
-	// Cloud Storageから既存CSVをダウンロード
+	// Firestoreから既存scoresを読み取り
 	var since time.Time
-	exists, err := storage.DownloadCSV(username, csvPath)
+	existingScores, err := fs.LoadScores(j.UserKey)
 	if err != nil {
-		log.Printf("[WARN] Failed to download existing CSV: %v", err)
+		log.Printf("[WARN] Failed to load scores from Firestore: %v", err)
 	}
-	// GCSから既存タッグ相方情報をダウンロード（速報レポートで使用）
-	cachedTagPartnersPath := filepath.Join(tmpDir, "cached_tag_partners.json")
-	tagPartnersExists, err := storage.DownloadTagPartners(username, cachedTagPartnersPath)
+	exists := len(existingScores) > 0
+
+	// Firestoreから既存タッグ相方情報を読み取り（速報レポートで使用）
+	cachedTagPartnersPath := ""
+	cachedPartners, err := fs.LoadTagPartners(j.UserKey)
 	if err != nil {
-		log.Printf("[WARN] Failed to download existing tag partners: %v", err)
+		log.Printf("[WARN] Failed to load tag partners from Firestore: %v", err)
 	}
-	if !tagPartnersExists {
-		cachedTagPartnersPath = ""
+	if len(cachedPartners) > 0 {
+		cachedTagPartnersPath = filepath.Join(tmpDir, "cached_tag_partners.json")
+		if err := saveTagPartners(cachedPartners, cachedTagPartnersPath); err != nil {
+			log.Printf("[WARN] Failed to save cached tag partners: %v", err)
+			cachedTagPartnersPath = ""
+		}
 	}
 
-	// バックフィル判定: 新フィールドが空のレコードがある日付を特定
-	needsBackfill := exists && storage.NeedsBackfill(csvPath)
+	// バックフィル判定: Firestoreから新フィールドが空のレコードがある日付を特定
+	needsBackfill := exists && fs.NeedsBackfill(j.UserKey)
 	var backfillDates map[string]bool
 	if needsBackfill {
-		backfillDates = storage.BackfillDates(csvPath)
+		backfillDates = fs.BackfillDates(j.UserKey)
 		log.Printf("[INFO] Backfill needed: %d dates with missing data", len(backfillDates))
 	}
 
@@ -135,22 +140,26 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 			// バックフィル: since=ゼロで対象日付のみ再スクレイプ
 			log.Printf("[INFO] Backfill mode: targeting specific dates")
 		} else {
-			since, err = storage.GetLatestDatetime(csvPath)
+			since, err = fs.GetLatestDatetime(j.UserKey)
 			if err != nil {
-				log.Printf("[WARN] Failed to read latest datetime: %v", err)
+				log.Printf("[WARN] Failed to read latest datetime from Firestore: %v", err)
 			}
 			if !since.IsZero() {
 				log.Printf("[INFO] Fetching scores after %s", since.Format("2006-01-02 15:04"))
 			}
 		}
 
-		// 前回データで即座に分析（速報レポート、キャッシュ済みタッグ情報付き）
-		prelimReport := runAnalysis(csvPath, tmpDir, cachedTagPartnersPath, "")
-		if prelimReport != "" {
-			jobsMu.Lock()
-			j.PreliminaryReport = prelimReport
-			jobsMu.Unlock()
-			log.Printf("[INFO] Job %s: preliminary report ready", j.ID)
+		// 既存データでCSVを生成して速報レポートを作成
+		if err := storage.SaveAllScoresCSV(existingScores, csvPath); err != nil {
+			log.Printf("[WARN] Failed to generate CSV for preliminary report: %v", err)
+		} else {
+			prelimReport := runAnalysis(csvPath, tmpDir, cachedTagPartnersPath, "")
+			if prelimReport != "" {
+				jobsMu.Lock()
+				j.PreliminaryReport = prelimReport
+				jobsMu.Unlock()
+				log.Printf("[INFO] Job %s: preliminary report ready", j.ID)
+			}
 		}
 	}
 
@@ -266,28 +275,28 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		gradelist.CheckUnknownGrades(datedScores, gradeMap)
 	}
 
-	// CSV保存
-	if needsBackfill {
-		// バックフィル: 旧CSVの古いデータ（再スクレイプでカバーできない期間）を残して新データとマージ
-		if err := mergeAndSaveCSV(datedScores, csvPath); err != nil {
-			setError(j, "内部エラーが発生しました", fmt.Sprintf("failed to save CSV: %v", err))
-			return
-		}
-	} else {
-		// 通常: 既存データに追記
-		if err := storage.SaveAllScoresCSV(datedScores, csvPath); err != nil {
-			setError(j, "内部エラーが発生しました", fmt.Sprintf("failed to save CSV: %v", err))
-			return
-		}
+	// Firestoreにscoresを書き込み
+	fs.SaveScores(j.UserKey, datedScores)
+
+	// Firestoreから全scoresを読み取り、CSV生成（GCSアップロード用 + Python分析用）
+	allScores, err := fs.LoadScores(j.UserKey)
+	if err != nil {
+		log.Printf("[WARN] Failed to reload scores from Firestore: %v", err)
+		// フォールバック: 既存 + 新規で組み立て
+		allScores = append(existingScores, datedScores...)
 	}
 
-	// Cloud Storageにアップロード
+	// CSVを生成してGCSにアップロード（二重書き込み維持）
+	if err := os.Remove(csvPath); err != nil && !os.IsNotExist(err) {
+		log.Printf("[WARN] Failed to remove temp CSV: %v", err)
+	}
+	if err := storage.SaveAllScoresCSV(allScores, csvPath); err != nil {
+		setError(j, "内部エラーが発生しました", fmt.Sprintf("failed to save CSV: %v", err))
+		return
+	}
 	if err := storage.UploadCSV(username, csvPath); err != nil {
 		log.Printf("[WARN] Failed to upload CSV to Cloud Storage: %v", err)
 	}
-
-	// Firestoreにscoresを書き込み
-	fs.SaveScores(j.UserKey, datedScores)
 
 	// タイムラインデータの保存
 	timelinePath := saveTimelines(datedScores, username, j.UserKey, tmpDir)
@@ -349,14 +358,19 @@ func RunCustomPeriod(userKey, start, end string) (string, error) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	csvPath := filepath.Join(tmpDir, "scores.csv")
-
-	exists, err := storage.DownloadCSVByKey(userKey, csvPath)
+	// Firestoreからscoresを読み取り
+	scores, err := fs.LoadScores(userKey)
 	if err != nil {
-		return "", fmt.Errorf("failed to download CSV: %w", err)
+		return "", fmt.Errorf("failed to load scores from Firestore: %w", err)
 	}
-	if !exists {
-		return "", fmt.Errorf("CSV not found for user")
+	if len(scores) == 0 {
+		return "", fmt.Errorf("no scores found for user")
+	}
+
+	// CSVを生成
+	csvPath := filepath.Join(tmpDir, "scores.csv")
+	if err := storage.SaveAllScoresCSV(scores, csvPath); err != nil {
+		return "", fmt.Errorf("failed to generate CSV: %w", err)
 	}
 
 	cmd := exec.Command("python3", "scripts/analyze.py", csvPath, "--start", start, "--end", end)
@@ -393,86 +407,24 @@ func saveTagPartners(partners []model.TagPartner, path string) error {
 	return os.WriteFile(path, b, 0644)
 }
 
-// mergeAndSaveCSV はバックフィル時に旧CSVと新スクレイプデータをマージして保存する。
-// 新データでカバーされる日時のレコードは新データで置き換え、それ以外は旧データを残す。
-func mergeAndSaveCSV(newScores model.DatedScores, csvPath string) error {
-	oldScores, err := storage.ReadAllScoresCSV(csvPath)
-	if err != nil {
-		return fmt.Errorf("failed to read old CSV: %w", err)
-	}
-
-	// 新データの日時セットを作成（重複判定用）
-	newDatetimes := make(map[string]bool)
-	for _, s := range newScores {
-		key := s.Datetime.Format("2006-01-02 15:04") + ":" + strconv.Itoa(s.PlayerNo)
-		newDatetimes[key] = true
-	}
-
-	// 旧データから、新データでカバーされていないレコードだけ残す
-	var keepOld model.DatedScores
-	for _, s := range oldScores {
-		key := s.Datetime.Format("2006-01-02 15:04") + ":" + strconv.Itoa(s.PlayerNo)
-		if !newDatetimes[key] {
-			keepOld = append(keepOld, s)
-		}
-	}
-
-	// マージ: 旧データ（古い期間）+ 新データ（新フィールド付き）
-	merged := append(keepOld, newScores...)
-
-	// 新規ファイルとして書き直す
-	if err := os.Remove(csvPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove old CSV: %w", err)
-	}
-	if err := storage.SaveAllScoresCSV(merged, csvPath); err != nil {
-		return fmt.Errorf("failed to save merged CSV: %w", err)
-	}
-
-	log.Printf("[INFO] Backfill merge: %d old records kept, %d new records, %d total", len(keepOld), len(newScores), len(merged))
-	return nil
-}
-
-// saveTimelines はDatedScoresからタイムラインデータを抽出し、JSONファイルに保存・GCSにアップロードする
+// saveTimelines はDatedScoresからタイムラインデータを抽出し、Firestoreに保存・GCSにアップロードする
 func saveTimelines(scores model.DatedScores, username, userKey, tmpDir string) string {
-	type timelineEntry struct {
-		Datetime string              `json:"datetime"`
-		Timeline *model.MatchTimeline `json:"timeline"`
-	}
+	// Firestoreにtimelinesを書き込み
+	fs.SaveTimelines(userKey, scores)
 
-	// 既存タイムラインをGCSからダウンロード
-	timelinePath := filepath.Join(tmpDir, "timelines.json")
-	var existing []timelineEntry
-	if found, err := storage.DownloadTimeline(username, timelinePath); err != nil {
-		log.Printf("[WARN] Failed to download existing timelines: %v", err)
-	} else if found {
-		data, err := os.ReadFile(timelinePath)
-		if err == nil {
-			if err := json.Unmarshal(data, &existing); err != nil {
-				log.Printf("[WARN] Failed to parse existing timelines: %v", err)
-			}
-		}
-	}
-
-	// 新しいタイムラインを追加
-	var added int
-	for _, s := range scores {
-		if s.MatchTimeline != nil {
-			existing = append(existing, timelineEntry{
-				Datetime: s.Datetime.Format("2006-01-02 15:04"),
-				Timeline: s.MatchTimeline,
-			})
-			added++
-		}
-	}
-
-	if added == 0 {
-		if len(existing) > 0 {
-			return timelinePath
-		}
+	// Firestoreから全タイムラインを読み取り（GCSアップロード用 + Python分析用）
+	entries, err := fs.LoadTimelines(userKey)
+	if err != nil {
+		log.Printf("[WARN] Failed to load timelines from Firestore: %v", err)
 		return ""
 	}
 
-	b, err := json.Marshal(existing)
+	if len(entries) == 0 {
+		return ""
+	}
+
+	timelinePath := filepath.Join(tmpDir, "timelines.json")
+	b, err := json.Marshal(entries)
 	if err != nil {
 		log.Printf("[WARN] Failed to marshal timelines: %v", err)
 		return ""
@@ -482,14 +434,12 @@ func saveTimelines(scores model.DatedScores, username, userKey, tmpDir string) s
 		return ""
 	}
 
+	// GCSにアップロード（二重書き込み維持）
 	if err := storage.UploadTimeline(username, timelinePath); err != nil {
 		log.Printf("[WARN] Failed to upload timelines to GCS: %v", err)
 	}
 
-	// Firestoreにtimelinesを書き込み
-	fs.SaveTimelines(userKey, scores)
-
-	log.Printf("[INFO] Saved %d new timelines (%d total)", added, len(existing))
+	log.Printf("[INFO] Loaded %d timelines from Firestore", len(entries))
 	return timelinePath
 }
 


### PR DESCRIPTION
## Summary

- **Issue #220 Phase 3**: Python分析の入力データソースをGCS CSV → Firestoreに切り替え
- `internal/firestore/` にscores/tag_partners/timelinesの読み取り関数（`LoadScores`, `LoadTagPartners`, `LoadTimelines`等）を追加
- `internal/pipeline/` のRun/RunCustomPeriodでGCSダウンロードをFirestore読み取りに置き換え
- バックフィル判定もFirestoreベースに変更（`NeedsBackfill`, `BackfillDates`）
- GCSへの書き込み（二重書き込み）はPhase 4まで維持

## Test plan

- [x] `make build` 成功
- [x] `make test` 全テスト通過
- [ ] stgデプロイ後、実際に分析を実行してFirestoreからの読み取りが正常に動作することを確認