### PR TITLE
feat: 覚醒抱え落ち判定と覚醒回数分析を追加

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1196,6 +1196,111 @@ def data_burst_before_death(data_list):
     }
 
 
+def data_burst_hold_death(data_list):
+    hold_deaths = []
+    no_hold_deaths = []
+
+    for d in data_list:
+        actions = d["actions"]
+        deaths = get_death_events(actions)
+        bursts = get_burst_events(actions)
+        ex_readies = get_ex_ready_events(actions)
+        if not deaths or not ex_readies:
+            continue
+
+        has_hold = False
+        for death in deaths:
+            death_time = death["action_start_sec"]
+            relevant_ex = [e for e in ex_readies if e["action_start_sec"] < death_time]
+            if not relevant_ex:
+                continue
+            last_ex_time = max(e["action_start_sec"] for e in relevant_ex)
+            burst_used = any(
+                b["action_start_sec"] >= last_ex_time
+                for b in bursts
+                if b["action_start_sec"] < death_time
+            )
+            if not burst_used:
+                has_hold = True
+                break
+
+        if has_hold:
+            hold_deaths.append(d)
+        else:
+            no_hold_deaths.append(d)
+
+    total = len(hold_deaths) + len(no_hold_deaths)
+    if total == 0:
+        return None
+
+    hold_wr = win_rate(hold_deaths) if hold_deaths else 0
+    no_hold_wr = win_rate(no_hold_deaths) if no_hold_deaths else 0
+
+    tips = []
+    if hold_deaths:
+        hold_rate = len(hold_deaths) / total * 100
+        tips.append(f"抱え落ちが発生した試合 **{len(hold_deaths)}/{total}戦**（**{hold_rate:.0f}%**）")
+    if hold_deaths and no_hold_deaths:
+        diff = no_hold_wr - hold_wr
+        if diff > 0:
+            tips.append(f"抱え落ちなしの試合の方が勝率 **{diff:.0f}%** 高い")
+
+    return {
+        "total": total,
+        "hold_death": {
+            "count": len(hold_deaths),
+            "rate": round(len(hold_deaths) / total * 100, 1),
+            "win_rate": round(hold_wr, 1),
+        },
+        "no_hold_death": {
+            "count": len(no_hold_deaths),
+            "rate": round(len(no_hold_deaths) / total * 100, 1),
+            "win_rate": round(no_hold_wr, 1),
+        },
+        "tips": tips,
+    }
+
+
+def data_burst_count(data_list):
+    by_count = defaultdict(list)
+
+    for d in data_list:
+        bursts = get_burst_events(d["actions"])
+        if not d["actions"]:
+            continue
+        count = len(bursts)
+        by_count[count].append(d)
+
+    if not by_count:
+        return None
+
+    results = []
+    for count in sorted(by_count.keys()):
+        matches = by_count[count]
+        wr = win_rate(matches)
+        results.append({
+            "count": count,
+            "label": f"{count}回" if count > 0 else "0回（未覚醒）",
+            "matches": len(matches),
+            "win_rate": round(wr, 1),
+        })
+
+    tips = []
+    if 2 in by_count and len(by_count[2]) >= 3:
+        wr_2 = win_rate(by_count[2])
+        others = [d for c, ds in by_count.items() if c < 2 for d in ds]
+        if others:
+            wr_other = win_rate(others)
+            diff = wr_2 - wr_other
+            if diff > 0:
+                tips.append(f"2回覚醒できた試合の勝率が **{diff:.0f}%** 高い → ゲージ管理と耐久管理が重要")
+
+    return {
+        "by_count": results,
+        "tips": tips,
+    }
+
+
 def build_period_report(all_data, ms_data, tag_partners=None):
     """1期間分の分析レポートを生成する"""
     ms_names = [ms for ms in sorted(ms_data.keys(), key=lambda x: -len(ms_data[x])) if len(ms_data[ms]) >= 3]
@@ -1224,6 +1329,8 @@ def build_period_report(all_data, ms_data, tag_partners=None):
 
         "fall_order": data_fall_order(all_data),
         "burst_before_death": data_burst_before_death(all_data),
+        "burst_hold_death": data_burst_hold_death(all_data),
+        "burst_count": data_burst_count(all_data),
 
         "time_of_day": data_time_of_day(all_data),
         "day_of_week": data_day_of_week(all_data),

--- a/static/app.js
+++ b/static/app.js
@@ -1139,6 +1139,32 @@ function BurstBeforeDeathSection({ burstData }) {
   <//>`;
 }
 
+function BurstHoldDeathSection({ holdData }) {
+  if (!holdData) return null;
+  var hd = holdData.hold_death;
+  var nhd = holdData.no_hold_death;
+  var rows = [
+    ['抱え落ちあり', hd.count + '戦 (' + hd.rate + '%)', colorPct(hd.win_rate)],
+    ['抱え落ちなし', nhd.count + '戦 (' + nhd.rate + '%)', colorPct(nhd.win_rate)],
+  ];
+  return html`<${Section} title="覚醒抱え落ち分析">
+    <p>覚醒ゲージMAX後に発動せず撃墜された試合を検出（対象: ${holdData.total}戦）</p>
+    <${Table} headers=${['パターン', '試合数', '勝率']} rows=${rows} />
+    <${Tips} tips=${holdData.tips} />
+  <//>`;
+}
+
+function BurstCountSection({ countData }) {
+  if (!countData || !countData.by_count || !countData.by_count.length) return null;
+  var rows = countData.by_count.map(function (c) {
+    return [c.label, c.matches + '戦', colorPct(c.win_rate)];
+  });
+  return html`<${Section} title="覚醒回数分析">
+    <${Table} headers=${['覚醒回数', '試合数', '勝率']} rows=${rows} />
+    <${Tips} tips=${countData.tips} />
+  <//>`;
+}
+
 // --- Share area ---
 
 function ShareArea({ shareData }) {
@@ -1208,6 +1234,8 @@ function TableOfContents({ data }) {
         <li><a href="#sec-fixed">固定相方分析</a></li>
         ${data.fall_order && html`<li><a href="#sec-fall-order">先落ち/後落ち分析</a></li>`}
         ${data.burst_before_death && html`<li><a href="#sec-burst-death">覚醒使い切り分析</a></li>`}
+        ${data.burst_hold_death && html`<li><a href="#sec-burst-hold">覚醒抱え落ち分析</a></li>`}
+        ${data.burst_count && html`<li><a href="#sec-burst-count">覚醒回数分析</a></li>`}
         <li><a href="#sec-time">時間帯別の勝率</a></li>
         <li><a href="#sec-dow">曜日別の勝率</a></li>
         <li><a href="#sec-daily">日別勝率</a></li>
@@ -1261,6 +1289,8 @@ function Report({ data, userKey }) {
     <div key="sec-fixed" id="sec-fixed"><${FixedPartnersSection} partners=${pd.fixed_partners} /></div>
     <div key="sec-fall-order" id="sec-fall-order"><${FallOrderSection} fallOrder=${pd.fall_order} /></div>
     <div key="sec-burst-death" id="sec-burst-death"><${BurstBeforeDeathSection} burstData=${pd.burst_before_death} /></div>
+    <div key="sec-burst-hold" id="sec-burst-hold"><${BurstHoldDeathSection} holdData=${pd.burst_hold_death} /></div>
+    <div key="sec-burst-count" id="sec-burst-count"><${BurstCountSection} countData=${pd.burst_count} /></div>
     <div key="sec-time" id="sec-time"><${TimeOfDaySection} time=${pd.time_of_day} /></div>
     <div key="sec-dow" id="sec-dow"><${DayOfWeekSection} dow=${pd.day_of_week} /></div>
     <div key="sec-daily" id="sec-daily"><${DailyTrendSection} daily=${pd.daily_trend} /></div>


### PR DESCRIPTION
## Summary

- 覚醒抱え落ち分析: ゲージMAX(`ex`)後に`exbst-*`発動なく撃墜された試合を検出し、抱え落ちあり/なしの勝率を比較
- 覚醒回数分析: 1試合中の覚醒発動回数(0/1/2回)別の勝率を分析。2回覚醒できた試合の勝率差をTipsで表示

closes #254

## Test plan

- [x] `python3 -m py_compile scripts/analyze.py` が通ること
- [ ] actionsデータのある試合で「覚醒抱え落ち分析」セクションが表示されること
- [ ] actionsデータのある試合で「覚醒回数分析」セクションが表示されること
- [ ] actionsデータのない試合のみの場合、両セクションが非表示になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)