### PR TITLE
infra: Pulumi secrets providerをパスフレーズからGCP KMSへ移行

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,8 +95,6 @@ jobs:
           pulumi login gs://${{ secrets.PULUMI_STATE_BUCKET }}
           pulumi stack select stg
           pulumi config set exvs-app:image "$IMAGE" --secret
-        env:
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
 
       - name: Commit updated Pulumi config
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -40,8 +40,6 @@ jobs:
 
           pulumi stack select prod
           pulumi config set exvs-app:image "$IMAGE" --secret
-        env:
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
 
       - name: Commit updated Pulumi config
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,5 +84,3 @@ jobs:
           pulumi login gs://${{ secrets.PULUMI_STATE_BUCKET }}
           pulumi stack select "${{ matrix.environment }}"
           pulumi up --yes
-        env:
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -62,8 +62,6 @@ jobs:
           fi
           echo "### shared" > /tmp/pulumi-preview.txt
           pulumi preview 2>&1 | tee -a /tmp/pulumi-preview.txt
-        env:
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
 
       - name: Pulumi preview (app/prod)
         if: steps.check-secrets.outputs.skip != 'true'
@@ -76,8 +74,6 @@ jobs:
           fi
           echo "### app (prod)" >> /tmp/pulumi-preview.txt
           pulumi preview 2>&1 | tee -a /tmp/pulumi-preview.txt
-        env:
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
 
       - name: Pulumi preview (app/stg)
         if: steps.check-secrets.outputs.skip != 'true'
@@ -89,8 +85,6 @@ jobs:
           fi
           echo "### app (stg)" >> /tmp/pulumi-preview.txt
           pulumi preview 2>&1 | tee -a /tmp/pulumi-preview.txt
-        env:
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
 
       - name: Comment preview on PR
         if: steps.check-secrets.outputs.skip != 'true' && always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## プロジェクト概要
 
-EXVS Analyzer は、EXVS2IB（機動戦士ガンダム エクストリームバーサス2 インフィニットブースト）の戦績分析Webアプリ。公式サイトから対戦データをスクレイピングし、GCSにCSVとして保存、Python分析を実行してJSONレポートを返す。
+EXVS Analyzer は、EXVS2IB（機動戦士ガンダム エクストリームバーサス2 インフィニットブースト）の戦績分析Webアプリ。公式サイトから対戦データをスクレイピングし、Firestoreに保存、Python分析を実行してJSONレポートを返す。
 
 ## ビルド・開発コマンド
 
@@ -38,18 +38,18 @@ python3 scripts/analyze.py /tmp/scores.csv
 # Firestoreから未登録グレードURLを抽出（要: gcloud auth application-default login）
 FIRESTORE_DATABASE=exvs-analyzer make extract-grades
 
-# Pulumiコマンド（Docker経由）
-PULUMI_CONFIG_PASSPHRASE=<passphrase> make pulumi-shared-preview            # shared プレビュー
-PULUMI_CONFIG_PASSPHRASE=<passphrase> STACK=prod make pulumi-app-preview    # app(本番) プレビュー
-PULUMI_CONFIG_PASSPHRASE=<passphrase> STACK=stg make pulumi-app-preview # app(検証) プレビュー
-PULUMI_CONFIG_PASSPHRASE=<passphrase> make pulumi-shared-shell              # shared シェル（pulumi upはここで）
-PULUMI_CONFIG_PASSPHRASE=<passphrase> STACK=prod make pulumi-app-shell      # app(本番) シェル
-PULUMI_CONFIG_PASSPHRASE=<passphrase> STACK=stg make pulumi-app-shell   # app(検証) シェル
+# Pulumiコマンド（Docker経由。secretはGCP KMSで暗号化するためパスフレーズ不要、ADCで復号）
+make pulumi-shared-preview            # shared プレビュー
+STACK=prod make pulumi-app-preview    # app(本番) プレビュー
+STACK=stg make pulumi-app-preview     # app(検証) プレビュー
+make pulumi-shared-shell              # shared シェル（pulumi upはここで）
+STACK=prod make pulumi-app-shell      # app(本番) シェル
+STACK=stg make pulumi-app-shell       # app(検証) シェル
 ```
 
 http://localhost:8080 でアクセス可能。
 
-**ローカル環境にGoはインストール済み。Python/Pulumiはインストールされていない。** テストやビルドはDocker経由（Makefile）でも直接でも実行可能。Pulumi操作時は `infra/.envrc`（direnv）から `PULUMI_CONFIG_PASSPHRASE` が自動で読み込まれる。**worktreeで作業する場合は、`.envrc` がgitignore対象のため元リポジトリからコピーすること。**
+**ローカル環境にGoはインストール済み。Python/Pulumiはインストールされていない。** テストやビルドはDocker経由（Makefile）でも直接でも実行可能。Pulumi のsecretは GCP KMS で暗号化しており（各スタックの `secretsprovider: gcpkms://...`）、`gcloud auth application-default login` 済みのADCで復号する。パスフレーズは不要。
 
 CIでは `go vet`、`go build`、`py_compile` を実行。ラベル `skip-ci` でスキップ可能。
 
@@ -119,7 +119,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 - **Go 1.26**、Webフレームワーク不使用（標準 `net/http`）
 - **Python 3.11** で分析（pip依存なし）
 - **Pulumi (TypeScript)** でインフラ管理
-- GCSバケットは環境変数 `GCS_BUCKET` で指定、ユーザーキーは SHA256(email)[:8] の16進数
+- ストレージはFirestore（環境変数 `FIRESTORE_DATABASE` で指定）、ユーザーキーは SHA256(email)[:8] の16進数
 - Cloud Runデプロイ、`PORT` 環境変数（デフォルト 8080）
 
 ## Goコーディング規約

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,6 @@ PULUMI_SHARED_RUN = docker run --rm --entrypoint "" \
 	-v "$(CURDIR)/infra/shared":/infra \
 	-v "$(HOME)/.config/gcloud":/root/.config/gcloud \
 	-w /infra \
-	-e PULUMI_CONFIG_PASSPHRASE \
 	-e CLOUDSDK_CORE_PROJECT=$$(gcloud config get-value project 2>/dev/null) \
 	-e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json \
 	$(PULUMI_IMAGE)
@@ -58,7 +57,6 @@ PULUMI_APP_RUN = docker run --rm --entrypoint "" \
 	-v "$(CURDIR)/infra/app":/infra \
 	-v "$(HOME)/.config/gcloud":/root/.config/gcloud \
 	-w /infra \
-	-e PULUMI_CONFIG_PASSPHRASE \
 	-e CLOUDSDK_CORE_PROJECT=$$(gcloud config get-value project 2>/dev/null) \
 	-e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json \
 	$(PULUMI_IMAGE)
@@ -83,7 +81,6 @@ pulumi-shared-shell:
 		-v "$(CURDIR)/infra/shared":/infra \
 		-v "$(HOME)/.config/gcloud":/root/.config/gcloud \
 		-w /infra \
-		-e PULUMI_CONFIG_PASSPHRASE \
 		-e CLOUDSDK_CORE_PROJECT=$$(gcloud config get-value project 2>/dev/null) \
 		-e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json \
 		$(PULUMI_IMAGE) \
@@ -109,7 +106,6 @@ pulumi-app-shell:
 		-v "$(CURDIR)/infra/app":/infra \
 		-v "$(HOME)/.config/gcloud":/root/.config/gcloud \
 		-w /infra \
-		-e PULUMI_CONFIG_PASSPHRASE \
 		-e CLOUDSDK_CORE_PROJECT=$$(gcloud config get-value project 2>/dev/null) \
 		-e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json \
 		$(PULUMI_IMAGE) \

--- a/infra/README.md
+++ b/infra/README.md
@@ -29,7 +29,6 @@ make pulumi-shared-init
 make pulumi-shared-shell
 pulumi config set gcp:project <PROJECT_ID> --secret
 pulumi config set exvs-shared:artifactRegistryRepo <REPO_NAME> --secret
-pulumi config set exvs-shared:gcsBucket <BUCKET_NAME> --secret
 # ... 他の secret も同様
 
 # 3. app スタック初期化（prod / staging）
@@ -41,7 +40,6 @@ STACK=stg make pulumi-app-init
 STACK=prod make pulumi-app-shell
 pulumi config set gcp:project <PROJECT_ID> --secret
 pulumi config set exvs-app:image <IMAGE_URI> --secret
-pulumi config set exvs-app:gcsBucket <BUCKET_NAME> --secret
 ```
 
 ## 日常操作
@@ -101,7 +99,10 @@ STACK=stg make pulumi-app-shell    # → pulumi up
 | Secret | 説明 |
 |--------|------|
 | `PULUMI_STATE_BUCKET` | Pulumiステート保存用GCSバケット名 |
-| `PULUMI_CONFIG_PASSPHRASE` | Pulumiスタックの暗号化パスフレーズ |
 | `IMAGE_URI` | コンテナイメージURIベース |
 | `WIF_PROVIDER` | Workload Identity Provider |
 | `WIF_SERVICE_ACCOUNT` | GitHub Actions用サービスアカウント |
+
+## シークレットの暗号化
+
+Pulumi config の secret 値は **GCP KMS** で暗号化する（各スタックの `secretsprovider: gcpkms://...`）。パスフレーズは不要。ローカルは ADC、CI は WIF で連合した `github-actions@` SA が KMS 鍵（`pulumi-secrets/pulumi-state`、ロール `cloudkms.cryptoKeyEncrypterDecrypter`）で復号する。

--- a/infra/app/Pulumi.prod.yaml
+++ b/infra/app/Pulumi.prod.yaml
@@ -1,16 +1,14 @@
+secretsprovider: gcpkms://projects/exvs2ib-analyzer/locations/asia-northeast1/keyRings/pulumi-secrets/cryptoKeys/pulumi-state
+encryptedkey: CiQAll9D5eDQTWUGot9QBNaAp0izroIFuFTdE4qYrByGGPxzZegSSQDTCZ+AwaQwWNCA5m1E21p9ntkmIebidXYcIBRWAMY+Hs1XQtL1r94xDEUUk+IN7NnrEvKDgv6Q62vQb8NwjXFpWtE2dHXicwE=
 config:
-  gcp:project:
-    secure: v1:ZNRhblgzjExwl3oi:jCZSB3rnlQbA4BQScwj+0FLexKyrfkNErex5lkvAkYk=
+  gcp:project: exvs2ib-analyzer
   gcp:region: asia-northeast1
   exvs-app:serviceName: exvs-analyzer
   exvs-app:cpu: "2"
-  exvs-app:memory: "1Gi"
+  exvs-app:memory: 1Gi
   exvs-app:maxInstances: "3"
   exvs-app:domain: www.exvs-analyzer.com
-  exvs-app:gcsBucket:
-    secure: v1:/zqLjVBPrsfEzVcl:NiJy0Q5GyfXBNnaUDXoVF49BCgQK/tIF2No0PMCrMOy2ousY2A==
-  exvs-app:image:
-    secure: v1:g2BGMZspS2+ZDsE4:0A3iWGqRrKCl6/nLXrAP96Pe94E1b60VLeIPr6m9zQZ8f8F+aB16tCiGMZ+YnxCYnz2h9iOj8BXg1Oqv2qYIHfw6FS90QV+oGXjg6KpZmcKkHggFsyc59u4RGjQ7fWSnmmPaIVDjMpc7D3PBQB2EqBAv0qiDttbitUuxN/fZJMm9Rsph7F8SOvB6UJVUpw==
-  exvs-app:sharedStack: organization/exvs-shared/shared
   exvs-app:firestoreDatabase: exvs-analyzer
-encryptionsalt: v1:ToX9TGUsy/w=:v1:i/etZsivSPrFlstj:Ext0d7LnzlUd5QqVkA9H3ECUQuMZzQ==
+  exvs-app:sharedStack: organization/exvs-shared/shared
+  exvs-app:image:
+    secure: v1:PRNQhsUK1id6Rvgb:t6ZPt7ROS932fxfrSPd6D5k27l2xAw4yIqHU10m2OMw524A5YEcoAIfY5VGPdg+Da8m3NHjYjOxD177dQEgatZQBJwTrUn+eu/hMWujMwTV6UmXLqA3lKz7+QnHI1THNOC2Mqhzd122z0fw2yFAbizM4SwAvCocpGW+Smhcf0lc1Q4LAXaW58jeEoiAc5w==

--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -1,16 +1,14 @@
-encryptionsalt: v1:evUdMCCS5y8=:v1:/OISA4XjAeNSfiWM:dpR57gY0VOZJwLVX4naIh01vl/GXDg==
+secretsprovider: gcpkms://projects/exvs2ib-analyzer/locations/asia-northeast1/keyRings/pulumi-secrets/cryptoKeys/pulumi-state
+encryptedkey: CiQAll9D5clh0fHz2l8vQjLU1VmkCiD6TyG13XKtTM6jX6KKD5ISSQDTCZ+AoxpZepVcGNm40FnomL1uFv8eXKH0TGicQvTbCbmZ6rATHfDzAhg6Dr11sphs93D3tx1aqt+/H7xEdNoKWmde4otm/Os=
 config:
-  gcp:project:
-    secure: v1:GFZ/rFuC+i0R/bSv:NNxS64NTcMbplD9tvMzrMcd5mprAYX+Q5EByqXsk5dE=
+  gcp:project: exvs2ib-analyzer
   gcp:region: asia-northeast1
+  exvs-app:serviceName: stg-exvs-analyzer
   exvs-app:cpu: "1"
   exvs-app:memory: 512Mi
   exvs-app:maxInstances: "1"
   exvs-app:domain: stg.exvs-analyzer.com
-  exvs-app:image:
-    secure: v1:08HgjkVGG7MPVIrg:j2hoLUQrj2MVkTfJVZ37/Mo4oePKM60JVjWt5I0tFHBSc59aWcQUi7rGmQ15GPHX0526TML4Tibm9Drpw/dMdUjJ4eVtrYuNkLFhcx6mQ/qd2r2tdvvmVK4R7ToR0F7pT64ZpuK+qXuSMFxatYXhVmvNSFuiAUa1xkX1umQcL8zgcvJzwrBddd5Zw3GkGQ==
-  exvs-app:gcsBucket:
-    secure: v1:ZpepUFqv5KJMeSu1:0iAEyxxqllexQbeTezIhRPKvwR+2/sW5VY9iqpRWtWDeidp+gw==
-  exvs-app:sharedStack: organization/exvs-shared/shared
-  exvs-app:serviceName: stg-exvs-analyzer
   exvs-app:firestoreDatabase: exvs-analyzer
+  exvs-app:sharedStack: organization/exvs-shared/shared
+  exvs-app:image:
+    secure: v1:2KkSUE/CbengJlAj:/95m31YPSQ0s+UXOAZE/czTtGVCJVkrH423zFI/AxOGsjOaylR92vlWKD1apF6vVqXVF+LUPkypSCY2ClAIzk5nI0uJYEdcr3qrOkmpvqzozIt9ifTJOMD0U97PBLhT/BaJ27OvmqEP7sLZnkbmkuuWhNC5eMlGVJ4KE9rH4uEMwpGak0IThHYUq4+ndOA==

--- a/infra/app/index.ts
+++ b/infra/app/index.ts
@@ -8,7 +8,6 @@ const memory = config.require("memory");
 const maxInstances = config.requireNumber("maxInstances");
 const image = config.requireSecret("image");
 const domain = config.require("domain");
-const gcsBucket = config.requireSecret("gcsBucket");
 const firestoreDatabase = config.require("firestoreDatabase");
 
 // shared スタックからDNSゾーン名を取得
@@ -33,10 +32,6 @@ export const service = new gcp.cloudrunv2.Service(
           image: image,
           ports: { containerPort: 8080, name: "http1" },
           envs: [
-            {
-              name: "GCS_BUCKET",
-              value: gcsBucket,
-            },
             {
               name: "FIRESTORE_DATABASE",
               value: firestoreDatabase,
@@ -107,6 +102,9 @@ export const domainMapping = new gcp.cloudrun.DomainMapping(
     spec: {
       routeName: service.name,
     },
+  },
+  {
+    ignoreChanges: ["metadata"],
   }
 );
 

--- a/infra/shared/Pulumi.shared.yaml
+++ b/infra/shared/Pulumi.shared.yaml
@@ -1,22 +1,14 @@
+secretsprovider: gcpkms://projects/exvs2ib-analyzer/locations/asia-northeast1/keyRings/pulumi-secrets/cryptoKeys/pulumi-state
+encryptedkey: CiQAll9D5e8qX9+YB1YJWlG7Sx5gRytgZk6xsNkSCAM2TC127HMSSQDTCZ+Abqa0CzlRadaj0QBEyS0L2XbZYdhSc4XKczuRqQ02Macz76n97o7n8oe7hXl8C96eNSJw2P/OdNOuhpic95NhftczFlo=
 config:
-  gcp:project:
-    secure: v1:5mlc0YqYBrP6+JnY:9wJLfHMP7NFoVGpxCyE1Wf3w+86SnUR+MsLuUEb3riA=
-  gcp:region: asia-northeast1
+  gcp:project: exvs2ib-analyzer
   exvs-shared:artifactRegistryRepo:
-    secure: v1:VbIvYzqs1EqP7mCq:io649d9teYZX/UhwbKWuf0KnPDhpCAUhgeljnRF0o6Pe1jZMsAWL
-  exvs-shared:gcsBucket:
-    secure: v1:FDni+wlqiUoc5S06:jWGmpPtpG1hSG40torNMBIivfq2iHNP/vlBCENX+i8GcYnBPUA==
-  exvs-shared:billingAccount:
-    secure: v1:5/TgN98t8hdG1qav:hLSkhcVrBNxj6Q69yM1rd9P3LCuqLr4alWp13Lti2fFBts9b
-  exvs-shared:budgetAmount:
-    secure: v1:qrKhhc7um2Ek9eFw:y/87HFSHHTHoRGfeHV75GubkNwo=
+    secure: v1:KP2sO7T7aUvq0Uex:LtJwI4sZC0i9/AmxTqobS45IlHWkPIymtaLnCfgzth3XhcU+FHuy
   exvs-shared:pulumiStateBucket:
-    secure: v1:Du/axuJkvq/wtqd/:EIsWkGiOhurIvwVomvsdiXa+lqgmP8yIoJV0fC96pll4wwVh8nYxTfihJ5Rt
-  exvs-shared:githubRepo: yuki9431/catalyzer
+    secure: v1:p4DDsOtBMQ6T8oSn:FlYZdExZluaVJ//IUrrlPHfeyrOYTewZY6gVbKe9YBku4OoKfcBOIjvu2kHD
   exvs-shared:computeSa:
-    secure: v1:LbTz4LuCxUSGA8es:fhlSyWN8rwdbNbJ8pjHD7AWCpFlf/7euPR9VzUST3AI234w1DhU9NroG7KZJ8UeaxIWMNfmKBmtTcjx7BralkAY3
-  exvs-shared:ownerEmail:
-    secure: v1:uzvrdYQSitlnOdvZ:POlAg8alvfoFJgKnN+a7HExEL7eh9EmGo8cLBijhCXUeV2uB
-  exvs-shared:domainVerificationTxt: google-site-verification=TAXKxm2PncupGRZkk0mBxIxslp_7aZj-w9dxPAi-ObE
+    secure: v1:pSwvWq5Btyn4T9xU:ME8U55HKMzSLOp8qAElz0UggboMQ0nysjkEl7D43vuEXWxU4O9AwGMoBN5SrLcWrl7XHZ66UPLX58EbkU596ZDja
   exvs-shared:domain: exvs-analyzer.com
-encryptionsalt: v1:LhK5YSaq0ug=:v1:dh0WNpFPQMm4olnx:5RwQ7+f6ti1RGXxRrpTPTfDUnpYN7A==
+  exvs-shared:domainVerificationTxt: google-site-verification=TAXKxm2PncupGRZkk0mBxIxslp_7aZj-w9dxPAi-ObE
+  exvs-shared:githubRepo: yuki9431/catalyzer
+  gcp:region: asia-northeast1

--- a/infra/shared/iam.ts
+++ b/infra/shared/iam.ts
@@ -1,12 +1,11 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as gcp from "@pulumi/gcp";
-import { stateBucket, dataBucket } from "./storage";
+import { stateBucket } from "./storage";
 import { services } from "./apis";
 
 const config = new pulumi.Config();
 const githubRepo = config.require("githubRepo");
 const computeSa = config.requireSecret("computeSa");
-const ownerEmail = config.requireSecret("ownerEmail");
 
 // GitHub Actions用サービスアカウント
 export const githubActionsSa = new gcp.serviceaccount.Account(
@@ -97,16 +96,6 @@ export const stateBucketBinding = new gcp.storage.BucketIAMMember(
   }
 );
 
-// データバケットへの管理権限（GitHub Actions SA）
-export const dataBucketBinding = new gcp.storage.BucketIAMMember(
-  "github-actions-data-bucket",
-  {
-    bucket: dataBucket.name,
-    role: "roles/storage.objectAdmin",
-    member: githubActionsSa.member,
-  }
-);
-
 // Cloud Buildバケットへのストレージ権限（gcloud builds submitのソースアップロード用）
 export const cloudbuildBucketBinding = new gcp.storage.BucketIAMMember(
   "github-actions-cloudbuild-bucket",
@@ -114,26 +103,6 @@ export const cloudbuildBucketBinding = new gcp.storage.BucketIAMMember(
     bucket: `${gcp.config.project}_cloudbuild`,
     role: "roles/storage.objectUser",
     member: githubActionsSa.member,
-  }
-);
-
-// オーナーアカウントにデータバケットの管理権限を付与
-export const dataBucketOwnerIam = new gcp.storage.BucketIAMMember(
-  "app-data-owner",
-  {
-    bucket: dataBucket.name,
-    role: "roles/storage.admin",
-    member: pulumi.interpolate`user:${ownerEmail}`,
-  }
-);
-
-// Cloud Runデフォルトcompute SAにデータバケットへの最低限の権限を付与
-export const dataBucketComputeSaIam = new gcp.storage.BucketIAMMember(
-  "app-data-compute-sa",
-  {
-    bucket: dataBucket.name,
-    role: "roles/storage.objectUser",
-    member: pulumi.interpolate`serviceAccount:${computeSa}`,
   }
 );
 

--- a/infra/shared/index.ts
+++ b/infra/shared/index.ts
@@ -1,7 +1,7 @@
 import { services } from "./apis";
 import { repository } from "./artifact-registry";
 import { dnsZone, nameServers } from "./dns";
-import { stateBucket, dataBucket } from "./storage";
+import { stateBucket } from "./storage";
 import { githubActionsSa, wifPool, wifProvider } from "./iam";
 import { firestoreDb } from "./firestore";
 // TODO: budget importはBilling Budget APIのquota project設定後に対応
@@ -10,7 +10,6 @@ import { firestoreDb } from "./firestore";
 // app スタックから StackReference で参照される出力
 export const dnsZoneName = dnsZone.name;
 export const dnsNameServers = nameServers;
-export const appDataBucketName = dataBucket.name;
 
 // 情報表示用
 export const enabledApis = services.map((s) => s.service);

--- a/infra/shared/storage.ts
+++ b/infra/shared/storage.ts
@@ -3,7 +3,6 @@ import * as gcp from "@pulumi/gcp";
 
 const config = new pulumi.Config();
 const pulumiStateBucket = config.requireSecret("pulumiStateBucket");
-const gcsBucket = config.requireSecret("gcsBucket");
 
 // Pulumiステート保存用バケット
 export const stateBucket = new gcp.storage.Bucket("pulumi-state", {
@@ -12,23 +11,4 @@ export const stateBucket = new gcp.storage.Bucket("pulumi-state", {
   uniformBucketLevelAccess: true,
   publicAccessPrevention: "enforced",
   forceDestroy: false,
-});
-
-// アプリ用データバケット（ユーザーCSV保存）
-export const dataBucket = new gcp.storage.Bucket("app-data", {
-  name: gcsBucket,
-  location: gcp.config.region!,
-  uniformBucketLevelAccess: true,
-  publicAccessPrevention: "enforced",
-  versioning: { enabled: true },
-  forceDestroy: false,
-  lifecycleRules: [
-    {
-      action: { type: "Delete" },
-      condition: {
-        numNewerVersions: 3,
-        withState: "ARCHIVED",
-      },
-    },
-  ],
 });


### PR DESCRIPTION
## Summary

Pulumiのパスフレーズ紛失に伴い、**同一プロジェクト内でstateをGCP KMS暗号化で再構築**した。既存のGCPリソース・Firestoreデータは一切変更せず、importのみで移行している（差分は各appスタックで死んだ `GCS_BUCKET` env を1個外すだけ）。

- **secrets provider移行**: shared/stg/prod 全スタックを `secretsprovider: gcpkms://...` で再構築しimport。パスフレーズは不要になり、ローカルはADC・CIはWIFの `github-actions@` SAがKMSで復号する
- **破壊的replaceの抑止**: `infra/app/index.ts` のDomainMappingに `ignoreChanges: ["metadata"]` を追加。import直後に出る `pulumiLabels: {}` の見せかけ差分がForceNewなmetadataを叩いてカスタムドメイン断＋SSL再発行を招くのを防いだ
- **死んだGCS資産の撤去**: app-dataバケット＋関連IAM、`exvs-shared:gcsBucket` / `exvs-app:gcsBucket` config、Cloud Runの `GCS_BUCKET` env（アプリは既にFirestore移行済み）
- **passphrase配線の除去**: build/deploy/deploy-prod/infra-ci の4ワークフローとMakefileから無効化した `PULUMI_CONFIG_PASSPHRASE` を削除
- **ドキュメント更新**: CLAUDE.md / infra README をFirestore・KMS前提に修正

GCP側の事前作業（このPR外で実施済み）:
- KMS鍵 `pulumi-secrets/pulumi-state`（asia-northeast1）作成
- CI SA `github-actions@` に `roles/cloudkms.cryptoKeyEncrypterDecrypter` 付与

## Test plan

- [ ] Infra CIのpreviewコメントで、各スタックが「Serviceの `GCS_BUCKET` env削除のみ・replace無し」になっていることを確認
- [ ] shared/stg/prod の preview に予期しない削除・再作成が含まれないこと
- [ ] マージ後、`deploy.yml` の自動 `pulumi up` がKMS復号込みで成功すること（手動upで検証済みなら No changes になる）
- [ ] マージ後にGitHub Secret `PULUMI_CONFIG_PASSPHRASE` を削除（任意・後始末）

🤖 Generated with [Claude Code](https://claude.com/claude-code)