### PR TITLE
feat: Python分析スクリプトの入力をCSVからJSONに変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,8 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
   → Collyで新規戦績をスクレイピング（状態: scraping）
   → data/ms_list.jsonからMS名・コストを補完
   → Firestoreにmatches/tag_partners書き込み（タイムラインはmatchesに埋め込み）
-  → Firestoreから全matches読み取り → CSV生成
-  → scripts/analyze.py でCSVを分析（状態: analyzing）
+  → Firestoreから全matches読み取り → 試合単位JSON生成
+  → scripts/analyze.py でJSONを分析（状態: analyzing）
   → JSONレポートを返却（状態: done）
 クライアントは GET /status/{id} でポーリング後、GET /result/{id} で結果取得
 ```
@@ -83,7 +83,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 - `internal/gradelist/` — グレードリストの読み込み・未知URL検出（`LoadGradeList`, `BuildGradeMap`, `CheckUnknownGrades`）
 - `internal/scraper/` — Collyベースのスクレイパー（`scraper.go`）+ バンダイナムコID認証（`login.go`）
 - `internal/firestore/` — Firestoreクライアント初期化（`client.go`）+ matches/tag_partnersの読み書き（タイムラインはmatches内に埋め込み）
-- `internal/pipeline/` — 分析パイプライン（`Job`型、ジョブストア、`Run`関数、CSV生成）
+- `internal/pipeline/` — 分析パイプライン（`Job`型、ジョブストア、`Run`関数、JSON生成）
 - `internal/server/` — HTTPハンドラ（`server.go`）+ IPベースレート制限（`ratelimit.go`）+ Basic認証（`basicauth.go`）+ 403一時ブロック（`block403.go`）
 - `scripts/analyze.py` — Python分析: カテゴリ別アドバイス、勝率、与被ダメ比、固定相方検出、JSON構造化レポート生成
 - `static/index.html` — SPA フロントエンド（ダークテーマ、レスポンシブ対応）

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,7 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
+	"sort"
 	"sync"
 	"time"
 
@@ -104,7 +103,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	csvPath := filepath.Join(tmpDir, "scores.csv")
+	jsonPath := filepath.Join(tmpDir, "scores.json")
 
 	// Firestoreから既存scoresを読み取り
 	var since time.Time
@@ -151,11 +150,11 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 			}
 		}
 
-		// 既存データでCSVを生成して速報レポートを作成
-		if err := saveScoresCSV(existingScores, csvPath); err != nil {
-			log.Printf("[WARN] Failed to generate CSV for preliminary report: %v", err)
+		// 既存データでJSONを生成して速報レポートを作成
+		if err := saveScoresJSON(existingScores, jsonPath); err != nil {
+			log.Printf("[WARN] Failed to generate JSON for preliminary report: %v", err)
 		} else {
-			prelimReport := runAnalysis(csvPath, tmpDir, cachedTagPartnersPath, "")
+			prelimReport := runAnalysis(jsonPath, tmpDir, cachedTagPartnersPath)
 			if prelimReport != "" {
 				jobsMu.Lock()
 				j.PreliminaryReport = prelimReport
@@ -219,7 +218,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	}
 
 	// 新規データがない場合はタッグ情報を付与して最終レポートにする
-	// csvPathには速報レポート用に生成したCSVが残っており、ここでそのまま再利用する
+	// jsonPathには速報レポート用に生成したJSONが残っており、ここでそのまま再利用する
 	if len(datedScores) == 0 && j.PreliminaryReport != "" {
 		var tagPartnersPath string
 		tagPartners := scraper.ScrapeTagPartners(jar)
@@ -240,7 +239,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		// タッグ情報がある場合は再分析、なければ速報レポートをそのまま使う
 		finalReport := j.PreliminaryReport
 		if tagPartnersPath != "" {
-			report := runAnalysis(csvPath, tmpDir, tagPartnersPath, "")
+			report := runAnalysis(jsonPath, tmpDir, tagPartnersPath)
 			if report != "" {
 				finalReport = report
 			}
@@ -277,7 +276,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	// Firestoreにscoresを書き込み
 	fs.SaveScores(j.UserKey, datedScores)
 
-	// Firestoreから全scoresを読み取り、Python分析用のCSVを生成
+	// Firestoreから全scoresを読み取り、Python分析用のJSONを生成
 	allScores, err := fs.LoadScores(j.UserKey)
 	if err != nil {
 		log.Printf("[WARN] Failed to reload scores from Firestore: %v", err)
@@ -285,16 +284,13 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		allScores = append(existingScores, datedScores...)
 	}
 
-	if err := os.Remove(csvPath); err != nil && !os.IsNotExist(err) {
-		log.Printf("[WARN] Failed to remove temp CSV: %v", err)
+	if err := os.Remove(jsonPath); err != nil && !os.IsNotExist(err) {
+		log.Printf("[WARN] Failed to remove temp JSON: %v", err)
 	}
-	if err := saveScoresCSV(allScores, csvPath); err != nil {
-		setError(j, "内部エラーが発生しました", fmt.Sprintf("failed to save CSV: %v", err))
+	if err := saveScoresJSON(allScores, jsonPath); err != nil {
+		setError(j, "内部エラーが発生しました", fmt.Sprintf("failed to save JSON: %v", err))
 		return
 	}
-
-	// タイムラインJSONを全scoresから生成（matchesコレクションに統合済み）
-	timelinePath := generateTimelineJSON(allScores, tmpDir)
 
 	// タッグ相方名を取得（403途中保存時はセッションが無効なのでキャッシュを使用）
 	var tagPartnersPath string
@@ -322,7 +318,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 
 	// Python分析実行
 	updateStatus(j, model.StatusAnalyzing)
-	report := runAnalysis(csvPath, tmpDir, tagPartnersPath, timelinePath)
+	report := runAnalysis(jsonPath, tmpDir, tagPartnersPath)
 	if report == "" {
 		setError(j, "分析処理に失敗しました", "analysis returned empty report")
 		return
@@ -358,17 +354,13 @@ func RunCustomPeriod(userKey, start, end string) (string, error) {
 		return "", fmt.Errorf("no scores found for user")
 	}
 
-	// CSVを生成
-	csvPath := filepath.Join(tmpDir, "scores.csv")
-	if err := saveScoresCSV(scores, csvPath); err != nil {
-		return "", fmt.Errorf("failed to generate CSV: %w", err)
+	// JSONを生成
+	jsonPath := filepath.Join(tmpDir, "scores.json")
+	if err := saveScoresJSON(scores, jsonPath); err != nil {
+		return "", fmt.Errorf("failed to generate JSON: %w", err)
 	}
 
-	args := []string{"scripts/analyze.py", csvPath, "--start", start, "--end", end}
-	timelinePath := generateTimelineJSON(scores, tmpDir)
-	if timelinePath != "" {
-		args = append(args, "--timeline", timelinePath)
-	}
+	args := []string{"scripts/analyze.py", jsonPath, "--start", start, "--end", end, "--ms-list", DefaultMSListPath}
 
 	cmd := exec.Command("python3", args...)
 	cmd.Dir = "/app"
@@ -404,50 +396,11 @@ func saveTagPartners(partners []model.TagPartner, path string) error {
 	return os.WriteFile(path, b, 0644)
 }
 
-// generateTimelineJSON はDatedScoresからタイムラインJSONを生成する（Python分析用）。
-func generateTimelineJSON(scores model.DatedScores, tmpDir string) string {
-	type timelineEntry struct {
-		Datetime string              `json:"datetime"`
-		Timeline *model.MatchTimeline `json:"timeline"`
-	}
-
-	var entries []timelineEntry
-	for _, s := range scores {
-		if s.MatchTimeline != nil {
-			entries = append(entries, timelineEntry{
-				Datetime: s.Datetime.Format("2006-01-02 15:04"),
-				Timeline: s.MatchTimeline,
-			})
-		}
-	}
-
-	if len(entries) == 0 {
-		return ""
-	}
-
-	timelinePath := filepath.Join(tmpDir, "timelines.json")
-	b, err := json.Marshal(entries)
-	if err != nil {
-		log.Printf("[WARN] Failed to marshal timelines: %v", err)
-		return ""
-	}
-	if err := os.WriteFile(timelinePath, b, 0644); err != nil {
-		log.Printf("[WARN] Failed to save timelines: %v", err)
-		return ""
-	}
-
-	log.Printf("[INFO] Generated %d timelines for analysis", len(entries))
-	return timelinePath
-}
-
 // runAnalysis はPython分析を実行してJSON形式のレポートを返す。失敗時は空文字を返す。
-func runAnalysis(csvPath, tmpDir, tagPartnersPath, timelinePath string) string {
-	args := []string{"scripts/analyze.py", csvPath}
+func runAnalysis(jsonPath, tmpDir, tagPartnersPath string) string {
+	args := []string{"scripts/analyze.py", jsonPath, "--ms-list", DefaultMSListPath}
 	if tagPartnersPath != "" {
 		args = append(args, "--tag-partners", tagPartnersPath)
-	}
-	if timelinePath != "" {
-		args = append(args, "--timeline", timelinePath)
 	}
 	cmd := exec.Command("python3", args...)
 	cmd.Dir = "/app"
@@ -501,51 +454,158 @@ func CleanupJobs(ttl time.Duration) {
 	}
 }
 
-// saveScoresCSV はDatedScoresをCSVファイルに保存する（Python分析用）。
-func saveScoresCSV(ds model.DatedScores, path string) error {
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
+// matchJSON はPython分析用の試合単位JSON構造
+type matchJSON struct {
+	Datetime   string       `json:"datetime"`
+	GameEndSec float64      `json:"game_end_sec"`
+	Players    []playerJSON `json:"players"`
+}
 
-	w := csv.NewWriter(f)
-	defer w.Flush()
+// playerJSON はPython分析用のプレイヤー情報
+type playerJSON struct {
+	PlayerNo        int          `json:"player_no"`
+	Name            string       `json:"name"`
+	City            string       `json:"city"`
+	Win             bool         `json:"win"`
+	MsName          string       `json:"ms_name"`
+	MsImageURL      string       `json:"ms_image_url"`
+	Score           int          `json:"score"`
+	Kills           int          `json:"kills"`
+	Deaths          int          `json:"deaths"`
+	GiveDamage      int          `json:"give_damage"`
+	ReceiveDamage   int          `json:"receive_damage"`
+	ExDamage        int          `json:"ex_damage"`
+	MsProficiency   string       `json:"ms_proficiency"`
+	TeamName        string       `json:"team_name"`
+	PlayerLevelURL  string       `json:"player_level_url"`
+	RankBadgeURL    string       `json:"rank_badge_url"`
+	ProfileURL      string       `json:"profile_url"`
+	ShuffleGradeURL string       `json:"shuffle_grade_url"`
+	TeamGradeURL    string       `json:"team_grade_url"`
+	ScoreRanking    int          `json:"score_ranking"`
+	ArcadeName      string       `json:"arcade_name"`
+	Actions         []actionJSON `json:"actions"`
+}
 
-	header := []string{"試合日時", "プレイヤーNo.", "地域", "プレイヤー名", "勝利判定", "機体名", "機体画像URL", "スコア", "撃墜数", "被撃墜数", "与ダメージ", "被ダメージ", "EXダメージ", "ランク", "チーム名", "称号画像URL", "称号バッジURL", "プロフィールURL", "シャッフルグレード画像URL", "チームグレード画像URL", "スコア順位", "店舗名"}
-	if err := w.Write(header); err != nil {
-		return err
-	}
+// actionJSON はタイムラインアクション
+type actionJSON struct {
+	Action         string  `json:"action"`
+	ActionStartSec float64 `json:"action_start_sec"`
+	ActionEndSec   float64 `json:"action_end_sec"`
+}
 
+// saveScoresJSON はDatedScoresを試合単位JSONファイルに保存する（Python分析用）。
+func saveScoresJSON(ds model.DatedScores, path string) error {
+	groups := make(map[string][]model.DatedScore)
 	for _, d := range ds {
-		row := []string{
-			d.Datetime.Format("2006-01-02 15:04"),
-			strconv.Itoa(d.PlayerNo),
-			d.PlayerScore.City,
-			d.PlayerScore.Name,
-			strconv.FormatBool(d.PlayerScore.Win),
-			d.PlayerScore.MsName,
-			d.PlayerScore.MsImageURL,
-			strconv.Itoa(d.PlayerScore.Score),
-			strconv.Itoa(d.PlayerScore.Kills),
-			strconv.Itoa(d.PlayerScore.Deaths),
-			strconv.Itoa(d.PlayerScore.GiveDamage),
-			strconv.Itoa(d.PlayerScore.ReceiveDamage),
-			strconv.Itoa(d.PlayerScore.ExDamage),
-			d.PlayerScore.MsProficiency,
-			d.PlayerScore.TeamName,
-			d.PlayerScore.PlayerLevelURL,
-			d.PlayerScore.RankBadgeURL,
-			d.PlayerScore.ProfileURL,
-			d.PlayerScore.ShuffleGradeURL,
-			d.PlayerScore.TeamGradeURL,
-			strconv.Itoa(d.PlayerScore.ScoreRanking),
-			d.PlayerScore.ArcadeName,
-		}
-		if err := w.Write(row); err != nil {
-			return err
-		}
+		key := d.Datetime.Format("2006-01-02T1504")
+		groups[key] = append(groups[key], d)
 	}
 
-	return nil
+	keys := make([]string, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	matches := make([]matchJSON, 0, len(keys))
+	for _, key := range keys {
+		entries := groups[key]
+		if len(entries) != 4 {
+			continue
+		}
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].PlayerNo < entries[j].PlayerNo
+		})
+
+		var gameEndSec float64
+		var timeline *model.MatchTimeline
+		for _, e := range entries {
+			if e.MatchTimeline != nil {
+				timeline = e.MatchTimeline
+				gameEndSec = timeline.GameEndSec
+				break
+			}
+		}
+
+		players := make([]playerJSON, len(entries))
+		for i, e := range entries {
+			actions := buildPlayerActions(timeline, e.PlayerNo)
+			players[i] = playerJSON{
+				PlayerNo:        e.PlayerNo,
+				Name:            e.PlayerScore.Name,
+				City:            e.PlayerScore.City,
+				Win:             e.PlayerScore.Win,
+				MsName:          e.PlayerScore.MsName,
+				MsImageURL:      e.PlayerScore.MsImageURL,
+				Score:           e.PlayerScore.Score,
+				Kills:           e.PlayerScore.Kills,
+				Deaths:          e.PlayerScore.Deaths,
+				GiveDamage:      e.PlayerScore.GiveDamage,
+				ReceiveDamage:   e.PlayerScore.ReceiveDamage,
+				ExDamage:        e.PlayerScore.ExDamage,
+				MsProficiency:   e.PlayerScore.MsProficiency,
+				TeamName:        e.PlayerScore.TeamName,
+				PlayerLevelURL:  e.PlayerScore.PlayerLevelURL,
+				RankBadgeURL:    e.PlayerScore.RankBadgeURL,
+				ProfileURL:      e.PlayerScore.ProfileURL,
+				ShuffleGradeURL: e.PlayerScore.ShuffleGradeURL,
+				TeamGradeURL:    e.PlayerScore.TeamGradeURL,
+				ScoreRanking:    e.PlayerScore.ScoreRanking,
+				ArcadeName:      e.PlayerScore.ArcadeName,
+				Actions:         actions,
+			}
+		}
+
+		matches = append(matches, matchJSON{
+			Datetime:   entries[0].Datetime.Format("2006-01-02 15:04"),
+			GameEndSec: gameEndSec,
+			Players:    players,
+		})
+	}
+
+	b, err := json.Marshal(matches)
+	if err != nil {
+		return fmt.Errorf("marshal scores JSON: %w", err)
+	}
+	return os.WriteFile(path, b, 0644)
+}
+
+// buildPlayerActions はMatchTimelineから特定プレイヤーのアクションを抽出する。
+func buildPlayerActions(timeline *model.MatchTimeline, playerNo int) []actionJSON {
+	if timeline == nil {
+		return []actionJSON{}
+	}
+
+	groupName := ""
+	switch playerNo {
+	case 1:
+		groupName = "team1-1"
+	case 2:
+		groupName = "team1-2"
+	case 3:
+		groupName = "team2-1"
+	case 4:
+		groupName = "team2-2"
+	}
+
+	var actions []actionJSON
+	for _, e := range timeline.Events {
+		if e.Group != groupName {
+			continue
+		}
+		action := e.ClassName
+		if e.IsPoint {
+			action = "death"
+		}
+		actions = append(actions, actionJSON{
+			Action:         action,
+			ActionStartSec: e.StartSec,
+			ActionEndSec:   e.EndSec,
+		})
+	}
+	if actions == nil {
+		return []actionJSON{}
+	}
+	return actions
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -360,7 +360,24 @@ func RunCustomPeriod(userKey, start, end string) (string, error) {
 		return "", fmt.Errorf("failed to generate JSON: %w", err)
 	}
 
+	// Firestoreからタッグ相方情報を読み取り
+	var tagPartnersPath string
+	partners, err := fs.LoadTagPartners(userKey)
+	if err != nil {
+		log.Printf("[WARN] Failed to load tag partners for custom period: %v", err)
+	}
+	if len(partners) > 0 {
+		tagPartnersPath = filepath.Join(tmpDir, "tag_partners.json")
+		if err := saveTagPartners(partners, tagPartnersPath); err != nil {
+			log.Printf("[WARN] Failed to save tag partners for custom period: %v", err)
+			tagPartnersPath = ""
+		}
+	}
+
 	args := []string{"scripts/analyze.py", jsonPath, "--start", start, "--end", end, "--ms-list", DefaultMSListPath}
+	if tagPartnersPath != "" {
+		args = append(args, "--tag-partners", tagPartnersPath)
+	}
 
 	cmd := exec.Command("python3", args...)
 	cmd.Dir = "/app"

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -10,7 +10,7 @@ import json
 import os
 import sys
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime
 
 
 def get_season(dt):
@@ -48,7 +48,8 @@ def get_season_half(dt):
 
 def load_json(path):
     with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
+        raw = json.load(f)
+    return [m for m in raw if len(m.get("players", [])) == 4]
 
 
 def detect_player_name(matches):
@@ -1088,12 +1089,12 @@ def build_period_report(all_data, ms_data, tag_partners=None):
 
 
 def filter_by_days(all_data, days):
-    """直近N日分のデータをフィルタする"""
+    """���近N日分（プレイ日基準）のデータをフィルタする"""
     if not all_data:
         return []
-    latest = max(d["datetime"] for d in all_data)
-    cutoff = latest - timedelta(days=days)
-    return [d for d in all_data if d["datetime"] >= cutoff]
+    play_dates = sorted(set(d["datetime"].date() for d in all_data), reverse=True)
+    target_dates = set(play_dates[:days])
+    return [d for d in all_data if d["datetime"].date() in target_dates]
 
 
 def filter_by_datetime_range(all_data, start, end):
@@ -1121,13 +1122,13 @@ def build_json_report(player_name, all_data, ms_data, tag_partners=None):
 
     # プリセット期間
     preset_periods = [
-        ("90d", 90, "90日間"),
-        ("60d", 60, "60日間"),
-        ("30d", 30, "30日間"),
-        ("14d", 14, "14日間"),
-        ("7d", 7, "7日間"),
-        ("3d", 3, "3日間"),
-        ("1d", 1, "1日間"),
+        ("90d", 90, "90日分"),
+        ("60d", 60, "60日分"),
+        ("30d", 30, "30日分"),
+        ("14d", 14, "14日分"),
+        ("7d", 7, "7日分"),
+        ("3d", 3, "3日分"),
+        ("1d", 1, "1日分"),
     ]
     for key, days, label in preset_periods:
         filtered = filter_by_days(all_data, days)

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 """
 EXVS2IB 戦績分析スクリプト
-CSVファイルを読み込み、JSON形式の構造化分析レポートを出力する。
-プレイヤー名はCSVのプレイヤーNo.1から自動取得する。
+JSONファイルを読み込み、JSON形式の構造化分析レポートを出力する。
+プレイヤー名はplayers[0]のnameから自動取得する。
 """
 
 import argparse
-import csv
 import json
 import os
 import sys
@@ -47,35 +46,23 @@ def get_season_half(dt):
     return "後半"
 
 
-def load_csv(path):
-    rows = []
+def load_json(path):
     with open(path, "r", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        for r in reader:
-            rows.append(r)
-    matches = []
-    for i in range(0, len(rows), 4):
-        if i + 3 < len(rows):
-            matches.append(rows[i : i + 4])
-    return matches
+        return json.load(f)
 
 
 def detect_player_name(matches):
     names = defaultdict(int)
     for m in matches:
-        name = m[0]["プレイヤー名"].strip()
+        name = m["players"][0]["name"].strip()
         if name:
             names[name] += 1
     return max(names, key=names.get) if names else ""
 
 
-def load_ms_cost_map(csv_path):
-    """ms_list.jsonから画像URL→コストのマップを生成する。
-    クエリパラメータを除去してマッチさせる。
-    """
-    ms_list_path = os.path.join(os.path.dirname(os.path.dirname(csv_path)), "data", "ms_list.json")
-    if not os.path.exists(ms_list_path):
-        # スクリプト配置場所からの相対パスでもフォールバック
+def load_ms_cost_map(ms_list_path):
+    """ms_list.jsonから画像URL→コストのマップを生成する。"""
+    if not ms_list_path or not os.path.exists(ms_list_path):
         ms_list_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "data", "ms_list.json")
     if not os.path.exists(ms_list_path):
         return {}
@@ -86,14 +73,13 @@ def load_ms_cost_map(csv_path):
         url = ms.get("ImageURL", "")
         cost = ms.get("Cost", 0)
         if url and cost:
-            # クエリパラメータを除去
             url = url.split("?")[0]
             cost_map[url] = cost
     return cost_map
 
 
 def get_player_ms(match):
-    ms = match[0]["機体名"].strip()
+    ms = match["players"][0]["ms_name"].strip()
     return ms if ms else "(不明)"
 
 
@@ -115,38 +101,39 @@ COST_LABEL = {
 
 
 def get_my_data(match, cost_map=None):
-    p = match[0]
-    p2 = match[1]
+    players = match["players"]
+    p = players[0]
+    p2 = players[1]
     cost_map = cost_map or {}
 
-    def lookup_cost(row):
-        url = row.get("機体画像URL", "").strip().split("?")[0]
+    def lookup_cost(player):
+        url = player.get("ms_image_url", "").strip().split("?")[0]
         return cost_map.get(url, 0)
 
     return {
-        "win": p["勝利判定"] in ("true", "win"),
+        "win": p["win"],
         "ms": get_player_ms(match),
         "ms_cost": lookup_cost(p),
-        "score": int(p["スコア"]),
-        "kills": int(p["撃墜数"]),
-        "deaths": int(p["被撃墜数"]),
-        "dmg_given": int(p["与ダメージ"]),
-        "dmg_taken": int(p["被ダメージ"]),
-        "ex_dmg": int(p["EXダメージ"]),
-        "datetime": datetime.strptime(p["試合日時"], "%Y-%m-%d %H:%M"),
-        "partner_name": p2["プレイヤー名"].strip(),
-        "partner_ms": p2["機体名"].strip() or "(不明)",
+        "score": p["score"],
+        "kills": p["kills"],
+        "deaths": p["deaths"],
+        "dmg_given": p["give_damage"],
+        "dmg_taken": p["receive_damage"],
+        "ex_dmg": p["ex_damage"],
+        "datetime": datetime.strptime(match["datetime"], "%Y-%m-%d %H:%M"),
+        "partner_name": p2["name"].strip(),
+        "partner_ms": p2["ms_name"].strip() or "(不明)",
         "partner_cost": lookup_cost(p2),
-        "partner_score": int(p2["スコア"]),
-        "partner_kills": int(p2["撃墜数"]),
-        "partner_deaths": int(p2["被撃墜数"]),
-        "partner_dmg_given": int(p2["与ダメージ"]),
-        "partner_dmg_taken": int(p2["被ダメージ"]),
+        "partner_score": p2["score"],
+        "partner_kills": p2["kills"],
+        "partner_deaths": p2["deaths"],
+        "partner_dmg_given": p2["give_damage"],
+        "partner_dmg_taken": p2["receive_damage"],
         "enemy_ms": [
-            match[2]["機体名"].strip() or "(不明)",
-            match[3]["機体名"].strip() or "(不明)",
+            players[2]["ms_name"].strip() or "(不明)",
+            players[3]["ms_name"].strip() or "(不明)",
         ],
-        "enemy_costs": [lookup_cost(match[2]), lookup_cost(match[3])],
+        "enemy_costs": [lookup_cost(players[2]), lookup_cost(players[3])],
     }
 
 
@@ -1179,20 +1166,20 @@ def build_custom_period_report(player_name, all_data, ms_data, start, end):
 
 def main():
     parser = argparse.ArgumentParser(description="EXVS2IB 戦績分析")
-    parser.add_argument("csv_path", help="CSVファイルパス")
+    parser.add_argument("json_path", help="試合データJSONファイルパス")
     parser.add_argument("--start", help="開始日時 (YYYY-MM-DD HH:MM)")
     parser.add_argument("--end", help="終了日時 (YYYY-MM-DD HH:MM)")
     parser.add_argument("--tag-partners", help="タッグ相方JSONファイルパス", default=None)
-    parser.add_argument("--timeline", help="タイムラインJSONファイルパス（将来の覚醒分析用）", default=None)
+    parser.add_argument("--ms-list", help="MSリストJSONファイルパス", default=None)
     args = parser.parse_args()
 
-    matches = load_csv(args.csv_path)
+    matches = load_json(args.json_path)
 
     if not matches:
         print("試合データが見つかりませんでした。")
         sys.exit(1)
 
-    cost_map = load_ms_cost_map(args.csv_path)
+    cost_map = load_ms_cost_map(args.ms_list)
     player_name = detect_player_name(matches)
     tag_partners = load_tag_partners(args.tag_partners)
 
@@ -1212,7 +1199,7 @@ def main():
     else:
         report_data = build_json_report(player_name, all_data, ms_data, tag_partners)
 
-    output_path = os.path.join(os.path.dirname(args.csv_path), "report.json")
+    output_path = os.path.join(os.path.dirname(args.json_path), "report.json")
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(report_data, f, ensure_ascii=False, indent=2)
     print(f"分析レポート(JSON)を出力しました: {output_path}")


### PR DESCRIPTION
## Summary
- パイプラインの Python 分析への入力形式を CSV から試合単位 JSON に変更
- タイムラインデータ（actions）も JSON 内に埋め込み、`--timeline` 引数を廃止
- `encoding/csv` / `strconv` 依存を削除し、`encoding/json` に一本化

## 変更内容
| ファイル | 変更 |
|---|---|
| `internal/pipeline/pipeline.go` | `saveScoresCSV` → `saveScoresJSON`、`generateTimelineJSON` 削除、`runAnalysis` 簡素化 |
| `scripts/analyze.py` | `load_csv` → `load_json`、日本語キー廃止、型変換不要に、`--ms-list` 追加 |
| `CLAUDE.md` | アーキテクチャ図を CSV→JSON に更新 |

## 新しい JSON 構造（Python 入力）
```json
[
  {
    "datetime": "2026-01-01 15:04",
    "game_end_sec": 92.0,
    "players": [
      {
        "player_no": 1, "name": "...", "win": true,
        "ms_name": "...", "score": 100, "kills": 3, "deaths": 1,
        "give_damage": 500, "receive_damage": 300, "ex_damage": 100,
        "actions": [{"action": "ex", "action_start_sec": 10.0, "action_end_sec": 15.0}],
        "..."
      }
    ]
  }
]
```

## Test plan
- [x] `go build ./...` 成功
- [x] `go vet ./...` 警告なし
- [x] `go test ./...` 全テストパス
- [x] `python3 -c "import py_compile; py_compile.compile('scripts/analyze.py', doraise=True)"` 成功
- [x] stg デプロイ後、分析実行でレポートが正常に生成される
- [x] 期間指定分析（`/period`）も正常動作

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)