### PR TITLE
ci: deployトリガーに--refを付け指定ブランチで実行可能にする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,7 @@ jobs:
         if: env.CHANGED == 'true'
         run: |
           gh workflow run deploy.yml \
+            --ref "${{ github.ref_name }}" \
             -f environment="stg"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -60,6 +60,7 @@ jobs:
         if: env.CHANGED == 'true'
         run: |
           gh workflow run deploy.yml \
+            --ref "${{ github.ref_name }}" \
             -f environment="prod"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## 概要
`gh workflow run deploy.yml` が `--ref` 未指定だと常にデフォルトブランチ(main)で実行されてしまう。`build.yml` / `deploy-prod.yml` を `workflow_dispatch` で別ブランチから実行した際に、deploy も同じブランチで走るよう `--ref "${{ github.ref_name }}"` を渡す。

## 変更点
- `.github/workflows/build.yml` — deploy.yml トリガーに `--ref` 追加
- `.github/workflows/deploy-prod.yml` — deploy.yml トリガーに `--ref` 追加

## 備考
- `--ref` で指定するブランチに `deploy.yml` が存在する必要があるが、リポジトリ全体に入っているため問題なし
- 機能変更を含まないCI設定変更のため `skip-ci` ラベル対象

🤖 Generated with [Claude Code](https://claude.com/claude-code)