### PR TITLE
feat(ui): ログイン成功後に結果画面へ即遷移しスケルトン表示

### DIFF
--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -92,6 +92,7 @@ type JobSnapshot struct {
 	PreliminaryVersion int
 	Error              string
 	PartialData        bool
+	LoggedIn           bool
 	UserKey            string
 }
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -42,6 +42,7 @@ type Job struct {
 	PreliminaryVersion int              `json:"preliminary_version,omitempty"`
 	Error              string           `json:"error,omitempty"`
 	PartialData        bool             `json:"partial_data,omitempty"`
+	LoggedIn           bool             `json:"logged_in,omitempty"`
 	UserKey            string           `json:"-"`
 	completedAt        time.Time
 }
@@ -87,6 +88,7 @@ func (j *Job) Snapshot() model.JobSnapshot {
 		PreliminaryVersion: j.PreliminaryVersion,
 		Error:              j.Error,
 		PartialData:        j.PartialData,
+		LoggedIn:           j.LoggedIn,
 		UserKey:            j.UserKey,
 	}
 }
@@ -238,6 +240,12 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		OnProgress:   onProgress,
 		OnBatchReady: onBatchReady,
 		BatchSize:    prelimBatchSize,
+		OnLoginSuccess: func() {
+			jobsMu.Lock()
+			j.LoggedIn = true
+			jobsMu.Unlock()
+			log.Printf("[INFO] Job %s: login succeeded", j.ID)
+		},
 	}
 	if len(backfillDates) > 0 {
 		scrapingOpt.BackfillDates = backfillDates

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -197,6 +197,13 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		jobsMu.Unlock()
 	}
 
+	// 同梱のMSリストから機体名マッピングを読み込み（速報・最終レポート両方で使用）
+	msList, err := mslist.LoadMSList(DefaultMSListPath)
+	if err != nil {
+		log.Printf("[WARN] MS list not found, MS names will be empty")
+	}
+	msMap := mslist.BuildMSNameMap(msList)
+
 	// 20試合ごとに速報レポートを段階的に更新するコールバック
 	var batchAnalysisMu sync.Mutex
 	var batchWg sync.WaitGroup
@@ -210,6 +217,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 			defer batchAnalysisMu.Unlock()
 			defer batchWg.Done()
 
+			mslist.FillMsNames(batchScores, msMap)
 			merged := mergeScores(existingScores, batchScores)
 
 			batchDir, err := os.MkdirTemp("", "exvs-batch-*")
@@ -325,13 +333,6 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		return
 	}
 
-	// 同梱のMSリストから機体名マッピングを読み込み
-	msList, err := mslist.LoadMSList(DefaultMSListPath)
-	if err != nil {
-		log.Printf("[WARN] MS list not found, MS names will be empty")
-	}
-
-	msMap := mslist.BuildMSNameMap(msList)
 	mslist.FillMsNames(datedScores, msMap)
 	mslist.CheckUnknownMS(datedScores)
 

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -90,6 +90,7 @@ type ScrapingOption struct {
 	BackfillDates  map[string]bool // バックフィル対象日付セット（"2006/01/02"形式）。nilなら全日付対象
 	OnBatchReady   func(scores model.DatedScores) // BatchSize試合ごとに蓄積スコアのスナップショットを通知
 	BatchSize      int                             // OnBatchReady発火間隔（試合数）。0の場合は通知しない
+	OnLoginSuccess func()                          // ログイン成功直後に1度だけ呼ばれる
 }
 
 // Scraping はスクレイピング処理を実行し、DatedScoresとログイン済みCookieJarを返す
@@ -118,6 +119,9 @@ func ScrapingWithOption(username, password string, since time.Time, opt Scraping
 	m := NewClient(username, password)
 	if err := m.Login(); err != nil {
 		return nil, nil, fmt.Errorf("ログインに失敗: %w", err)
+	}
+	if opt.OnLoginSuccess != nil {
+		opt.OnLoginSuccess()
 	}
 
 	// Phase 1: rankpageから日別ページURLを収集

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -154,6 +154,9 @@ func StartServer() {
 		if snap.Error != "" {
 			resp["error"] = snap.Error
 		}
+		if snap.LoggedIn {
+			resp["logged_in"] = true
+		}
 		if snap.PreliminaryReport != "" {
 			resp["has_preliminary_report"] = true
 			resp["preliminary_version"] = snap.PreliminaryVersion

--- a/static/app.js
+++ b/static/app.js
@@ -1569,7 +1569,6 @@ function Report({ data, userKey }) {
 
   return html`
     <div class="topbar">
-      <div class="brand">EXVS2IB 戦績分析<small>${esc(data.player_name)}</small></div>
       <div class="spacer" />
       <${PeriodSelector} periods=${allPeriods} selected=${selectedPeriod} onSelect=${setSelectedPeriod}
         userKey=${userKey} onCustomReport=${handleCustomReport} />
@@ -1610,6 +1609,39 @@ function Report({ data, userKey }) {
 
 // --- Main app logic ---
 
+// ログイン成功後、データ到着までのダッシュボード骨組み表示
+function Skeleton() {
+  function bar(w, h, mb) {
+    return html`<div class="skel" style=${{ width: w, height: h + 'px', marginBottom: (mb || 0) + 'px' }}></div>`;
+  }
+  return html`
+    <div class="topbar">
+      <div class="spacer" />
+      <div class="skel skel-pill"></div>
+    </div>
+    <div class="kpi-grid">
+      ${[0, 1, 2, 3, 4, 5].map(function () {
+        return html`<div class="kpi">${bar('50%', 12, 12)}${bar('70%', 28)}</div>`;
+      })}
+    </div>
+    <div class="panel">
+      ${bar('30%', 16, 14)}${bar('100%', 220)}
+    </div>
+    <div class="panel">
+      ${bar('24%', 16, 14)}
+      ${[0, 1, 2, 3].map(function () { return bar('100%', 14, 10); })}
+    </div>
+  `;
+}
+
+function showSkeleton() {
+  var reportEl = document.getElementById('report');
+  reportEl.style.display = 'block';
+  var pageTitle = document.getElementById('pageTitle');
+  if (pageTitle) pageTitle.style.display = 'none';
+  render(html`<${Skeleton} />`, reportEl);
+}
+
 function renderReport(data, userKey) {
   var reportEl = document.getElementById('report');
   reportEl.style.display = 'block';
@@ -1649,6 +1681,8 @@ async function analyze() {
 
   document.getElementById('loginForm').style.display = 'none';
   var lastPreliminaryVersion = 0;
+  var switched = false;
+  var renderedReal = false;
 
   try {
     var res = await fetch('/analyze', {
@@ -1687,11 +1721,19 @@ async function analyze() {
         progressWrap.style.display = 'none';
       }
 
-      if (statusData.has_preliminary_report && statusData.preliminary_version > lastPreliminaryVersion) {
+      // ログイン成功を確認した瞬間に結果画面（スケルトン）へ切り替える
+      if (!switched && statusData.logged_in) {
+        switched = true;
+        showSkeleton();
+      }
+
+      // 速報レポートは結果画面へ切り替えた後にのみ反映する
+      if (switched && statusData.has_preliminary_report && statusData.preliminary_version > lastPreliminaryVersion) {
         var prelimRes = await fetch('/result/' + jobId);
         var prelimData = await prelimRes.json();
         if (prelimData.report && prelimData.preliminary) {
           renderReport(prelimData.report, prelimData.user_key);
+          renderedReal = true;
           statusText.textContent = '最新データを取得中...';
           lastPreliminaryVersion = statusData.preliminary_version;
         }
@@ -1710,6 +1752,7 @@ async function analyze() {
         }
 
         renderReport(resultData.report, resultData.user_key);
+        renderedReal = true;
         if (resultData.partial) {
           var warning = document.getElementById('error');
           warning.style.display = 'block';
@@ -1724,6 +1767,12 @@ async function analyze() {
   } catch (e) {
     error.style.display = 'block';
     error.textContent = e.message;
+    // まだ実データを描画していない（ログイン中 or スケルトン表示中）なら結果画面を畳んでログイン画面へ戻す
+    if (!renderedReal) {
+      render(null, reportEl);
+      reportEl.style.display = 'none';
+      if (pageTitle) pageTitle.style.display = '';
+    }
     document.getElementById('loginForm').style.display = 'block';
   } finally {
     btn.disabled = false;

--- a/static/index.html
+++ b/static/index.html
@@ -66,6 +66,14 @@
     /* ===== Report container (dashboard) ===== */
     .report { line-height: 1.7; padding-bottom: 40px; }
 
+    /* ===== Skeleton (loading placeholder) ===== */
+    .skel {
+      background: linear-gradient(90deg, var(--panel-2) 25%, var(--line) 37%, var(--panel-2) 63%);
+      background-size: 400% 100%; border-radius: 8px; animation: skel-shimmer 1.4s ease infinite;
+    }
+    @keyframes skel-shimmer { 0% { background-position: 100% 0; } 100% { background-position: -100% 0; } }
+    .skel-pill { width: 120px; height: 38px; border-radius: 999px; }
+
     /* ===== Topbar ===== */
     .topbar {
       position: sticky; top: 0; z-index: 50;

--- a/static/index.html
+++ b/static/index.html
@@ -79,8 +79,14 @@
       position: sticky; top: 0; z-index: 50;
       display: flex; align-items: center; gap: 12px;
       padding: calc(12px + env(safe-area-inset-top)) 16px 12px; margin: 0 -16px 16px;
-      background: rgba(13,22,32,.82); backdrop-filter: blur(10px);
+      background: rgba(13,22,32,.82);
       border-bottom: 1px solid var(--line);
+    }
+    /* blurはtopbar自身ではなく擬似要素に持たせる。backdrop-filterは子孫のposition:fixedの包含ブロックを生成するため、
+       topbarに直接付けるとモバイルのボトムシート(.period-dropdown)がビューポートではなくtopbar基準になり画面上部へはみ出す */
+    .topbar::before {
+      content: ''; position: absolute; inset: 0; z-index: -1;
+      -webkit-backdrop-filter: blur(10px); backdrop-filter: blur(10px);
     }
     .brand { font-size: 1.05em; font-weight: 800; color: var(--accent); white-space: nowrap; }
     .brand small { display: block; font-size: .62em; font-weight: 500; color: var(--muted); letter-spacing: .04em; }


### PR DESCRIPTION
## 概要
ログイン成功を確認した瞬間に分析結果画面へ切り替わるようにする。データ到着までの間はスケルトンUI（ダッシュボードの骨組み）を表示し、速報・最終レポートで差し替える。

## 背景
ログイン検証はスクレイピング中（非同期）に行われ、`POST /analyze` の応答時点では成否が分からない。そこでログイン成功を明示シグナル化し、フロントはそれを契機に遷移する。

## 変更点
- **backend**
  - `scraper.ScrapingOption` に `OnLoginSuccess` コールバックを追加し、ログイン成功直後に1度呼ぶ
  - `Job.LoggedIn` / `JobSnapshot.LoggedIn` を追加、`Run` でコールバックを設定
  - `GET /status/{id}` が `logged_in: true` を返す
- **frontend**
  - `logged_in` 確認後に結果画面（スケルトンUI）へ即遷移
  - 速報レポートは遷移後にのみ反映。最終レポートで差し替え
  - 失敗時（ログインエラー等）は結果画面を畳んでログイン画面へ復帰
  - スケルトン用CSS（シマー）を追加
  - ダッシュボードヘッダのブランド表示（EXVS2IB 戦績分析・パイロット名）を削除

## 挙動
1. 分析開始 → ログイン中はスピナー表示
2. ログイン成功 → 結果画面（スケルトン）へ即遷移。裏でスクレイピング継続中は上部に進捗バー
3. 速報/最終レポート到着 → スケルトンを実ダッシュボードへ差し替え

## テスト
- [x] `go build` / `go vet` / `go test ./internal/...`（Docker経由、ALL_OK）
- [x] `node --check static/app.js`
- [ ] 実ログイン→スクレイピングのUI実走確認（要・実認証情報。レビュワー側で `make restart` 後に確認をお願いします）

🤖 Generated with [Claude Code](https://claude.com/claude-code)