### PR TITLE
feat(scraper): 403発生時のリクエスト時刻列ダンプ計装を追加

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -401,6 +401,10 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 
 	sem := make(chan struct{}, maxParallelism)
 
+	// 計装: 時間窓型レート検知の窓W・閾値N実測用。各リクエスト完了の相対時刻(ms)を記録し403時にダンプする
+	detailStart := time.Now()
+	var reqTimesMs []int64
+
 	for _, entry := range entries {
 		// キャンセル済みなら新規リクエストを発行しない
 		select {
@@ -435,6 +439,7 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 			mu.Lock()
 			scores = append(scores, parsed...)
 			processed++
+			reqTimesMs = append(reqTimesMs, time.Since(detailStart).Milliseconds())
 			shouldBatch := onBatch != nil && batchSize > 0 && processed%batchSize == 0
 			var snapshot model.DatedScores
 			if shouldBatch {
@@ -463,6 +468,7 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 
 	if has403 {
 		log.Printf("[WARN] 403 detected during detail fetch: %d/%d pages completed, returning partial data", processed, total)
+		log.Printf("[METRIC] 403 rate dump: 各リクエスト完了の相対ms (n=%d): %v", len(reqTimesMs), reqTimesMs)
 		return scores, ErrAccessDenied
 	}
 	if errorCount > 0 {

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -401,7 +401,7 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 
 	sem := make(chan struct{}, maxParallelism)
 
-	// 計装: 時間窓型レート検知の窓W・閾値N実測用。各リクエスト完了の相対時刻(ms)を記録し403時にダンプする
+	// 計装: 時間窓型レート検知の窓W・閾値N実測用。各リクエスト送信の相対時刻(ms)を記録し403時にダンプする
 	detailStart := time.Now()
 	var reqTimesMs []int64
 
@@ -435,11 +435,12 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 				return
 			}
 
+			sentMs := time.Since(detailStart).Milliseconds()
 			parsed, err := fetchSingleDetail(ctx, jar, e)
 			mu.Lock()
 			scores = append(scores, parsed...)
 			processed++
-			reqTimesMs = append(reqTimesMs, time.Since(detailStart).Milliseconds())
+			reqTimesMs = append(reqTimesMs, sentMs)
 			shouldBatch := onBatch != nil && batchSize > 0 && processed%batchSize == 0
 			var snapshot model.DatedScores
 			if shouldBatch {
@@ -468,7 +469,7 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 
 	if has403 {
 		log.Printf("[WARN] 403 detected during detail fetch: %d/%d pages completed, returning partial data", processed, total)
-		log.Printf("[METRIC] 403 rate dump: 各リクエスト完了の相対ms (n=%d): %v", len(reqTimesMs), reqTimesMs)
+		log.Printf("[METRIC] 403 rate dump: 各リクエスト送信の相対ms (n=%d): %v", len(reqTimesMs), reqTimesMs)
 		return scores, ErrAccessDenied
 	}
 	if errorCount > 0 {


### PR DESCRIPTION
## Summary
- バンナム側の403が**時間窓型レート検知**（待てば解消する）と判明したため、窓Wと閾値Nを実測する計装を追加
- `fetchDetailPagesStreaming` で各リクエスト完了の相対ms を記録し、403検出時に `[METRIC] 403 rate dump` としてログへダンプ
- 本処理のロジックには影響しない（6行の追加のみ）

## 背景
- 403は100% `match_detail` 取得段階で発生（日別ページ側はゼロ）
- 「待てば解消」＝時間窓型で確定。並列化前(P=1)では出なかった証言とも整合
- 閾値Nは完走ジョブ実測から105〜329件の間と推定。精密値が未確定のため計装で実測する
- 実測した W・N を、後続の「分割＋チャンク間クールダウン」対策のチャンクサイズ・クールダウン長の決定に用いる

## 検証手順
- [ ] stgへデプロイ
- [ ] 大量データのアカウントで分析を1回実行し403を再現
- [ ] `[METRIC] 403 rate dump` のログを取得し、任意の窓幅で累積を計算して W・N を割り出す

🤖 Generated with [Claude Code](https://claude.com/claude-code)