### PR TITLE
fix(frontend): ログイン文言を移動しiPhoneの白い余白を解消

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1536,8 +1536,6 @@ function reAnalyze() {
   if (lf) lf.style.display = 'block';
   var t = document.getElementById('pageTitle');
   if (t) t.style.display = '';
-  var st = document.getElementById('pageSubtitle');
-  if (st) st.style.display = '';
   window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
@@ -1618,8 +1616,6 @@ function renderReport(data, userKey) {
   // ダッシュボードのtopbarがブランド表示を担うため、静的な見出しは隠す
   var pageTitle = document.getElementById('pageTitle');
   if (pageTitle) pageTitle.style.display = 'none';
-  var pageSubtitle = document.getElementById('pageSubtitle');
-  if (pageSubtitle) pageSubtitle.style.display = 'none';
   render(html`<${Report} data=${data} userKey=${userKey} />`, reportEl);
 }
 
@@ -1650,8 +1646,6 @@ async function analyze() {
 
   var pageTitle = document.getElementById('pageTitle');
   if (pageTitle) pageTitle.style.display = '';
-  var pageSubtitle = document.getElementById('pageSubtitle');
-  if (pageSubtitle) pageSubtitle.style.display = '';
 
   document.getElementById('loginForm').style.display = 'none';
   var lastPreliminaryVersion = 0;

--- a/static/index.html
+++ b/static/index.html
@@ -35,7 +35,7 @@
     }
     .container { max-width: 1080px; margin: 0 auto; padding: 16px; padding-left: max(16px, env(safe-area-inset-left)); padding-right: max(16px, env(safe-area-inset-right)); padding-bottom: max(16px, env(safe-area-inset-bottom)); }
     h1 { text-align: center; color: var(--accent); margin: 40px 0 10px; font-size: 1.8em; }
-    h1.brand { margin: 48px 0 32px; line-height: 0; }
+    h1.brand { margin: max(48px, calc(env(safe-area-inset-top) + 16px)) 0 32px; line-height: 0; }
     h1.brand img { display: block; width: min(360px, 78%); height: auto; margin: 0 auto; }
     .login-form { background: var(--panel); border-radius: 12px; padding: 30px; margin: 0 auto 30px; max-width: 480px; }
     .login-lead { text-align: center; color: var(--text); font-size: 1.05em; font-weight: 600; margin-bottom: 24px; }
@@ -70,7 +70,7 @@
     .topbar {
       position: sticky; top: 0; z-index: 50;
       display: flex; align-items: center; gap: 12px;
-      padding: 12px 16px; margin: 0 -16px 16px;
+      padding: calc(12px + env(safe-area-inset-top)) 16px 12px; margin: 0 -16px 16px;
       background: rgba(13,22,32,.82); backdrop-filter: blur(10px);
       border-bottom: 1px solid var(--line);
     }
@@ -118,7 +118,7 @@
     .tabs {
       display: flex; gap: 6px; overflow-x: auto; -webkit-overflow-scrolling: touch;
       padding: 4px; margin-bottom: 14px; background: var(--panel); border: 1px solid var(--line);
-      border-radius: 14px; position: sticky; top: 64px; z-index: 40;
+      border-radius: 14px; position: sticky; top: calc(64px + env(safe-area-inset-top)); z-index: 40;
     }
     .tab {
       flex: 0 0 auto; padding: 9px 16px; border: none; border-radius: 10px;

--- a/static/index.html
+++ b/static/index.html
@@ -2,7 +2,8 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#0d1620">
   <title>catalyzer</title>
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="icon" type="image/png" sizes="48x48" href="favicon-48.png">
@@ -26,17 +27,18 @@
       --shadow: 0 6px 20px rgba(0,0,0,.35);
     }
     * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { background: var(--bg); }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      background: radial-gradient(1200px 600px at 50% -200px, #14283a 0%, var(--bg) 60%);
-      color: var(--text); min-height: 100vh;
+      background: var(--bg) radial-gradient(1200px 600px at 50% -200px, #14283a 0%, var(--bg) 60%) no-repeat;
+      color: var(--text); min-height: 100vh; min-height: 100dvh;
     }
-    .container { max-width: 1080px; margin: 0 auto; padding: 16px; }
+    .container { max-width: 1080px; margin: 0 auto; padding: 16px; padding-left: max(16px, env(safe-area-inset-left)); padding-right: max(16px, env(safe-area-inset-right)); padding-bottom: max(16px, env(safe-area-inset-bottom)); }
     h1 { text-align: center; color: var(--accent); margin: 40px 0 10px; font-size: 1.8em; }
-    h1.brand { margin: 48px 0 12px; line-height: 0; }
+    h1.brand { margin: 48px 0 32px; line-height: 0; }
     h1.brand img { display: block; width: min(360px, 78%); height: auto; margin: 0 auto; }
-    .subtitle { text-align: center; color: var(--muted); margin-bottom: 40px; }
     .login-form { background: var(--panel); border-radius: 12px; padding: 30px; margin: 0 auto 30px; max-width: 480px; }
+    .login-lead { text-align: center; color: var(--text); font-size: 1.05em; font-weight: 600; margin-bottom: 24px; }
     .form-group { margin-bottom: 20px; }
     label { display: block; margin-bottom: 6px; color: #aaa; font-size: 0.9em; }
     input[type="text"], input[type="password"] {
@@ -276,9 +278,9 @@
 <body>
   <div class="container">
     <h1 class="brand" id="pageTitle"><img src="logo.svg" alt="catalyzer"></h1>
-    <p class="subtitle" id="pageSubtitle">バンダイナムコIDでログインして戦績を分析</p>
 
     <div class="login-form" id="loginForm">
+      <p class="login-lead">バンダイナムコIDでログインして戦績を分析</p>
       <div class="form-group">
         <label for="username">バンダイナムコID (メールアドレス)</label>
         <input type="text" id="username" placeholder="example@email.com">


### PR DESCRIPTION
- 「バンダイナムコIDでログインして戦績を分析」をロゴ直下からログインフォーム内のリード文に移動
- viewport-fit=cover と theme-color、html背景色の指定でiPhoneの上下オーバースクロール時の白い余白を解消
- セーフエリア対応の余白をcontainerに追加
- 不要になった pageSubtitle 参照を削除
- PWA standalone を想定し、sticky topbar / sticky tabs / ログインロゴを env(safe-area-inset-top) で保護（通常のSafari表示では見た目不変）