### PR TITLE
feat: analyze.pyにactionsデータの読み込みとヘルパー関数を追加

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -101,6 +101,26 @@ COST_LABEL = {
 }
 
 
+def get_death_events(actions):
+    return [a for a in actions if a.get("action") == "death"]
+
+
+def get_burst_events(actions):
+    return [a for a in actions if a.get("action") in ("exbst-f", "exbst-s", "exbst-e")]
+
+
+def get_ex_ready_events(actions):
+    return [a for a in actions if a.get("action") == "ex"]
+
+
+def get_overlimit_events(actions):
+    return [a for a in actions if a.get("action") == "exbst-ov"]
+
+
+def get_ov_ready_events(actions):
+    return [a for a in actions if a.get("action") == "ov"]
+
+
 def get_my_data(match, cost_map=None):
     players = match["players"]
     p = players[0]
@@ -135,6 +155,9 @@ def get_my_data(match, cost_map=None):
             players[3]["ms_name"].strip() or "(不明)",
         ],
         "enemy_costs": [lookup_cost(players[2]), lookup_cost(players[3])],
+        "actions": p.get("actions", []),
+        "partner_actions": p2.get("actions", []),
+        "game_end_sec": match.get("game_end_sec", 0),
     }
 
 


### PR DESCRIPTION
## Summary

- `get_my_data()` に `actions`, `partner_actions`, `game_end_sec` フィールドを追加
- 覚醒・オバリミ・撃墜イベントを抽出するヘルパー関数5つを実装
- 古いデータ（フィールドなし）でもエラーにならないよう `.get()` で互換性を確保

closes #252

## Test plan

- [ ] `python3 -m py_compile scripts/analyze.py` が通ること
- [ ] 既存のレポート生成が正常に動作すること（新フィールドは追加のみで既存ロジックに影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)