### PR TITLE
chore: リポジトリ名変更に伴いモジュールパス等を catalyzer へ更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EXVS2IB 戦績分析ツール (exvs-analyzer)
+# catalyzer — EXVS2IB 戦績分析ツール
 
 機動戦士ガンダム EXTREME VS.2 INFINITE BOOST の戦績をスクレイピングし、分析レポートを生成するWebアプリケーション。
 

--- a/cmd/extract-grades/main.go
+++ b/cmd/extract-grades/main.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"sort"
 
-	"github.com/yuki9431/exvs-analyzer/internal/firestore"
-	"github.com/yuki9431/exvs-analyzer/internal/gradelist"
+	"github.com/yuki9431/catalyzer/internal/firestore"
+	"github.com/yuki9431/catalyzer/internal/gradelist"
 )
 
 func main() {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/yuki9431/exvs-analyzer/internal/server"
+import "github.com/yuki9431/catalyzer/internal/server"
 
 func main() {
 	server.StartServer()

--- a/cmd/update-mslist/main.go
+++ b/cmd/update-mslist/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/yuki9431/exvs-analyzer/internal/mslist"
-	"github.com/yuki9431/exvs-analyzer/internal/scraper"
+	"github.com/yuki9431/catalyzer/internal/mslist"
+	"github.com/yuki9431/catalyzer/internal/scraper"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yuki9431/exvs-analyzer
+module github.com/yuki9431/catalyzer
 
 go 1.26
 

--- a/infra/shared/Pulumi.shared.yaml
+++ b/infra/shared/Pulumi.shared.yaml
@@ -12,7 +12,7 @@ config:
     secure: v1:qrKhhc7um2Ek9eFw:y/87HFSHHTHoRGfeHV75GubkNwo=
   exvs-shared:pulumiStateBucket:
     secure: v1:Du/axuJkvq/wtqd/:EIsWkGiOhurIvwVomvsdiXa+lqgmP8yIoJV0fC96pll4wwVh8nYxTfihJ5Rt
-  exvs-shared:githubRepo: yuki9431/exvs-analyzer
+  exvs-shared:githubRepo: yuki9431/catalyzer
   exvs-shared:computeSa:
     secure: v1:LbTz4LuCxUSGA8es:fhlSyWN8rwdbNbJ8pjHD7AWCpFlf/7euPR9VzUST3AI234w1DhU9NroG7KZJ8UeaxIWMNfmKBmtTcjx7BralkAY3
   exvs-shared:ownerEmail:

--- a/internal/firestore/scores.go
+++ b/internal/firestore/scores.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/firestore"
-	"github.com/yuki9431/exvs-analyzer/internal/model"
+	"github.com/yuki9431/catalyzer/internal/model"
 )
 
 // matchDoc はFirestoreに保存するmatchesドキュメントの構造体

--- a/internal/firestore/tag_partners.go
+++ b/internal/firestore/tag_partners.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/yuki9431/exvs-analyzer/internal/model"
+	"github.com/yuki9431/catalyzer/internal/model"
 )
 
 // tagPartnerDoc はFirestoreに保存するtag_partnersドキュメントの構造体

--- a/internal/gradelist/gradelist.go
+++ b/internal/gradelist/gradelist.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/yuki9431/exvs-analyzer/internal/model"
+	"github.com/yuki9431/catalyzer/internal/model"
 )
 
 // GradeInfo は階級画像URLと階級名のマッピング

--- a/internal/mslist/mslist.go
+++ b/internal/mslist/mslist.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/yuki9431/exvs-analyzer/internal/model"
+	"github.com/yuki9431/catalyzer/internal/model"
 )
 
 // stripQuery はURLからクエリパラメータを除去する

--- a/internal/mslist/mslist_test.go
+++ b/internal/mslist/mslist_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/yuki9431/exvs-analyzer/internal/model"
+	"github.com/yuki9431/catalyzer/internal/model"
 )
 
 func TestBuildMSNameMap(t *testing.T) {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -14,11 +14,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	fs "github.com/yuki9431/exvs-analyzer/internal/firestore"
-	"github.com/yuki9431/exvs-analyzer/internal/gradelist"
-	"github.com/yuki9431/exvs-analyzer/internal/model"
-	"github.com/yuki9431/exvs-analyzer/internal/mslist"
-	"github.com/yuki9431/exvs-analyzer/internal/scraper"
+	fs "github.com/yuki9431/catalyzer/internal/firestore"
+	"github.com/yuki9431/catalyzer/internal/gradelist"
+	"github.com/yuki9431/catalyzer/internal/model"
+	"github.com/yuki9431/catalyzer/internal/mslist"
+	"github.com/yuki9431/catalyzer/internal/scraper"
 )
 
 // DefaultMSListPath はデフォルトのMSリストパス

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/gocolly/colly/v2"
-	"github.com/yuki9431/exvs-analyzer/internal/model"
+	"github.com/yuki9431/catalyzer/internal/model"
 )
 
 const (

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,9 +11,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/yuki9431/exvs-analyzer/internal/firestore"
-	"github.com/yuki9431/exvs-analyzer/internal/model"
-	"github.com/yuki9431/exvs-analyzer/internal/pipeline"
+	"github.com/yuki9431/catalyzer/internal/firestore"
+	"github.com/yuki9431/catalyzer/internal/model"
+	"github.com/yuki9431/catalyzer/internal/pipeline"
 	"golang.org/x/time/rate"
 )
 


### PR DESCRIPTION
## Summary
- GitHubリポジトリを `yuki9431/exvs-analyzer` → `yuki9431/catalyzer` にリネームしたことに合わせ、**リポジトリ名に直結する箇所のみ**を更新
- `go.mod` のモジュールパス + 全Goインポート（cmd/* 3、internal/* 8）を `github.com/yuki9431/catalyzer` へ
- README タイトルと `infra/shared/Pulumi.shared.yaml` の `githubRepo` を更新

## 意図的に変更していない箇所
リポジトリ名とは別物のインフラリソース識別子（変更すると `pulumi up` で実リソースが再作成・破壊される）は温存:
- ドメイン `exvs-analyzer.com` / Firestore DB名 / Cloud Runサービス名 / Artifact Registry / DNSゾーン / Pulumiプロジェクト名(`exvs-app`,`exvs-shared`) / `IMAGE_NAME`

## 要注意（マージ後に別途対応が必要）
- `infra/shared/iam.ts` で `githubRepo` が Workload Identity の `attributeCondition`（`assertion.repository=='...'`）と principalSet に使われている。GitHubはリネーム後 `yuki9431/catalyzer` をOIDCトークンに載せるため、**shared に `pulumi up` を当てるまで GitHub Actions の GCP 認証は条件不一致で失敗する**

## Test plan
- [x] Docker経由で `go build ./...` / `go vet ./...` がパス（go.mod/go.sum に余計な変更なし）
- [ ] マージ後 shared に `pulumi up` を適用しCI認証を復旧

🤖 Generated with [Claude Code](https://claude.com/claude-code)