### PR TITLE
fix: app stg/prod スタックをKMS状態と整合させ deploy を復旧

### DIFF
--- a/infra/app/Pulumi.prod.yaml
+++ b/infra/app/Pulumi.prod.yaml
@@ -1,14 +1,14 @@
 secretsprovider: gcpkms://projects/exvs2ib-analyzer/locations/asia-northeast1/keyRings/pulumi-secrets/cryptoKeys/pulumi-state
-encryptedkey: CiQAll9D5eDQTWUGot9QBNaAp0izroIFuFTdE4qYrByGGPxzZegSSQDTCZ+AwaQwWNCA5m1E21p9ntkmIebidXYcIBRWAMY+Hs1XQtL1r94xDEUUk+IN7NnrEvKDgv6Q62vQb8NwjXFpWtE2dHXicwE=
+encryptedkey: CiQAll9D5d1UfBgQCPwxIK7lhY2Nmj9h8+QoNlRNXZtG6hZ2ENgSSADTCZ+A4ORiOrqJM/CSYXSXcH2H9xpwwL5MsJbPD9yXTantitJt/o+fSKysqZ/lVXjn6tyI+Jj19I4AL5/1ioU2U1v7QvQWEg==
 config:
-  gcp:project: exvs2ib-analyzer
-  gcp:region: asia-northeast1
-  exvs-app:serviceName: exvs-analyzer
   exvs-app:cpu: "2"
-  exvs-app:memory: 1Gi
-  exvs-app:maxInstances: "3"
   exvs-app:domain: www.exvs-analyzer.com
   exvs-app:firestoreDatabase: exvs-analyzer
-  exvs-app:sharedStack: organization/exvs-shared/shared
   exvs-app:image:
-    secure: v1:PRNQhsUK1id6Rvgb:t6ZPt7ROS932fxfrSPd6D5k27l2xAw4yIqHU10m2OMw524A5YEcoAIfY5VGPdg+Da8m3NHjYjOxD177dQEgatZQBJwTrUn+eu/hMWujMwTV6UmXLqA3lKz7+QnHI1THNOC2Mqhzd122z0fw2yFAbizM4SwAvCocpGW+Smhcf0lc1Q4LAXaW58jeEoiAc5w==
+    secure: v1:sZeW5rCsP4c1QxJP:KqBswaxyOAP5G/HD6tV1lMtGyqG+GG/kzgcj2HQfa6c7r4UpGTlyvQVaKEqhsZQpoLJKJgXgmk7xacAJ5nXkgkgFCaN/qgZEqOMwee6MlCACsEeJYqEoshrR9Va2T9WLtp6yXNFmqV//PXMkFPPIvPV5sjseHTbZaYV/LhbL5Lc6Bg5s5iMFwY+MoBdY1w==
+  exvs-app:maxInstances: "3"
+  exvs-app:memory: 1Gi
+  exvs-app:serviceName: exvs-analyzer
+  exvs-app:sharedStack: organization/exvs-shared/shared
+  gcp:project: exvs2ib-analyzer
+  gcp:region: asia-northeast1

--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -1,14 +1,14 @@
 secretsprovider: gcpkms://projects/exvs2ib-analyzer/locations/asia-northeast1/keyRings/pulumi-secrets/cryptoKeys/pulumi-state
-encryptedkey: CiQAll9D5clh0fHz2l8vQjLU1VmkCiD6TyG13XKtTM6jX6KKD5ISSQDTCZ+AoxpZepVcGNm40FnomL1uFv8eXKH0TGicQvTbCbmZ6rATHfDzAhg6Dr11sphs93D3tx1aqt+/H7xEdNoKWmde4otm/Os=
+encryptedkey: CiQAll9D5WDA7usIHCU/rNrKnSr+O2Xzg+vXaTCsa5NSOw6loLISSQDTCZ+A4B7OnFsieoFe5+hdATGg6IDYWfj2OxYlVBH4gDymLO8WhUw5UYJ5YlZsazRt77LU3cBiJL+jnrYBIl1IdyxBbkqVgkU=
 config:
-  gcp:project: exvs2ib-analyzer
-  gcp:region: asia-northeast1
-  exvs-app:serviceName: stg-exvs-analyzer
   exvs-app:cpu: "1"
-  exvs-app:memory: 512Mi
-  exvs-app:maxInstances: "1"
   exvs-app:domain: stg.exvs-analyzer.com
   exvs-app:firestoreDatabase: exvs-analyzer
-  exvs-app:sharedStack: organization/exvs-shared/shared
   exvs-app:image:
-    secure: v1:zRW5nWc/x5y/pIgb:wfROvpQk4pRoeDvfzWaR5gB2+AxRtUF3K/kgFNvIV81wLblAzeftiCf9m3y8kKBpKAtM3OBVVxMW0j5F8wirmJy2mPO1llDzDPN+/KQhsx9Hn3fKCRZ3dYg0HKnibFoYuR52GY/NTaLExrZqGOG7Jq09U3B/gxPB7QPC5PDMjfMUvQSYUyq5AsP0VeJl9w==
+    secure: v1:+Cw9yChZfyqINJVk:VxBoq5A8M/wH1lVSAQ8VffUpMsGQpeRcUUqNuqZXqkqTvzI2/jw5bACZijmEQleUPsR4gK0jdHpoMInBmLdqUBcw7x8MoAkZz0w9cTh9Ao0lCU+q2SwBKDYS7a0Z60OXg08Ih74j3RY1fZfG1E3QEbuqaXhBKYPbuJjRcYYLgp9CNWDj2ToTjFxhEauhLg==
+  exvs-app:maxInstances: "1"
+  exvs-app:memory: 512Mi
+  exvs-app:serviceName: stg-exvs-analyzer
+  exvs-app:sharedStack: organization/exvs-shared/shared
+  gcp:project: exvs2ib-analyzer
+  gcp:region: asia-northeast1


### PR DESCRIPTION
## 背景

`PULUMI_CONFIG_PASSPHRASE` 紛失に伴う GCP KMS への移行作業で、**app の stg/prod スタックの状態チェックポイントが `passphrase` 型のまま残っていた**。

`pulumi up` は yaml の `secretsprovider` ではなく **バケット内の状態の `secrets_providers`** を見て secrets manager を構築するため、CI から passphrase env を外した後、`deploy.yml` が以下で失敗し続けていた:

```
error: constructing secrets manager of type "passphrase":
passphrase must be set with PULUMI_CONFIG_PASSPHRASE ...
```

shared スタックは `cloud`(KMS) 型で正常だった（CI deploy 対象外のため上書きされなかった）。stg/prod だけ、過去の旧 passphrase yaml での `up` で状態が passphrase 型に再シリアライズされていた。

## 対応

stg/prod の状態を **GCP KMS で再 import**（実 GCP リソースには一切触れず、状態のみ再構築）し、secrets provider を `passphrase` → `cloud`(KMS) へ変換した。

再 init で `encryptedkey` が新しい DEK に変わったため、本 PR で git 側の yaml を状態と整合させる。

- **image は実環境で稼働中の値を維持**（stg=`5236a238` / prod=`a68dabfb`）— 移行で実環境のアプリは変えない方針
- マージ後 `deploy.yml` の `up` で適用される差分は **`GCS_BUCKET` env の削除のみ**（image 不変・無停止ローリング、破壊的 replace なし）

## マージ後の挙動

`infra/app/Pulumi.*.yaml` 変更により `deploy.yml` が stg/prod で `pulumi up` を実行 → secrets manager が KMS で構築され成功する。これでデプロイフローが復旧する。

> 注: image を最新へ上げ直す場合は移行完了後に `build.yml` / `deploy-prod.yml` の正規フローで行う。