### PR TITLE
fix: 覚醒抱え落ち分析の文言修正とN機目対応

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1146,8 +1146,7 @@ def data_fall_order(data_list):
 
 
 def data_burst_hold_death(data_list):
-    first_hold = []
-    second_hold = []
+    hold_by_death = defaultdict(list)
     no_hold = []
     total = 0
 
@@ -1160,10 +1159,9 @@ def data_burst_hold_death(data_list):
             continue
 
         total += 1
-        has_first_hold = False
-        has_second_hold = False
+        has_any_hold = False
 
-        for i, death in enumerate(deaths[:2]):
+        for i, death in enumerate(deaths):
             death_time = death["action_start_sec"]
             relevant_ex = [e for e in ex_readies if e["action_start_sec"] < death_time]
             if not relevant_ex:
@@ -1175,16 +1173,10 @@ def data_burst_hold_death(data_list):
                 if b["action_start_sec"] < death_time
             )
             if not burst_used:
-                if i == 0:
-                    has_first_hold = True
-                else:
-                    has_second_hold = True
+                hold_by_death[i + 1].append(d)
+                has_any_hold = True
 
-        if has_first_hold:
-            first_hold.append(d)
-        if has_second_hold:
-            second_hold.append(d)
-        if not has_first_hold and not has_second_hold:
+        if not has_any_hold:
             no_hold.append(d)
 
     if total == 0:
@@ -1197,20 +1189,25 @@ def data_burst_hold_death(data_list):
             "win_rate": round(win_rate(matches), 1) if matches else 0,
         }
 
+    by_death = []
+    for nth in sorted(hold_by_death.keys()):
+        matches = hold_by_death[nth]
+        stats = build_stats(matches)
+        stats["label"] = f"{nth}機目に抱え落ち"
+        by_death.append(stats)
+
     tips = []
-    if first_hold and no_hold:
-        diff = win_rate(no_hold) - win_rate(first_hold)
+    if by_death and no_hold:
+        all_hold = [d for ms in hold_by_death.values() for d in ms]
+        seen = set()
+        unique_hold = [d for d in all_hold if id(d) not in seen and not seen.add(id(d))]
+        diff = win_rate(no_hold) - win_rate(unique_hold)
         if diff > 0:
-            tips.append(f"1機目で抱え落ちすると勝率 **{diff:.0f}%** 低下")
-    if second_hold and no_hold:
-        diff = win_rate(no_hold) - win_rate(second_hold)
-        if diff > 0:
-            tips.append(f"2機目で抱え落ちすると勝率 **{diff:.0f}%** 低下")
+            tips.append(f"抱え落ちなしの試合の方が勝率 **{diff:.0f}%** 高い")
 
     return {
         "total": total,
-        "first_hold": build_stats(first_hold),
-        "second_hold": build_stats(second_hold),
+        "by_death": by_death,
         "no_hold": build_stats(no_hold),
         "tips": tips,
     }

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1198,7 +1198,7 @@ def data_burst_hold_death(data_list):
 
     tips = []
     if by_death and no_hold:
-        all_hold = [d for ms in hold_by_death.values() for d in ms]
+        all_hold = [d for matches in hold_by_death.values() for d in matches]
         seen = set()
         unique_hold = [d for d in all_hold if id(d) not in seen and not seen.add(id(d))]
         diff = win_rate(no_hold) - win_rate(unique_hold)

--- a/static/app.js
+++ b/static/app.js
@@ -655,7 +655,7 @@ function MsStatsSection({ msStats }) {
       ${ms.fall_order && html`<${SubSection} title="先落ち/後落ち分析">
         <${FallOrderContent} fallOrder=${ms.fall_order} />
       <//>`}
-      ${ms.burst_hold_death && html`<${SubSection} title="抱え落ち">
+      ${ms.burst_hold_death && html`<${SubSection} title="覚醒抱え落ち">
         <${BurstHoldDeathContent} holdData=${ms.burst_hold_death} />
       <//>`}
       ${ms.burst_count && html`<${SubSection} title="覚醒回数">
@@ -1141,16 +1141,13 @@ function FallOrderContent({ fallOrder }) {
 
 function BurstHoldDeathContent({ holdData }) {
   if (!holdData) return null;
-  var fh = holdData.first_hold;
-  var sh = holdData.second_hold;
   var nh = holdData.no_hold;
-  var rows = [
-    ['1機目抱え落ち', fh.count + '戦 (' + fh.rate + '%)', colorPct(fh.win_rate)],
-    ['2機目抱え落ち', sh.count + '戦 (' + sh.rate + '%)', colorPct(sh.win_rate)],
-    ['抱え落ちなし', nh.count + '戦 (' + nh.rate + '%)', colorPct(nh.win_rate)],
-  ];
+  var rows = (holdData.by_death || []).filter(function (d) { return d.count > 0; }).map(function (d) {
+    return [d.label, d.count + '戦 (' + d.rate + '%)', colorPct(d.win_rate)];
+  });
+  rows.push(['抱え落ちなし', nh.count + '戦 (' + nh.rate + '%)', colorPct(nh.win_rate)]);
   return html`<div>
-    <p>ゲージが溜まった状態で発動せずに撃墜された試合（対象: ${holdData.total}戦）</p>
+    <p>覚醒ゲージが溜まった状態で発動せずに撃墜された試合（対象: ${holdData.total}戦）</p>
     <${Table} headers=${['パターン', '試合数', '勝率']} rows=${rows} />
     <${Tips} tips=${holdData.tips} />
   </div>`;


### PR DESCRIPTION
## Summary
- セクション名を「覚醒抱え落ち」に変更
- 説明文の「ゲージ」→「覚醒ゲージ」
- パターン名を「x機目に抱え落ち」に変更
- 2機目までの制限を撤廃し3機目以降も動的対応（count > 0の場合のみ表示）

## Test plan
- [ ] セクション名が「覚醒抱え落ち」になっていること
- [ ] 説明文が「覚醒ゲージが溜まった状態で…」になっていること
- [ ] 「x機目に抱え落ち」の表記になっていること
- [ ] 0件の機目行が非表示になること

🤖 Generated with [Claude Code](https://claude.ai/code)