### PR TITLE
fix: MSリスト自動更新の重複PR作成を防止

### DIFF
--- a/.github/workflows/update-mslist.yml
+++ b/.github/workflows/update-mslist.yml
@@ -20,11 +20,26 @@ jobs:
 
       - uses: actions/checkout@v6
 
+      - name: Check for existing PR
+        id: existing-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OPEN_PR=$(gh pr list --search "MSリストを自動更新" --state open --json number --jq '.[0].number')
+          if [ -n "$OPEN_PR" ] && [ "$OPEN_PR" != "null" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Open PR #$OPEN_PR already exists, skipping"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/setup-go@v6
+        if: steps.existing-pr.outputs.skip == 'false'
         with:
           go-version: "1.26"
 
       - name: Run update-mslist
+        if: steps.existing-pr.outputs.skip == 'false'
         env:
           USERNAME: ${{ secrets.USERNAME }}
           PASSWORD: ${{ secrets.PASSWORD }}
@@ -32,6 +47,7 @@ jobs:
 
       - name: Check for changes
         id: diff
+        if: steps.existing-pr.outputs.skip == 'false'
         run: |
           if git diff --quiet data/ms_list.json; then
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-mslist.yml
+++ b/.github/workflows/update-mslist.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Create PR
         id: create-pr
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.existing-pr.outputs.skip == 'false' && steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -77,8 +77,8 @@ jobs:
         if: steps.create-pr.outputs.pr_url
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.create-pr.outputs.pr_url }}
         run: |
-          PR_URL="${{ steps.create-pr.outputs.pr_url }}"
           # CIチェックが登録されるまでポーリング（最大5分）
           CI_DETECTED=false
           for i in $(seq 1 30); do
@@ -102,10 +102,11 @@ jobs:
         if: steps.create-pr.outputs.pr_url
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.create-pr.outputs.pr_url }}
         run: |
           # push to main で stg build（build.yml）は自動トリガーされる
           # stg build 完了を待ってから deploy-prod.yml で本番昇格
-          MERGE_SHA=$(gh pr view "${{ steps.create-pr.outputs.pr_url }}" --json mergeCommit --jq '.mergeCommit.oid')
+          MERGE_SHA=$(gh pr view "$PR_URL" --json mergeCommit --jq '.mergeCommit.oid')
           for i in $(seq 1 30); do
             STG_RUN_ID=$(gh run list --workflow=build.yml --branch=main --commit="$MERGE_SHA" --limit=1 --json databaseId --jq '.[0].databaseId' 2>/dev/null)
             if [ -n "$STG_RUN_ID" ] && [ "$STG_RUN_ID" != "null" ]; then


### PR DESCRIPTION
## Summary
- 既存のオープンPRがある場合、スクレイピングとPR作成をスキップするチェックを追加
- #265, #266, #267 のような重複PRの発生を防止

## Test plan
- [ ] 手動実行で既存PRなし→通常通りスクレイピングが実行されることを確認
- [ ] 既存のオープンPRがある状態で手動実行→スキップされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)