### PR TITLE
chore: ログイン画面のサブタイトル文言を削除

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1536,8 +1536,6 @@ function reAnalyze() {
   if (lf) lf.style.display = 'block';
   var t = document.getElementById('pageTitle');
   if (t) t.style.display = '';
-  var st = document.getElementById('pageSubtitle');
-  if (st) st.style.display = '';
   window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
@@ -1618,8 +1616,6 @@ function renderReport(data, userKey) {
   // ダッシュボードのtopbarがブランド表示を担うため、静的な見出しは隠す
   var pageTitle = document.getElementById('pageTitle');
   if (pageTitle) pageTitle.style.display = 'none';
-  var pageSubtitle = document.getElementById('pageSubtitle');
-  if (pageSubtitle) pageSubtitle.style.display = 'none';
   render(html`<${Report} data=${data} userKey=${userKey} />`, reportEl);
 }
 
@@ -1650,8 +1646,6 @@ async function analyze() {
 
   var pageTitle = document.getElementById('pageTitle');
   if (pageTitle) pageTitle.style.display = '';
-  var pageSubtitle = document.getElementById('pageSubtitle');
-  if (pageSubtitle) pageSubtitle.style.display = '';
 
   document.getElementById('loginForm').style.display = 'none';
   var lastPreliminaryVersion = 0;

--- a/static/index.html
+++ b/static/index.html
@@ -35,7 +35,6 @@
     h1 { text-align: center; color: var(--accent); margin: 40px 0 10px; font-size: 1.8em; }
     h1.brand { margin: 48px 0 12px; line-height: 0; }
     h1.brand img { display: block; width: min(360px, 78%); height: auto; margin: 0 auto; }
-    .subtitle { text-align: center; color: var(--muted); margin-bottom: 40px; }
     .login-form { background: var(--panel); border-radius: 12px; padding: 30px; margin: 0 auto 30px; max-width: 480px; }
     .form-group { margin-bottom: 20px; }
     label { display: block; margin-bottom: 6px; color: #aaa; font-size: 0.9em; }
@@ -276,7 +275,6 @@
 <body>
   <div class="container">
     <h1 class="brand" id="pageTitle"><img src="logo.svg" alt="catalyzer"></h1>
-    <p class="subtitle" id="pageSubtitle">バンダイナムコIDでログインして戦績を分析</p>
 
     <div class="login-form" id="loginForm">
       <div class="form-group">


### PR DESCRIPTION
## Summary
- ログイン画面の「バンダイナムコIDでログインして戦績を分析」サブタイトルを削除
- 未使用となった `.subtitle` CSSルールと、削除済み要素 `pageSubtitle` を参照する `app.js` のデッドコードも除去

## Test plan
- [ ] `node --check static/app.js` がパス（確認済み）
- [ ] ログイン画面でサブタイトルが表示されないこと
- [ ] レポート表示/再分析時のヘッダー表示切替が従来通り動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)