### PR TITLE
fix: arcade_nameをプレイヤー1のみにセットする

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -600,6 +600,11 @@ func parseDetailPage(s *goquery.Selection, date, hour string, wins []bool, shopN
 			scoreRanking = scoreRankings[i]
 		}
 
+		arcadeName := ""
+		if i == 0 {
+			arcadeName = shopName
+		}
+
 		result := model.DatedScore{
 			PlayerNo: i + 1,
 			Datetime: datetime,
@@ -623,7 +628,7 @@ func parseDetailPage(s *goquery.Selection, date, hour string, wins []bool, shopN
 				ShuffleGradeURL: shuffleGrade,
 				TeamGradeURL:    teamGrade,
 				ScoreRanking:    scoreRanking,
-				ArcadeName:      shopName,
+				ArcadeName:      arcadeName,
 			},
 		}
 


### PR DESCRIPTION
## Summary
- `parseDetailPage`で全4プレイヤーに同じ`shopName`がセットされていたバグを修正
- プレイヤー1（`i == 0`）のみ`shopName`をセットし、プレイヤー2〜4は空文字にする

Resolves #236

## Test plan
- [ ] `make build` が成功すること
- [ ] スクレイピング結果でプレイヤー1のみにarcade_nameがセットされていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)