### PR TITLE
fix: 先落ち分析に0落ち/同時落ちを追加し全覚醒分析を機体別に移動

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1079,6 +1079,7 @@ def build_share_data(all_data, ms_data):
 
 
 def data_fall_order(data_list):
+    no_fall = []
     first_fall = []
     second_fall = []
     same_time = []
@@ -1086,21 +1087,35 @@ def data_fall_order(data_list):
     for d in data_list:
         my_deaths = get_death_events(d["actions"])
         partner_deaths = get_death_events(d["partner_actions"])
-        if not my_deaths or not partner_deaths:
-            continue
-        my_first = my_deaths[0]["action_start_sec"]
-        partner_first = partner_deaths[0]["action_start_sec"]
-        if my_first < partner_first:
+        if not my_deaths:
+            no_fall.append(d)
+        elif not partner_deaths:
             first_fall.append(d)
-        elif my_first > partner_first:
-            second_fall.append(d)
         else:
-            same_time.append(d)
+            my_first = my_deaths[0]["action_start_sec"]
+            partner_first = partner_deaths[0]["action_start_sec"]
+            if my_first < partner_first:
+                first_fall.append(d)
+            elif my_first > partner_first:
+                second_fall.append(d)
+            else:
+                same_time.append(d)
 
-    total = len(first_fall) + len(second_fall) + len(same_time)
+    total = len(no_fall) + len(first_fall) + len(second_fall) + len(same_time)
     if total == 0:
         return None
 
+    def build_stats(matches):
+        return {
+            "count": len(matches),
+            "rate": round(len(matches) / total * 100, 1) if total > 0 else 0,
+            "win_rate": round(win_rate(matches), 1) if matches else 0,
+            "avg_dmg_given": round(avg([d["dmg_given"] for d in matches])) if matches else 0,
+            "avg_dmg_taken": round(avg([d["dmg_taken"] for d in matches])) if matches else 0,
+            "dmg_efficiency": round(dmg_efficiency(matches), 3) if matches else 0,
+        }
+
+    no_fall_wr = win_rate(no_fall) if no_fall else 0
     first_wr = win_rate(first_fall) if first_fall else 0
     second_wr = win_rate(second_fall) if second_fall else 0
 
@@ -1110,29 +1125,22 @@ def data_fall_order(data_list):
         if abs(diff) >= 5:
             better = "後落ち" if diff > 0 else "先落ち"
             tips.append(f"**{better}**の方が勝率 **{abs(diff):.0f}%** 高い")
-    if first_fall and total > 0:
-        first_rate = len(first_fall) / total * 100
+    fall_total = len(first_fall) + len(second_fall) + len(same_time)
+    if first_fall and fall_total > 0:
+        first_rate = len(first_fall) / fall_total * 100
         if first_rate >= 60:
             tips.append(f"先落ち率 **{first_rate:.0f}%** → 前に出すぎている可能性")
+    if no_fall and first_fall:
+        diff = no_fall_wr - first_wr
+        if diff >= 10:
+            tips.append(f"0落ちの試合は先落ちより勝率 **{diff:.0f}%** 高い → 耐久管理が重要")
 
     return {
         "total": total,
-        "first_fall": {
-            "count": len(first_fall),
-            "rate": round(len(first_fall) / total * 100, 1) if total > 0 else 0,
-            "win_rate": round(first_wr, 1),
-            "avg_dmg_given": round(avg([d["dmg_given"] for d in first_fall])) if first_fall else 0,
-            "avg_dmg_taken": round(avg([d["dmg_taken"] for d in first_fall])) if first_fall else 0,
-            "dmg_efficiency": round(dmg_efficiency(first_fall), 3) if first_fall else 0,
-        },
-        "second_fall": {
-            "count": len(second_fall),
-            "rate": round(len(second_fall) / total * 100, 1) if total > 0 else 0,
-            "win_rate": round(second_wr, 1),
-            "avg_dmg_given": round(avg([d["dmg_given"] for d in second_fall])) if second_fall else 0,
-            "avg_dmg_taken": round(avg([d["dmg_taken"] for d in second_fall])) if second_fall else 0,
-            "dmg_efficiency": round(dmg_efficiency(second_fall), 3) if second_fall else 0,
-        },
+        "no_fall": build_stats(no_fall),
+        "first_fall": build_stats(first_fall),
+        "second_fall": build_stats(second_fall),
+        "same_time": build_stats(same_time),
         "tips": tips,
     }
 
@@ -1318,6 +1326,10 @@ def build_period_report(all_data, ms_data, tag_partners=None):
             "cost_pair": data_cost_pair(data),
             "dmg_contribution": data_dmg_contribution(data),
             "deaths_impact": data_deaths_impact(data),
+            "fall_order": data_fall_order(data),
+            "burst_before_death": data_burst_before_death(data),
+            "burst_hold_death": data_burst_hold_death(data),
+            "burst_count": data_burst_count(data),
         }
 
     return {
@@ -1326,11 +1338,6 @@ def build_period_report(all_data, ms_data, tag_partners=None):
         "win_loss_pattern": data_win_loss_pattern(all_data),
         "ms_stats": ms_stats,
         "fixed_partners": data_fixed_partners(all_data, tag_partners),
-
-        "fall_order": data_fall_order(all_data),
-        "burst_before_death": data_burst_before_death(all_data),
-        "burst_hold_death": data_burst_hold_death(all_data),
-        "burst_count": data_burst_count(all_data),
 
         "time_of_day": data_time_of_day(all_data),
         "day_of_week": data_day_of_week(all_data),

--- a/static/app.js
+++ b/static/app.js
@@ -652,6 +652,18 @@ function MsStatsSection({ msStats }) {
       <${SubSection} title="ダメージ貢献率">
         <${DmgContributionSubSection} dmg=${ms.dmg_contribution} />
       <//>
+      ${ms.fall_order && html`<${SubSection} title="先落ち/後落ち分析">
+        <${FallOrderContent} fallOrder=${ms.fall_order} />
+      <//>`}
+      ${ms.burst_before_death && html`<${SubSection} title="覚醒使い切り分析">
+        <${BurstBeforeDeathContent} burstData=${ms.burst_before_death} />
+      <//>`}
+      ${ms.burst_hold_death && html`<${SubSection} title="覚醒抱え落ち分析">
+        <${BurstHoldDeathContent} holdData=${ms.burst_hold_death} />
+      <//>`}
+      ${ms.burst_count && html`<${SubSection} title="覚醒回数分析">
+        <${BurstCountContent} countData=${ms.burst_count} />
+      <//>`}
     <//></div>`;
   });
 }
@@ -1109,22 +1121,26 @@ function SeasonSection({ seasons }) {
 
 // --- Fall order / Burst before death ---
 
-function FallOrderSection({ fallOrder }) {
+function FallOrderContent({ fallOrder }) {
   if (!fallOrder) return null;
+  var n = fallOrder.no_fall;
   var f = fallOrder.first_fall;
   var s = fallOrder.second_fall;
+  var st = fallOrder.same_time;
   var rows = [
+    ['0落ち', n.count + '戦 (' + n.rate + '%)', colorPct(n.win_rate), colorDmgGiven(n.avg_dmg_given), colorDmgTaken(n.avg_dmg_taken), colorDE(n.dmg_efficiency, 3)],
     ['先落ち', f.count + '戦 (' + f.rate + '%)', colorPct(f.win_rate), colorDmgGiven(f.avg_dmg_given), colorDmgTaken(f.avg_dmg_taken), colorDE(f.dmg_efficiency, 3)],
     ['後落ち', s.count + '戦 (' + s.rate + '%)', colorPct(s.win_rate), colorDmgGiven(s.avg_dmg_given), colorDmgTaken(s.avg_dmg_taken), colorDE(s.dmg_efficiency, 3)],
+    ['同時落ち', st.count + '戦 (' + st.rate + '%)', colorPct(st.win_rate), colorDmgGiven(st.avg_dmg_given), colorDmgTaken(st.avg_dmg_taken), colorDE(st.dmg_efficiency, 3)],
   ];
-  return html`<${Section} title="先落ち/後落ち分析">
-    <p>対象: ${fallOrder.total}戦（自分と相方の両方に撃墜データがある試合）</p>
+  return html`<div>
+    <p>対象: ${fallOrder.total}戦</p>
     <${Table} headers=${['パターン', '試合数', '勝率', '与ダメ', '被ダメ', '与被ダメ比']} rows=${rows} />
     <${Tips} tips=${fallOrder.tips} />
-  <//>`;
+  </div>`;
 }
 
-function BurstBeforeDeathSection({ burstData }) {
+function BurstBeforeDeathContent({ burstData }) {
   if (!burstData) return null;
   var u = burstData.used_before_death;
   var h = burstData.held_at_death;
@@ -1132,14 +1148,14 @@ function BurstBeforeDeathSection({ burstData }) {
     ['覚醒使い切り後に落ち', u.count + '回 (' + u.rate + '%)', colorPct(u.win_rate)],
     ['覚醒未使用で落ち', h.count + '回 (' + h.rate + '%)', colorPct(h.win_rate)],
   ];
-  return html`<${Section} title="覚醒使い切り分析">
+  return html`<div>
     <p>覚醒ゲージが溜まった後の撃墜 ${burstData.total}回を分析</p>
     <${Table} headers=${['パターン', '回数', '勝率']} rows=${rows} />
     <${Tips} tips=${burstData.tips} />
-  <//>`;
+  </div>`;
 }
 
-function BurstHoldDeathSection({ holdData }) {
+function BurstHoldDeathContent({ holdData }) {
   if (!holdData) return null;
   var hd = holdData.hold_death;
   var nhd = holdData.no_hold_death;
@@ -1147,22 +1163,22 @@ function BurstHoldDeathSection({ holdData }) {
     ['抱え落ちあり', hd.count + '戦 (' + hd.rate + '%)', colorPct(hd.win_rate)],
     ['抱え落ちなし', nhd.count + '戦 (' + nhd.rate + '%)', colorPct(nhd.win_rate)],
   ];
-  return html`<${Section} title="覚醒抱え落ち分析">
+  return html`<div>
     <p>覚醒ゲージMAX後に発動せず撃墜された試合を検出（対象: ${holdData.total}戦）</p>
     <${Table} headers=${['パターン', '試合数', '勝率']} rows=${rows} />
     <${Tips} tips=${holdData.tips} />
-  <//>`;
+  </div>`;
 }
 
-function BurstCountSection({ countData }) {
+function BurstCountContent({ countData }) {
   if (!countData || !countData.by_count || !countData.by_count.length) return null;
   var rows = countData.by_count.map(function (c) {
     return [c.label, c.matches + '戦', colorPct(c.win_rate)];
   });
-  return html`<${Section} title="覚醒回数分析">
+  return html`<div>
     <${Table} headers=${['覚醒回数', '試合数', '勝率']} rows=${rows} />
     <${Tips} tips=${countData.tips} />
-  <//>`;
+  </div>`;
 }
 
 // --- Share area ---
@@ -1232,10 +1248,6 @@ function TableOfContents({ data }) {
           </details>
         </li>`}
         <li><a href="#sec-fixed">固定相方分析</a></li>
-        ${data.fall_order && html`<li><a href="#sec-fall-order">先落ち/後落ち分析</a></li>`}
-        ${data.burst_before_death && html`<li><a href="#sec-burst-death">覚醒使い切り分析</a></li>`}
-        ${data.burst_hold_death && html`<li><a href="#sec-burst-hold">覚醒抱え落ち分析</a></li>`}
-        ${data.burst_count && html`<li><a href="#sec-burst-count">覚醒回数分析</a></li>`}
         <li><a href="#sec-time">時間帯別の勝率</a></li>
         <li><a href="#sec-dow">曜日別の勝率</a></li>
         <li><a href="#sec-daily">日別勝率</a></li>
@@ -1287,10 +1299,6 @@ function Report({ data, userKey }) {
     <//></div>
     <div key="sec-ms"><${MsStatsSection} msStats=${pd.ms_stats} /></div>
     <div key="sec-fixed" id="sec-fixed"><${FixedPartnersSection} partners=${pd.fixed_partners} /></div>
-    <div key="sec-fall-order" id="sec-fall-order"><${FallOrderSection} fallOrder=${pd.fall_order} /></div>
-    <div key="sec-burst-death" id="sec-burst-death"><${BurstBeforeDeathSection} burstData=${pd.burst_before_death} /></div>
-    <div key="sec-burst-hold" id="sec-burst-hold"><${BurstHoldDeathSection} holdData=${pd.burst_hold_death} /></div>
-    <div key="sec-burst-count" id="sec-burst-count"><${BurstCountSection} countData=${pd.burst_count} /></div>
     <div key="sec-time" id="sec-time"><${TimeOfDaySection} time=${pd.time_of_day} /></div>
     <div key="sec-dow" id="sec-dow"><${DayOfWeekSection} dow=${pd.day_of_week} /></div>
     <div key="sec-daily" id="sec-daily"><${DailyTrendSection} daily=${pd.daily_trend} /></div>


### PR DESCRIPTION
## Summary
- `data_fall_order`に0落ち（未撃墜）・同時落ちカテゴリを追加。全試合を分析対象に含める
- 相方0落ちで自分だけ撃墜された試合を「先落ち」としてカウント
- `fall_order`, `burst_before_death`, `burst_hold_death`, `burst_count`の4セクションをトップレベルから各機体別分析（`ms_stats`）内に移動

## Test plan
- [x] stg環境で分析を実行し、機体別分析内に先落ち/後落ち・覚醒使い切り・抱え落ち・覚醒回数の4セクションが表示されることを確認
- [x] 0落ち・先落ち・後落ち・同時落ちの4行がテーブルに表示されることを確認
- [ ] トップレベルに覚醒/撃墜関連の分析セクションが表示されないことを確認
- [ ] 目次から覚醒/撃墜関連のリンクが消えていることを確認
- [ ] 各機体の試合数に応じた分析結果になっていること

Closes #258

🤖 Generated with [Claude Code](https://claude.ai/code)