### PR TITLE
perf: レポートキャッシュと速報表示の高速化

### DIFF
--- a/internal/firestore/report_cache.go
+++ b/internal/firestore/report_cache.go
@@ -1,0 +1,65 @@
+package firestore
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"cloud.google.com/go/firestore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// SaveReportCache は分析レポートJSONをFirestoreにキャッシュとして保存する。
+func SaveReportCache(userKey string, reportJSON string) {
+	c := getClient()
+	if c == nil {
+		return
+	}
+
+	if len(reportJSON) > 900000 {
+		log.Printf("[WARN] Firestore: report cache for user %s is %d bytes (approaching 1MB limit)", userKey, len(reportJSON))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	ref := c.Collection("users").Doc(userKey).Collection("cache").Doc("report")
+	_, err := ref.Set(ctx, map[string]interface{}{
+		"report":     reportJSON,
+		"updated_at": firestore.ServerTimestamp,
+	})
+	if err != nil {
+		log.Printf("[WARN] Firestore: failed to save report cache: %v", err)
+		return
+	}
+
+	log.Printf("[INFO] Firestore: saved report cache for user %s (%d bytes)", userKey, len(reportJSON))
+}
+
+// LoadReportCache はFirestoreからキャッシュされた分析レポートJSONを読み取る。
+// キャッシュが存在しない場合は空文字列とnilを返す。
+func LoadReportCache(userKey string) (string, error) {
+	c := getClient()
+	if c == nil {
+		return "", fmt.Errorf("firestore client not initialized")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	ref := c.Collection("users").Doc(userKey).Collection("cache").Doc("report")
+	doc, err := ref.Get(ctx)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return "", nil
+		}
+		return "", fmt.Errorf("get report cache: %w", err)
+	}
+
+	report, ok := doc.Data()["report"].(string)
+	if !ok {
+		return "", nil
+	}
+	return report, nil
+}

--- a/internal/firestore/scores.go
+++ b/internal/firestore/scores.go
@@ -256,7 +256,7 @@ func BackfillDates(userKey string) map[string]bool {
 func groupByDatetime(scores model.DatedScores) map[string][]model.DatedScore {
 	groups := make(map[string][]model.DatedScore)
 	for _, s := range scores {
-		key := s.Datetime.Format("2006-01-02T1504")
+		key := s.Datetime.Format(model.MatchKeyFormat)
 		groups[key] = append(groups[key], s)
 	}
 	return groups

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -6,6 +6,9 @@ import (
 	"time"
 )
 
+// MatchKeyFormat は試合を一意に識別するためのdatetimeフォーマット
+const MatchKeyFormat = "2006-01-02T1504"
+
 // MSInfo は機体情報（画像URL → 機体名のマッピング）
 type MSInfo struct {
 	Name     string

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -105,6 +105,18 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 
 	jsonPath := filepath.Join(tmpDir, "scores.json")
 
+	// キャッシュされたレポートがあれば即座に速報レポートとして表示
+	cachedReport, err := fs.LoadReportCache(j.UserKey)
+	if err != nil {
+		log.Printf("[WARN] Failed to load cached report: %v", err)
+	}
+	if cachedReport != "" {
+		jobsMu.Lock()
+		j.PreliminaryReport = cachedReport
+		jobsMu.Unlock()
+		log.Printf("[INFO] Job %s: cached preliminary report ready", j.ID)
+	}
+
 	// Firestoreから既存scoresを読み取り
 	var since time.Time
 	existingScores, err := fs.LoadScores(j.UserKey)
@@ -150,16 +162,18 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 			}
 		}
 
-		// 既存データでJSONを生成して速報レポートを作成
-		if err := saveScoresJSON(existingScores, jsonPath); err != nil {
-			log.Printf("[WARN] Failed to generate JSON for preliminary report: %v", err)
-		} else {
-			prelimReport := runAnalysis(jsonPath, tmpDir, cachedTagPartnersPath)
-			if prelimReport != "" {
-				jobsMu.Lock()
-				j.PreliminaryReport = prelimReport
-				jobsMu.Unlock()
-				log.Printf("[INFO] Job %s: preliminary report ready", j.ID)
+		// キャッシュがない場合のみ、既存データから速報レポートを生成
+		if cachedReport == "" {
+			if err := saveScoresJSON(existingScores, jsonPath); err != nil {
+				log.Printf("[WARN] Failed to generate JSON for preliminary report: %v", err)
+			} else {
+				prelimReport := runAnalysis(jsonPath, tmpDir, cachedTagPartnersPath)
+				if prelimReport != "" {
+					jobsMu.Lock()
+					j.PreliminaryReport = prelimReport
+					jobsMu.Unlock()
+					log.Printf("[INFO] Job %s: preliminary report ready", j.ID)
+				}
 			}
 		}
 	}
@@ -250,6 +264,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		j.Report = finalReport
 		j.completedAt = time.Now()
 		jobsMu.Unlock()
+		fs.SaveReportCache(j.UserKey, finalReport)
 		log.Printf("[INFO] Job %s completed (no new data)", j.ID)
 		return
 	}
@@ -276,13 +291,8 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	// Firestoreにscoresを書き込み
 	fs.SaveScores(j.UserKey, datedScores)
 
-	// Firestoreから全scoresを読み取り、Python分析用のJSONを生成
-	allScores, err := fs.LoadScores(j.UserKey)
-	if err != nil {
-		log.Printf("[WARN] Failed to reload scores from Firestore: %v", err)
-		// フォールバック: 既存 + 新規で組み立て
-		allScores = append(existingScores, datedScores...)
-	}
+	// 既存 + 新規をメモリ上でマージ（Firestoreの再読み取りを省略）
+	allScores := mergeScores(existingScores, datedScores)
 
 	if err := os.Remove(jsonPath); err != nil && !os.IsNotExist(err) {
 		log.Printf("[WARN] Failed to remove temp JSON: %v", err)
@@ -330,6 +340,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	j.PartialData = is403WithPartialData
 	j.completedAt = time.Now()
 	jobsMu.Unlock()
+	fs.SaveReportCache(j.UserKey, report)
 	if is403WithPartialData {
 		log.Printf("[INFO] Job %s completed with partial data (403 during scraping)", j.ID)
 	} else {
@@ -625,4 +636,28 @@ func buildPlayerActions(timeline *model.MatchTimeline, playerNo int) []actionJSO
 		return []actionJSON{}
 	}
 	return actions
+}
+
+// mergeScores は既存のscoresに新規scoresをマージする。
+// バックフィル時に同じdatetimeのレコードがある場合は新規側で上書きする。
+func mergeScores(existing, newScores model.DatedScores) model.DatedScores {
+	newKeys := make(map[string]bool)
+	for _, s := range newScores {
+		key := s.Datetime.Format("2006-01-02T1504")
+		newKeys[key] = true
+	}
+
+	merged := make(model.DatedScores, 0, len(existing)+len(newScores))
+	for _, s := range existing {
+		key := s.Datetime.Format("2006-01-02T1504")
+		if !newKeys[key] {
+			merged = append(merged, s)
+		}
+	}
+	merged = append(merged, newScores...)
+
+	sort.Slice(merged, func(i, j int) bool {
+		return merged[i].Datetime.Before(merged[j].Datetime)
+	})
+	return merged
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -526,7 +526,7 @@ type actionJSON struct {
 func saveScoresJSON(ds model.DatedScores, path string) error {
 	groups := make(map[string][]model.DatedScore)
 	for _, d := range ds {
-		key := d.Datetime.Format("2006-01-02T1504")
+		key := d.Datetime.Format(model.MatchKeyFormat)
 		groups[key] = append(groups[key], d)
 	}
 
@@ -643,13 +643,13 @@ func buildPlayerActions(timeline *model.MatchTimeline, playerNo int) []actionJSO
 func mergeScores(existing, newScores model.DatedScores) model.DatedScores {
 	newKeys := make(map[string]bool)
 	for _, s := range newScores {
-		key := s.Datetime.Format("2006-01-02T1504")
+		key := s.Datetime.Format(model.MatchKeyFormat)
 		newKeys[key] = true
 	}
 
 	merged := make(model.DatedScores, 0, len(existing)+len(newScores))
 	for _, s := range existing {
-		key := s.Datetime.Format("2006-01-02T1504")
+		key := s.Datetime.Format(model.MatchKeyFormat)
 		if !newKeys[key] {
 			merged = append(merged, s)
 		}


### PR DESCRIPTION
## Summary
- 分析完了時にレポートJSONをFirestoreにキャッシュ（`users/{userKey}/cache/report`）
- 次回分析時にキャッシュから即座に速報レポートを表示（1ドキュメント読み、数十ms）
- キャッシュヒット時は旧来の速報生成（Firestore全量読み取り+Python分析）をスキップ
- スクレイピング後のFirestore全量再読み取り（120sタイムアウト）をメモリ上のマージに置換

## 改善効果
- 2回目以降の分析で速報レポートが即表示される（従来: 全試合読み取り+Python分析の完了待ち）
- 最終レポート生成時のFirestore読み取りが1回削減される

## Test plan
- [ ] 初回ユーザー（キャッシュなし）で従来通り速報→最終レポートが表示されること
- [ ] 2回目以降の分析で速報レポートが即表示されること
- [ ] 最終レポートが正しく生成され、キャッシュが更新されること
- [ ] Firestore未接続時にエラーにならずフォールバックすること

Closes #260

🤖 Generated with [Claude Code](https://claude.ai/code)