### PR TITLE
perf: スクレイピング中の段階的速報レポート更新

### DIFF
--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -82,16 +82,17 @@ const (
 
 // JobSnapshot はジョブ状態のスナップショット
 type JobSnapshot struct {
-	ID                string
-	Status            JobStatus
-	Message           string
-	Progress          int
-	ProgressTotal     int
-	Report            string
-	PreliminaryReport string
-	Error             string
-	PartialData       bool
-	UserKey           string
+	ID                 string
+	Status             JobStatus
+	Message            string
+	Progress           int
+	ProgressTotal      int
+	Report             string
+	PreliminaryReport  string
+	PreliminaryVersion int
+	Error              string
+	PartialData        bool
+	UserKey            string
 }
 
 // DatedScores は日付付きスコアのリスト

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -198,6 +198,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	// 20試合ごとに速報レポートを段階的に更新するコールバック
 	var batchAnalysisMu sync.Mutex
 	var batchWg sync.WaitGroup
+	defer batchWg.Wait()
 	onBatchReady := func(batchScores model.DatedScores) {
 		if !batchAnalysisMu.TryLock() {
 			return
@@ -273,9 +274,6 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 			on403[0](model.UserKey(username))
 		}
 	}
-	// バッチ分析が実行中なら完了を待つ
-	batchWg.Wait()
-
 	if len(datedScores) == 0 && !exists {
 		setError(j, "戦績データが見つかりませんでした", "no scores found")
 		return

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -27,6 +27,9 @@ const DefaultMSListPath = "data/ms_list.json"
 // DefaultGradeListPath はデフォルトのグレードリストパス
 const DefaultGradeListPath = "data/grade_list.json"
 
+// prelimBatchSize はスクレイピング中に速報レポートを更新する間隔（試合数）
+const prelimBatchSize = 20
+
 // Job はバックグラウンドジョブの情報
 type Job struct {
 	ID                 string           `json:"id"`
@@ -36,6 +39,7 @@ type Job struct {
 	ProgressTotal      int              `json:"progress_total,omitempty"`
 	Report             string           `json:"report,omitempty"`
 	PreliminaryReport  string           `json:"preliminary_report,omitempty"`
+	PreliminaryVersion int              `json:"preliminary_version,omitempty"`
 	Error              string           `json:"error,omitempty"`
 	PartialData        bool             `json:"partial_data,omitempty"`
 	UserKey            string           `json:"-"`
@@ -73,16 +77,17 @@ func (j *Job) Snapshot() model.JobSnapshot {
 	jobsMu.RLock()
 	defer jobsMu.RUnlock()
 	return model.JobSnapshot{
-		ID:                j.ID,
-		Status:            j.Status,
-		Message:           j.Message,
-		Progress:          j.Progress,
-		ProgressTotal:     j.ProgressTotal,
-		Report:            j.Report,
-		PreliminaryReport: j.PreliminaryReport,
-		Error:             j.Error,
-		PartialData:       j.PartialData,
-		UserKey:           j.UserKey,
+		ID:                 j.ID,
+		Status:             j.Status,
+		Message:            j.Message,
+		Progress:           j.Progress,
+		ProgressTotal:      j.ProgressTotal,
+		Report:             j.Report,
+		PreliminaryReport:  j.PreliminaryReport,
+		PreliminaryVersion: j.PreliminaryVersion,
+		Error:              j.Error,
+		PartialData:        j.PartialData,
+		UserKey:            j.UserKey,
 	}
 }
 
@@ -113,6 +118,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	if cachedReport != "" {
 		jobsMu.Lock()
 		j.PreliminaryReport = cachedReport
+		j.PreliminaryVersion++
 		jobsMu.Unlock()
 		log.Printf("[INFO] Job %s: cached preliminary report ready", j.ID)
 	}
@@ -171,6 +177,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 				if prelimReport != "" {
 					jobsMu.Lock()
 					j.PreliminaryReport = prelimReport
+					j.PreliminaryVersion++
 					jobsMu.Unlock()
 					log.Printf("[INFO] Job %s: preliminary report ready", j.ID)
 				}
@@ -188,16 +195,56 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		jobsMu.Unlock()
 	}
 
+	// 20試合ごとに速報レポートを段階的に更新するコールバック
+	var batchAnalysisMu sync.Mutex
+	var batchWg sync.WaitGroup
+	onBatchReady := func(batchScores model.DatedScores) {
+		if !batchAnalysisMu.TryLock() {
+			return
+		}
+		batchWg.Add(1)
+		go func() {
+			defer batchAnalysisMu.Unlock()
+			defer batchWg.Done()
+
+			merged := mergeScores(existingScores, batchScores)
+
+			batchDir, err := os.MkdirTemp("", "exvs-batch-*")
+			if err != nil {
+				log.Printf("[WARN] Failed to create batch temp dir: %v", err)
+				return
+			}
+			defer os.RemoveAll(batchDir)
+
+			batchPath := filepath.Join(batchDir, "scores.json")
+			if err := saveScoresJSON(merged, batchPath); err != nil {
+				log.Printf("[WARN] Failed to save batch JSON: %v", err)
+				return
+			}
+
+			report := runAnalysis(batchPath, batchDir, cachedTagPartnersPath)
+			if report != "" {
+				jobsMu.Lock()
+				j.PreliminaryReport = report
+				j.PreliminaryVersion++
+				jobsMu.Unlock()
+				log.Printf("[INFO] Job %s: incremental preliminary report ready (%d scores)", j.ID, len(merged))
+			}
+		}()
+	}
+
+	scrapingOpt := scraper.ScrapingOption{
+		OnProgress:   onProgress,
+		OnBatchReady: onBatchReady,
+		BatchSize:    prelimBatchSize,
+	}
+	if len(backfillDates) > 0 {
+		scrapingOpt.BackfillDates = backfillDates
+	}
+
 	var datedScores model.DatedScores
 	var jar http.CookieJar
-	if len(backfillDates) > 0 {
-		datedScores, jar, err = scraper.ScrapingWithOption(username, password, since, scraper.ScrapingOption{
-			OnProgress:    onProgress,
-			BackfillDates: backfillDates,
-		})
-	} else {
-		datedScores, jar, err = scraper.Scraping(username, password, since, onProgress)
-	}
+	datedScores, jar, err = scraper.ScrapingWithOption(username, password, since, scrapingOpt)
 	// 403の場合でも途中データがあれば保存・分析を続行する
 	is403WithPartialData := errors.Is(err, scraper.ErrAccessDenied) && len(datedScores) > 0
 	if err != nil && !is403WithPartialData {
@@ -226,6 +273,9 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 			on403[0](model.UserKey(username))
 		}
 	}
+	// バッチ分析が実行中なら完了を待つ
+	batchWg.Wait()
+
 	if len(datedScores) == 0 && !exists {
 		setError(j, "戦績データが見つかりませんでした", "no scores found")
 		return

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -88,6 +88,8 @@ type ProgressFunc func(current, total int)
 type ScrapingOption struct {
 	OnProgress     ProgressFunc
 	BackfillDates  map[string]bool // バックフィル対象日付セット（"2006/01/02"形式）。nilなら全日付対象
+	OnBatchReady   func(scores model.DatedScores) // BatchSize試合ごとに蓄積スコアのスナップショットを通知
+	BatchSize      int                             // OnBatchReady発火間隔（試合数）。0の場合は通知しない
 }
 
 // Scraping はスクレイピング処理を実行し、DatedScoresとログイン済みCookieJarを返す
@@ -150,7 +152,7 @@ func ScrapingWithOption(username, password string, since time.Time, opt Scraping
 		streamErr = streamMatchEntries(ctx, cancel, m.HTTPClient.Jar, dailyLinks, since, entryCh)
 	}()
 
-	scores, detailErr := fetchDetailPagesStreaming(ctx, cancel, m.HTTPClient.Jar, entryCh, notify)
+	scores, detailErr := fetchDetailPagesStreaming(ctx, cancel, m.HTTPClient.Jar, entryCh, notify, opt.OnBatchReady, opt.BatchSize)
 
 	// 403の場合は途中データがあればエラーと一緒に返す（呼び出し元で途中保存できるようにする）
 	if streamErr != nil || detailErr != nil {
@@ -362,7 +364,7 @@ func collectMatchEntries(jar http.CookieJar, dl dailyLink, since time.Time) ([]m
 
 // fetchDetailPagesStreaming はチャネルから試合エントリを受信しつつ詳細ページを並列取得する
 // HTTPエラーが1件でもあればエラーを返す。403の場合はErrAccessDeniedを返し即座にキャンセルする
-func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, jar http.CookieJar, entryCh <-chan matchEntry, notify func(int, int)) (model.DatedScores, error) {
+func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, jar http.CookieJar, entryCh <-chan matchEntry, notify func(int, int), onBatch func(model.DatedScores), batchSize int) (model.DatedScores, error) {
 	// まず全エントリを収集してtotalを確定させる（キャンセル時はチャネルが閉じるまで待つ）
 	var entries []matchEntry
 	for entry := range entryCh {
@@ -433,6 +435,12 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 			mu.Lock()
 			scores = append(scores, parsed...)
 			processed++
+			shouldBatch := onBatch != nil && batchSize > 0 && processed%batchSize == 0
+			var snapshot model.DatedScores
+			if shouldBatch {
+				snapshot = make(model.DatedScores, len(scores))
+				copy(snapshot, scores)
+			}
 			if err != nil {
 				errorCount++
 				if errors.Is(err, ErrAccessDenied) {
@@ -444,6 +452,9 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 			mu.Unlock()
 
 			notify(current, total)
+			if shouldBatch {
+				onBatch(snapshot)
+			}
 			time.Sleep(requestDelay)
 		}(entry)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -156,6 +156,7 @@ func StartServer() {
 		}
 		if snap.PreliminaryReport != "" {
 			resp["has_preliminary_report"] = true
+			resp["preliminary_version"] = snap.PreliminaryVersion
 		}
 
 		sendJSON(w, http.StatusOK, resp)

--- a/static/app.js
+++ b/static/app.js
@@ -1324,7 +1324,7 @@ async function analyze() {
   render(null, reportEl);
 
   document.getElementById('loginForm').style.display = 'none';
-  var preliminaryShown = false;
+  var lastPreliminaryVersion = 0;
 
   try {
     var res = await fetch('/analyze', {
@@ -1363,13 +1363,13 @@ async function analyze() {
         progressWrap.style.display = 'none';
       }
 
-      if (statusData.has_preliminary_report && !preliminaryShown) {
+      if (statusData.has_preliminary_report && statusData.preliminary_version > lastPreliminaryVersion) {
         var prelimRes = await fetch('/result/' + jobId);
         var prelimData = await prelimRes.json();
         if (prelimData.report && prelimData.preliminary) {
           renderReport(prelimData.report, prelimData.user_key);
           statusText.textContent = '最新データを取得中...';
-          preliminaryShown = true;
+          lastPreliminaryVersion = statusData.preliminary_version;
         }
       }
 


### PR DESCRIPTION
## Summary
- スクレイピング中、20試合分の詳細ページ取得ごとにPython分析を実行して速報レポートを段階的に更新
- 初回ユーザー（キャッシュ・既存データなし）でも早期にレポートが表示される
- 分析はgoroutineで非同期実行し、`sync.Mutex.TryLock()`で多重実行を防止するためスクレイピング速度に影響しない
- Firestoreへの保存は従来通りスクレイピング完了後に1回（MS名解決・グレードチェック済みのデータのみ保存）

## 変更内容
- `ScrapingOption`に`OnBatchReady`コールバックと`BatchSize`を追加
- `fetchDetailPagesStreaming`で20試合ごとにスコアのスナップショットをコールバックに通知
- パイプラインでバッチ分析を専用tmpDirで非同期実行
- `PreliminaryVersion`フィールドでフロントエンドが速報の更新を検知し再描画

## Test plan
- [ ] 初回ユーザー（データなし）で20試合到達時に速報レポートが表示されること
- [ ] 速報レポートがスクレイピング進行に伴い更新されること（20→40→...）
- [ ] 最終レポートが正しく生成され、速報を置き換えること
- [ ] 既存ユーザー（キャッシュあり）で従来通りキャッシュ速報が即表示されること
- [ ] 403発生時に途中データが正しく保存・分析されること
- [ ] スクレイピング速度が低下しないこと

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)