### PR TITLE
feat: 戦績データ削除CLIツールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 
 - `cmd/server/main.go` — エントリポイント。`internal/server.StartServer()` に委譲
 - `cmd/update-mslist/main.go` — MSリストをスクレイピングして `data/ms_list.json` を更新するCLI
+- `cmd/delete-recent-scores/` — 指定ユーザーの最新N日間の戦績を削除するCLI（ドライラン対応）
 - `internal/model/` — 型定義 + `UserKey`（`PlayerScore`, `DatedScore`, `MSInfo`, `MatchEvent`, `MatchTimeline`, `TagPartner`, `JobStatus`, `JobSnapshot`）
 - `internal/mslist/` — MSリストの読み書き・マージ（`LoadMSList`, `SaveMSList`, `MergeMSList`, `BuildMSNameMap`, `FillMsNames`, `CheckUnknownMS`）
 - `internal/gradelist/` — グレードリストの読み込み・未知URL検出（`LoadGradeList`, `BuildGradeMap`, `CheckUnknownGrades`）

--- a/cmd/delete-recent-scores/README.md
+++ b/cmd/delete-recent-scores/README.md
@@ -1,0 +1,70 @@
+# delete-recent-scores
+
+指定ユーザーの最新N日間の戦績データ（scores + timelines）をFirestoreから削除するCLIツール。
+
+## オプション
+
+| フラグ | 必須 | デフォルト | 説明 |
+|--------|------|-----------|------|
+| `-user` | Yes | - | 対象ユーザーキー（SHA256(email)[:8]の16進数） |
+| `-days` | No | 2 | 削除する日数（最新日から遡る。1〜30） |
+| `-execute` | No | false | 指定しない場合はドライラン（確認のみ） |
+
+## 環境変数
+
+| 変数 | 説明 |
+|------|------|
+| `GCP_PROJECT` | GCPプロジェクトID |
+| `FIRESTORE_DATABASE` | FirestoreデータベースID |
+| `GOOGLE_APPLICATION_CREDENTIALS` | GCP認証情報ファイルのパス（ローカル実行時） |
+
+## ローカルからの実行（Docker経由）
+
+ローカル環境にGoはインストールされていないため、Docker経由で実行する。
+
+### ドライラン（確認のみ）
+
+```bash
+docker run --rm \
+  -v "$PWD/go.mod":/app/go.mod:ro \
+  -v "$PWD/go.sum":/app/go.sum:ro \
+  -v "$PWD/internal":/app/internal:ro \
+  -v "$PWD/cmd":/app/cmd:ro \
+  -v "$HOME/.config/gcloud/application_default_credentials.json":/tmp/adc.json:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/adc.json \
+  -e GCP_PROJECT=<project-id> \
+  -e FIRESTORE_DATABASE=<database-id> \
+  -w /app \
+  golang:1.26-alpine \
+  go run ./cmd/delete-recent-scores -user <userKey> -days 3
+```
+
+### 削除実行
+
+```bash
+docker run --rm \
+  -v "$PWD/go.mod":/app/go.mod:ro \
+  -v "$PWD/go.sum":/app/go.sum:ro \
+  -v "$PWD/internal":/app/internal:ro \
+  -v "$PWD/cmd":/app/cmd:ro \
+  -v "$HOME/.config/gcloud/application_default_credentials.json":/tmp/adc.json:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/adc.json \
+  -e GCP_PROJECT=<project-id> \
+  -e FIRESTORE_DATABASE=<database-id> \
+  -w /app \
+  golang:1.26-alpine \
+  go run ./cmd/delete-recent-scores -user <userKey> -days 3 -execute
+```
+
+## 動作
+
+1. 指定ユーザーの最新試合日時を取得
+2. 最新日の0:00から`(days-1)`日前をカットオフとして算出
+3. カットオフ以降の`scores`と`timelines`ドキュメントを一覧表示
+4. `-execute`指定時のみ、バッチ削除を実行
+
+## 注意事項
+
+- `-execute`を付けない限りデータは削除されない（ドライランで安全に確認可能）
+- 削除は不可逆。実行前にドライランで対象を必ず確認すること
+- GCP認証には`gcloud auth application-default login`で事前にADCを取得しておくこと

--- a/cmd/delete-recent-scores/main.go
+++ b/cmd/delete-recent-scores/main.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"cloud.google.com/go/firestore"
+)
+
+func main() {
+	userKey := flag.String("user", "", "対象ユーザーキー（必須）")
+	days := flag.Int("days", 2, "削除する日数（最新日から遡る。最大30）")
+	execute := flag.Bool("execute", false, "実際に削除を実行する（省略時はドライラン）")
+	flag.Parse()
+
+	if *userKey == "" {
+		fmt.Fprintln(os.Stderr, "Usage: delete-recent-scores -user <userKey> [-days N] [-execute]")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+	if *days < 1 || *days > 30 {
+		log.Fatal("-days は 1〜30 の範囲で指定してください")
+	}
+
+	projectID := os.Getenv("GCP_PROJECT")
+	dbID := os.Getenv("FIRESTORE_DATABASE")
+	if projectID == "" || dbID == "" {
+		log.Fatal("GCP_PROJECT and FIRESTORE_DATABASE are required")
+	}
+
+	ctx := context.Background()
+	client, err := firestore.NewClientWithDatabase(ctx, projectID, dbID)
+	if err != nil {
+		log.Fatalf("Failed to init Firestore: %v", err)
+	}
+	defer client.Close()
+
+	userRef := client.Collection("users").Doc(*userKey)
+
+	// 最新日時を取得
+	latestDocs, err := userRef.Collection("scores").OrderBy("datetime", firestore.Desc).Limit(1).Documents(ctx).GetAll()
+	if err != nil || len(latestDocs) == 0 {
+		log.Fatalf("Failed to get latest datetime: %v", err)
+	}
+	latestTime := latestDocs[0].Data()["datetime"].(time.Time)
+	log.Printf("[INFO] Latest datetime: %s", latestTime.Format("2006-01-02 15:04"))
+
+	// cutoff = 最新日の0:00から (days-1) 日前
+	cutoff := latestTime.Truncate(24 * time.Hour).AddDate(0, 0, -(*days - 1))
+	log.Printf("[INFO] Cutoff (deleting >= %s): %d days", cutoff.Format("2006-01-02"), *days)
+
+	// 削除対象を収集
+	scoreDocs, err := userRef.Collection("scores").Where("datetime", ">=", cutoff).Documents(ctx).GetAll()
+	if err != nil {
+		log.Fatalf("Failed to query scores: %v", err)
+	}
+	timelineDocs, err := userRef.Collection("timelines").Where("datetime", ">=", cutoff).Documents(ctx).GetAll()
+	if err != nil {
+		log.Fatalf("Failed to query timelines: %v", err)
+	}
+
+	log.Printf("[INFO] Scores to delete: %d documents", len(scoreDocs))
+	for _, doc := range scoreDocs {
+		data := doc.Data()
+		dt := data["datetime"].(time.Time)
+		log.Printf("  - %s player%v %v (doc: %s)", dt.Format("2006-01-02 15:04"), data["player_no"], data["name"], doc.Ref.ID)
+	}
+	log.Printf("[INFO] Timelines to delete: %d documents", len(timelineDocs))
+
+	if !*execute {
+		log.Printf("[DRY RUN] No changes made. Add -execute to delete.")
+		return
+	}
+
+	// 削除実行
+	allRefs := make([]*firestore.DocumentRef, 0, len(scoreDocs)+len(timelineDocs))
+	for _, doc := range scoreDocs {
+		allRefs = append(allRefs, doc.Ref)
+	}
+	for _, doc := range timelineDocs {
+		allRefs = append(allRefs, doc.Ref)
+	}
+
+	const batchLimit = 500
+	for i := 0; i < len(allRefs); i += batchLimit {
+		end := i + batchLimit
+		if end > len(allRefs) {
+			end = len(allRefs)
+		}
+		batch := client.Batch()
+		for _, ref := range allRefs[i:end] {
+			batch.Delete(ref)
+		}
+		if _, err := batch.Commit(ctx); err != nil {
+			log.Fatalf("Batch delete failed (%d-%d): %v", i, end, err)
+		}
+	}
+
+	log.Printf("[INFO] Deleted %d scores + %d timelines = %d documents total",
+		len(scoreDocs), len(timelineDocs), len(allRefs))
+}


### PR DESCRIPTION
## Summary
- 指定ユーザーの最新N日間のscores/timelinesをFirestoreから削除するCLIツール(`cmd/delete-recent-scores/`)を追加
- ドライラン対応で安全に確認後に実行可能
- `-days`オプションで日数指定（1〜30、デフォルト2）

## Test plan
- [ ] `make build` が成功すること
- [ ] ドライラン（`-execute`なし）で対象一覧が表示されること
- [ ] `-execute`付きで削除が実行されること