### PR TITLE
feat: 先落ち/後落ち分析と覚醒使い切り分析を追加

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1078,6 +1078,126 @@ def build_share_data(all_data, ms_data):
     return items
 
 
+def data_fall_order(data_list):
+    first_fall = []
+    second_fall = []
+    same_time = []
+
+    for d in data_list:
+        my_deaths = get_death_events(d["actions"])
+        partner_deaths = get_death_events(d["partner_actions"])
+        if not my_deaths or not partner_deaths:
+            continue
+        my_first = my_deaths[0]["action_start_sec"]
+        partner_first = partner_deaths[0]["action_start_sec"]
+        if my_first < partner_first:
+            first_fall.append(d)
+        elif my_first > partner_first:
+            second_fall.append(d)
+        else:
+            same_time.append(d)
+
+    total = len(first_fall) + len(second_fall) + len(same_time)
+    if total == 0:
+        return None
+
+    first_wr = win_rate(first_fall) if first_fall else 0
+    second_wr = win_rate(second_fall) if second_fall else 0
+
+    tips = []
+    if first_fall and second_fall:
+        diff = second_wr - first_wr
+        if abs(diff) >= 5:
+            better = "後落ち" if diff > 0 else "先落ち"
+            tips.append(f"**{better}**の方が勝率 **{abs(diff):.0f}%** 高い")
+    if first_fall and total > 0:
+        first_rate = len(first_fall) / total * 100
+        if first_rate >= 60:
+            tips.append(f"先落ち率 **{first_rate:.0f}%** → 前に出すぎている可能性")
+
+    return {
+        "total": total,
+        "first_fall": {
+            "count": len(first_fall),
+            "rate": round(len(first_fall) / total * 100, 1) if total > 0 else 0,
+            "win_rate": round(first_wr, 1),
+            "avg_dmg_given": round(avg([d["dmg_given"] for d in first_fall])) if first_fall else 0,
+            "avg_dmg_taken": round(avg([d["dmg_taken"] for d in first_fall])) if first_fall else 0,
+            "dmg_efficiency": round(dmg_efficiency(first_fall), 3) if first_fall else 0,
+        },
+        "second_fall": {
+            "count": len(second_fall),
+            "rate": round(len(second_fall) / total * 100, 1) if total > 0 else 0,
+            "win_rate": round(second_wr, 1),
+            "avg_dmg_given": round(avg([d["dmg_given"] for d in second_fall])) if second_fall else 0,
+            "avg_dmg_taken": round(avg([d["dmg_taken"] for d in second_fall])) if second_fall else 0,
+            "dmg_efficiency": round(dmg_efficiency(second_fall), 3) if second_fall else 0,
+        },
+        "tips": tips,
+    }
+
+
+def data_burst_before_death(data_list):
+    used_before_death = []
+    held_at_death = []
+
+    for d in data_list:
+        actions = d["actions"]
+        deaths = get_death_events(actions)
+        bursts = get_burst_events(actions)
+        ex_readies = get_ex_ready_events(actions)
+        if not deaths:
+            continue
+
+        for death in deaths:
+            death_time = death["action_start_sec"]
+            burst_used = any(
+                b["action_end_sec"] <= death_time
+                for b in bursts
+                if b["action_start_sec"] < death_time and b["action_end_sec"] > 0
+            )
+            had_gauge = any(
+                e["action_start_sec"] < death_time
+                for e in ex_readies
+            )
+            if not had_gauge:
+                continue
+            if burst_used:
+                used_before_death.append(d)
+            else:
+                held_at_death.append(d)
+
+    total = len(used_before_death) + len(held_at_death)
+    if total == 0:
+        return None
+
+    used_wr = win_rate(used_before_death) if used_before_death else 0
+    held_wr = win_rate(held_at_death) if held_at_death else 0
+
+    tips = []
+    if used_before_death and held_at_death:
+        diff = used_wr - held_wr
+        if diff > 0:
+            tips.append(f"覚醒を使い切ってから落ちた試合の勝率が **{diff:.0f}%** 高い")
+        if len(held_at_death) / total * 100 >= 30:
+            tips.append(f"覚醒を抱えたまま落ちた割合 **{len(held_at_death) / total * 100:.0f}%** → ゲージが溜まったら早めに使おう")
+
+    return {
+        "total": total,
+        "used_before_death": {
+            "count": len(used_before_death),
+            "rate": round(len(used_before_death) / total * 100, 1),
+            "win_rate": round(used_wr, 1),
+        },
+        "held_at_death": {
+            "count": len(held_at_death),
+            "rate": round(len(held_at_death) / total * 100, 1),
+            "win_rate": round(held_wr, 1),
+        },
+        "tips": tips,
+    }
+
+
 def build_period_report(all_data, ms_data, tag_partners=None):
     """1期間分の分析レポートを生成する"""
     ms_names = [ms for ms in sorted(ms_data.keys(), key=lambda x: -len(ms_data[x])) if len(ms_data[ms]) >= 3]
@@ -1103,6 +1223,9 @@ def build_period_report(all_data, ms_data, tag_partners=None):
         "win_loss_pattern": data_win_loss_pattern(all_data),
         "ms_stats": ms_stats,
         "fixed_partners": data_fixed_partners(all_data, tag_partners),
+
+        "fall_order": data_fall_order(all_data),
+        "burst_before_death": data_burst_before_death(all_data),
 
         "time_of_day": data_time_of_day(all_data),
         "day_of_week": data_day_of_week(all_data),

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1151,18 +1151,16 @@ def data_burst_before_death(data_list):
 
         for death in deaths:
             death_time = death["action_start_sec"]
-            burst_used = any(
-                b["action_end_sec"] <= death_time
-                for b in bursts
-                if b["action_start_sec"] < death_time and b["action_end_sec"] > 0
-            )
-            had_gauge = any(
-                e["action_start_sec"] < death_time
-                for e in ex_readies
-            )
-            if not had_gauge:
+            relevant_ex = [e for e in ex_readies if e["action_start_sec"] < death_time]
+            if not relevant_ex:
                 continue
-            if burst_used:
+            last_ex_time = max(e["action_start_sec"] for e in relevant_ex)
+            burst_after_last_ex = any(
+                b["action_start_sec"] >= last_ex_time and b["action_end_sec"] <= death_time
+                for b in bursts
+                if b["action_end_sec"] > 0
+            )
+            if burst_after_last_ex:
                 used_before_death.append(d)
             else:
                 held_at_death.append(d)

--- a/static/app.js
+++ b/static/app.js
@@ -1107,6 +1107,38 @@ function SeasonSection({ seasons }) {
   <//>`;
 }
 
+// --- Fall order / Burst before death ---
+
+function FallOrderSection({ fallOrder }) {
+  if (!fallOrder) return null;
+  var f = fallOrder.first_fall;
+  var s = fallOrder.second_fall;
+  var rows = [
+    ['先落ち', f.count + '戦 (' + f.rate + '%)', colorPct(f.win_rate), colorDmgGiven(f.avg_dmg_given), colorDmgTaken(f.avg_dmg_taken), colorDE(f.dmg_efficiency, 3)],
+    ['後落ち', s.count + '戦 (' + s.rate + '%)', colorPct(s.win_rate), colorDmgGiven(s.avg_dmg_given), colorDmgTaken(s.avg_dmg_taken), colorDE(s.dmg_efficiency, 3)],
+  ];
+  return html`<${Section} title="先落ち/後落ち分析">
+    <p>対象: ${fallOrder.total}戦（自分と相方の両方に撃墜データがある試合）</p>
+    <${Table} headers=${['パターン', '試合数', '勝率', '与ダメ', '被ダメ', '与被ダメ比']} rows=${rows} />
+    <${Tips} tips=${fallOrder.tips} />
+  <//>`;
+}
+
+function BurstBeforeDeathSection({ burstData }) {
+  if (!burstData) return null;
+  var u = burstData.used_before_death;
+  var h = burstData.held_at_death;
+  var rows = [
+    ['覚醒使い切り後に落ち', u.count + '回 (' + u.rate + '%)', colorPct(u.win_rate)],
+    ['覚醒未使用で落ち', h.count + '回 (' + h.rate + '%)', colorPct(h.win_rate)],
+  ];
+  return html`<${Section} title="覚醒使い切り分析">
+    <p>覚醒ゲージが溜まった後の撃墜 ${burstData.total}回を分析</p>
+    <${Table} headers=${['パターン', '回数', '勝率']} rows=${rows} />
+    <${Tips} tips=${burstData.tips} />
+  <//>`;
+}
+
 // --- Share area ---
 
 function ShareArea({ shareData }) {
@@ -1174,6 +1206,8 @@ function TableOfContents({ data }) {
           </details>
         </li>`}
         <li><a href="#sec-fixed">固定相方分析</a></li>
+        ${data.fall_order && html`<li><a href="#sec-fall-order">先落ち/後落ち分析</a></li>`}
+        ${data.burst_before_death && html`<li><a href="#sec-burst-death">覚醒使い切り分析</a></li>`}
         <li><a href="#sec-time">時間帯別の勝率</a></li>
         <li><a href="#sec-dow">曜日別の勝率</a></li>
         <li><a href="#sec-daily">日別勝率</a></li>
@@ -1225,6 +1259,8 @@ function Report({ data, userKey }) {
     <//></div>
     <div key="sec-ms"><${MsStatsSection} msStats=${pd.ms_stats} /></div>
     <div key="sec-fixed" id="sec-fixed"><${FixedPartnersSection} partners=${pd.fixed_partners} /></div>
+    <div key="sec-fall-order" id="sec-fall-order"><${FallOrderSection} fallOrder=${pd.fall_order} /></div>
+    <div key="sec-burst-death" id="sec-burst-death"><${BurstBeforeDeathSection} burstData=${pd.burst_before_death} /></div>
     <div key="sec-time" id="sec-time"><${TimeOfDaySection} time=${pd.time_of_day} /></div>
     <div key="sec-dow" id="sec-dow"><${DayOfWeekSection} dow=${pd.day_of_week} /></div>
     <div key="sec-daily" id="sec-daily"><${DailyTrendSection} daily=${pd.daily_trend} /></div>


### PR DESCRIPTION
## Summary

- 先落ち/後落ち分析: 自分と相方の最初の撃墜タイミングを比較し、先落ち率・パターン別の勝率・与被ダメ・与被ダメ比を表示
- 覚醒使い切り分析: 覚醒ゲージMAX後の撃墜で、覚醒を使い切って落ちたか/抱えたまま落ちたかを判定し勝率を比較
- actionsデータがない試合（古いデータ）では自動的にスキップしセクション非表示

closes #253

## Test plan

- [x] `python3 -m py_compile scripts/analyze.py` が通ること
- [ ] actionsデータのある試合で「先落ち/後落ち分析」セクションが表示されること
- [ ] actionsデータのある試合で「覚醒使い切り分析」セクションが表示されること
- [ ] actionsデータのない試合のみの場合、両セクションが非表示になること
- [ ] 目次に覚醒データがある場合のみリンクが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)