### PR TITLE
fix: 先落ち/後落ち分析に0落ちを追加し機体別分析に移動

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1082,7 +1082,6 @@ def data_fall_order(data_list):
     no_fall = []
     first_fall = []
     second_fall = []
-    same_time = []
 
     for d in data_list:
         my_deaths = get_death_events(d["actions"])
@@ -1094,14 +1093,12 @@ def data_fall_order(data_list):
         else:
             my_first = my_deaths[0]["action_start_sec"]
             partner_first = partner_deaths[0]["action_start_sec"]
-            if my_first < partner_first:
+            if my_first <= partner_first:
                 first_fall.append(d)
-            elif my_first > partner_first:
-                second_fall.append(d)
             else:
-                same_time.append(d)
+                second_fall.append(d)
 
-    total = len(no_fall) + len(first_fall) + len(second_fall) + len(same_time)
+    total = len(no_fall) + len(first_fall) + len(second_fall)
     if total == 0:
         return None
 
@@ -1125,7 +1122,7 @@ def data_fall_order(data_list):
         if abs(diff) >= 5:
             better = "後落ち" if diff > 0 else "先落ち"
             tips.append(f"**{better}**の方が勝率 **{abs(diff):.0f}%** 高い")
-    fall_total = len(first_fall) + len(second_fall) + len(same_time)
+    fall_total = len(first_fall) + len(second_fall)
     if first_fall and fall_total > 0:
         first_rate = len(first_fall) / fall_total * 100
         if first_rate >= 60:

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1079,6 +1079,7 @@ def build_share_data(all_data, ms_data):
 
 
 def data_fall_order(data_list):
+    no_fall = []
     first_fall = []
     second_fall = []
     same_time = []
@@ -1086,21 +1087,35 @@ def data_fall_order(data_list):
     for d in data_list:
         my_deaths = get_death_events(d["actions"])
         partner_deaths = get_death_events(d["partner_actions"])
-        if not my_deaths or not partner_deaths:
-            continue
-        my_first = my_deaths[0]["action_start_sec"]
-        partner_first = partner_deaths[0]["action_start_sec"]
-        if my_first < partner_first:
+        if not my_deaths:
+            no_fall.append(d)
+        elif not partner_deaths:
             first_fall.append(d)
-        elif my_first > partner_first:
-            second_fall.append(d)
         else:
-            same_time.append(d)
+            my_first = my_deaths[0]["action_start_sec"]
+            partner_first = partner_deaths[0]["action_start_sec"]
+            if my_first < partner_first:
+                first_fall.append(d)
+            elif my_first > partner_first:
+                second_fall.append(d)
+            else:
+                same_time.append(d)
 
-    total = len(first_fall) + len(second_fall) + len(same_time)
+    total = len(no_fall) + len(first_fall) + len(second_fall) + len(same_time)
     if total == 0:
         return None
 
+    def build_stats(matches):
+        return {
+            "count": len(matches),
+            "rate": round(len(matches) / total * 100, 1) if total > 0 else 0,
+            "win_rate": round(win_rate(matches), 1) if matches else 0,
+            "avg_dmg_given": round(avg([d["dmg_given"] for d in matches])) if matches else 0,
+            "avg_dmg_taken": round(avg([d["dmg_taken"] for d in matches])) if matches else 0,
+            "dmg_efficiency": round(dmg_efficiency(matches), 3) if matches else 0,
+        }
+
+    no_fall_wr = win_rate(no_fall) if no_fall else 0
     first_wr = win_rate(first_fall) if first_fall else 0
     second_wr = win_rate(second_fall) if second_fall else 0
 
@@ -1110,29 +1125,21 @@ def data_fall_order(data_list):
         if abs(diff) >= 5:
             better = "後落ち" if diff > 0 else "先落ち"
             tips.append(f"**{better}**の方が勝率 **{abs(diff):.0f}%** 高い")
-    if first_fall and total > 0:
-        first_rate = len(first_fall) / total * 100
+    fall_total = len(first_fall) + len(second_fall) + len(same_time)
+    if first_fall and fall_total > 0:
+        first_rate = len(first_fall) / fall_total * 100
         if first_rate >= 60:
             tips.append(f"先落ち率 **{first_rate:.0f}%** → 前に出すぎている可能性")
+    if no_fall and first_fall:
+        diff = no_fall_wr - first_wr
+        if diff >= 10:
+            tips.append(f"0落ちの試合は先落ちより勝率 **{diff:.0f}%** 高い → 耐久管理が重要")
 
     return {
         "total": total,
-        "first_fall": {
-            "count": len(first_fall),
-            "rate": round(len(first_fall) / total * 100, 1) if total > 0 else 0,
-            "win_rate": round(first_wr, 1),
-            "avg_dmg_given": round(avg([d["dmg_given"] for d in first_fall])) if first_fall else 0,
-            "avg_dmg_taken": round(avg([d["dmg_taken"] for d in first_fall])) if first_fall else 0,
-            "dmg_efficiency": round(dmg_efficiency(first_fall), 3) if first_fall else 0,
-        },
-        "second_fall": {
-            "count": len(second_fall),
-            "rate": round(len(second_fall) / total * 100, 1) if total > 0 else 0,
-            "win_rate": round(second_wr, 1),
-            "avg_dmg_given": round(avg([d["dmg_given"] for d in second_fall])) if second_fall else 0,
-            "avg_dmg_taken": round(avg([d["dmg_taken"] for d in second_fall])) if second_fall else 0,
-            "dmg_efficiency": round(dmg_efficiency(second_fall), 3) if second_fall else 0,
-        },
+        "no_fall": build_stats(no_fall),
+        "first_fall": build_stats(first_fall),
+        "second_fall": build_stats(second_fall),
         "tips": tips,
     }
 
@@ -1213,6 +1220,8 @@ def build_period_report(all_data, ms_data, tag_partners=None):
             "cost_pair": data_cost_pair(data),
             "dmg_contribution": data_dmg_contribution(data),
             "deaths_impact": data_deaths_impact(data),
+            "fall_order": data_fall_order(data),
+            "burst_before_death": data_burst_before_death(data),
         }
 
     return {
@@ -1221,9 +1230,6 @@ def build_period_report(all_data, ms_data, tag_partners=None):
         "win_loss_pattern": data_win_loss_pattern(all_data),
         "ms_stats": ms_stats,
         "fixed_partners": data_fixed_partners(all_data, tag_partners),
-
-        "fall_order": data_fall_order(all_data),
-        "burst_before_death": data_burst_before_death(all_data),
 
         "time_of_day": data_time_of_day(all_data),
         "day_of_week": data_day_of_week(all_data),

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1082,6 +1082,7 @@ def data_fall_order(data_list):
     no_fall = []
     first_fall = []
     second_fall = []
+    same_time = []
 
     for d in data_list:
         my_deaths = get_death_events(d["actions"])
@@ -1093,12 +1094,14 @@ def data_fall_order(data_list):
         else:
             my_first = my_deaths[0]["action_start_sec"]
             partner_first = partner_deaths[0]["action_start_sec"]
-            if my_first <= partner_first:
+            if my_first < partner_first:
                 first_fall.append(d)
-            else:
+            elif my_first > partner_first:
                 second_fall.append(d)
+            else:
+                same_time.append(d)
 
-    total = len(no_fall) + len(first_fall) + len(second_fall)
+    total = len(no_fall) + len(first_fall) + len(second_fall) + len(same_time)
     if total == 0:
         return None
 
@@ -1122,7 +1125,7 @@ def data_fall_order(data_list):
         if abs(diff) >= 5:
             better = "後落ち" if diff > 0 else "先落ち"
             tips.append(f"**{better}**の方が勝率 **{abs(diff):.0f}%** 高い")
-    fall_total = len(first_fall) + len(second_fall)
+    fall_total = len(first_fall) + len(second_fall) + len(same_time)
     if first_fall and fall_total > 0:
         first_rate = len(first_fall) / fall_total * 100
         if first_rate >= 60:
@@ -1137,6 +1140,7 @@ def data_fall_order(data_list):
         "no_fall": build_stats(no_fall),
         "first_fall": build_stats(first_fall),
         "second_fall": build_stats(second_fall),
+        "same_time": build_stats(same_time),
         "tips": tips,
     }
 

--- a/static/app.js
+++ b/static/app.js
@@ -652,6 +652,12 @@ function MsStatsSection({ msStats }) {
       <${SubSection} title="ダメージ貢献率">
         <${DmgContributionSubSection} dmg=${ms.dmg_contribution} />
       <//>
+      ${ms.fall_order && html`<${SubSection} title="先落ち/後落ち分析">
+        <${FallOrderContent} fallOrder=${ms.fall_order} />
+      <//>`}
+      ${ms.burst_before_death && html`<${SubSection} title="覚醒使い切り分析">
+        <${BurstBeforeDeathContent} burstData=${ms.burst_before_death} />
+      <//>`}
     <//></div>`;
   });
 }
@@ -1109,22 +1115,24 @@ function SeasonSection({ seasons }) {
 
 // --- Fall order / Burst before death ---
 
-function FallOrderSection({ fallOrder }) {
+function FallOrderContent({ fallOrder }) {
   if (!fallOrder) return null;
+  var n = fallOrder.no_fall;
   var f = fallOrder.first_fall;
   var s = fallOrder.second_fall;
   var rows = [
+    ['0落ち', n.count + '戦 (' + n.rate + '%)', colorPct(n.win_rate), colorDmgGiven(n.avg_dmg_given), colorDmgTaken(n.avg_dmg_taken), colorDE(n.dmg_efficiency, 3)],
     ['先落ち', f.count + '戦 (' + f.rate + '%)', colorPct(f.win_rate), colorDmgGiven(f.avg_dmg_given), colorDmgTaken(f.avg_dmg_taken), colorDE(f.dmg_efficiency, 3)],
     ['後落ち', s.count + '戦 (' + s.rate + '%)', colorPct(s.win_rate), colorDmgGiven(s.avg_dmg_given), colorDmgTaken(s.avg_dmg_taken), colorDE(s.dmg_efficiency, 3)],
   ];
-  return html`<${Section} title="先落ち/後落ち分析">
-    <p>対象: ${fallOrder.total}戦（自分と相方の両方に撃墜データがある試合）</p>
+  return html`<div>
+    <p>対象: ${fallOrder.total}戦</p>
     <${Table} headers=${['パターン', '試合数', '勝率', '与ダメ', '被ダメ', '与被ダメ比']} rows=${rows} />
     <${Tips} tips=${fallOrder.tips} />
-  <//>`;
+  </div>`;
 }
 
-function BurstBeforeDeathSection({ burstData }) {
+function BurstBeforeDeathContent({ burstData }) {
   if (!burstData) return null;
   var u = burstData.used_before_death;
   var h = burstData.held_at_death;
@@ -1132,11 +1140,11 @@ function BurstBeforeDeathSection({ burstData }) {
     ['覚醒使い切り後に落ち', u.count + '回 (' + u.rate + '%)', colorPct(u.win_rate)],
     ['覚醒未使用で落ち', h.count + '回 (' + h.rate + '%)', colorPct(h.win_rate)],
   ];
-  return html`<${Section} title="覚醒使い切り分析">
+  return html`<div>
     <p>覚醒ゲージが溜まった後の撃墜 ${burstData.total}回を分析</p>
     <${Table} headers=${['パターン', '回数', '勝率']} rows=${rows} />
     <${Tips} tips=${burstData.tips} />
-  <//>`;
+  </div>`;
 }
 
 // --- Share area ---
@@ -1206,8 +1214,6 @@ function TableOfContents({ data }) {
           </details>
         </li>`}
         <li><a href="#sec-fixed">固定相方分析</a></li>
-        ${data.fall_order && html`<li><a href="#sec-fall-order">先落ち/後落ち分析</a></li>`}
-        ${data.burst_before_death && html`<li><a href="#sec-burst-death">覚醒使い切り分析</a></li>`}
         <li><a href="#sec-time">時間帯別の勝率</a></li>
         <li><a href="#sec-dow">曜日別の勝率</a></li>
         <li><a href="#sec-daily">日別勝率</a></li>
@@ -1259,8 +1265,6 @@ function Report({ data, userKey }) {
     <//></div>
     <div key="sec-ms"><${MsStatsSection} msStats=${pd.ms_stats} /></div>
     <div key="sec-fixed" id="sec-fixed"><${FixedPartnersSection} partners=${pd.fixed_partners} /></div>
-    <div key="sec-fall-order" id="sec-fall-order"><${FallOrderSection} fallOrder=${pd.fall_order} /></div>
-    <div key="sec-burst-death" id="sec-burst-death"><${BurstBeforeDeathSection} burstData=${pd.burst_before_death} /></div>
     <div key="sec-time" id="sec-time"><${TimeOfDaySection} time=${pd.time_of_day} /></div>
     <div key="sec-dow" id="sec-dow"><${DayOfWeekSection} dow=${pd.day_of_week} /></div>
     <div key="sec-daily" id="sec-daily"><${DailyTrendSection} daily=${pd.daily_trend} /></div>

--- a/static/app.js
+++ b/static/app.js
@@ -1120,10 +1120,12 @@ function FallOrderContent({ fallOrder }) {
   var n = fallOrder.no_fall;
   var f = fallOrder.first_fall;
   var s = fallOrder.second_fall;
+  var st = fallOrder.same_time;
   var rows = [
     ['0落ち', n.count + '戦 (' + n.rate + '%)', colorPct(n.win_rate), colorDmgGiven(n.avg_dmg_given), colorDmgTaken(n.avg_dmg_taken), colorDE(n.dmg_efficiency, 3)],
     ['先落ち', f.count + '戦 (' + f.rate + '%)', colorPct(f.win_rate), colorDmgGiven(f.avg_dmg_given), colorDmgTaken(f.avg_dmg_taken), colorDE(f.dmg_efficiency, 3)],
     ['後落ち', s.count + '戦 (' + s.rate + '%)', colorPct(s.win_rate), colorDmgGiven(s.avg_dmg_given), colorDmgTaken(s.avg_dmg_taken), colorDE(s.dmg_efficiency, 3)],
+    ['同時落ち', st.count + '戦 (' + st.rate + '%)', colorPct(st.win_rate), colorDmgGiven(st.avg_dmg_given), colorDmgTaken(st.avg_dmg_taken), colorDE(st.dmg_efficiency, 3)],
   ];
   return html`<div>
     <p>対象: ${fallOrder.total}戦</p>


### PR DESCRIPTION
## Summary
- `data_fall_order`に「0落ち」カテゴリを追加。自分が撃墜されなかった試合も分析対象に含める
- 相方が0落ちで自分だけ撃墜された試合を「先落ち」としてカウント（従来は両方に撃墜データがある試合のみ対象だった）
- `fall_order`と`burst_before_death`をトップレベルのセクションから各機体別分析（`ms_stats`）内に移動
- 0落ちの勝率が先落ちより10%以上高い場合、耐久管理のtipsを表示

## Test plan
- [ ] stg環境で分析を実行し、機体別分析内に先落ち/後落ち分析と覚醒使い切り分析が表示されることを確認
- [ ] 0落ち・先落ち・後落ちの3行がテーブルに表示されることを確認
- [ ] トップレベルに先落ち/後落ち分析・覚醒使い切り分析が表示されないことを確認
- [ ] 目次から先落ち/後落ち分析・覚醒使い切り分析のリンクが消えていることを確認
- [ ] 各機体の試合数に応じた分析結果になっていること（全体合算ではなく機体別のデータ）

Closes #258

🤖 Generated with [Claude Code](https://claude.ai/code)