### PR TITLE
fix(ui): スケルトンをジョブ開始直後に即表示する

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1681,7 +1681,6 @@ async function analyze() {
 
   document.getElementById('loginForm').style.display = 'none';
   var lastPreliminaryVersion = 0;
-  var switched = false;
   var renderedReal = false;
 
   try {
@@ -1697,6 +1696,9 @@ async function analyze() {
     }
 
     var jobId = data.id;
+
+    // スケルトンは即表示する（実データではないので遷移待ち不要）
+    showSkeleton();
 
     while (true) {
       await new Promise(function (r) { setTimeout(r, 3000); });
@@ -1721,14 +1723,8 @@ async function analyze() {
         progressWrap.style.display = 'none';
       }
 
-      // ログイン成功を確認した瞬間に結果画面（スケルトン）へ切り替える
-      if (!switched && statusData.logged_in) {
-        switched = true;
-        showSkeleton();
-      }
-
-      // 速報レポートは結果画面へ切り替えた後にのみ反映する
-      if (switched && statusData.has_preliminary_report && statusData.preliminary_version > lastPreliminaryVersion) {
+      // 速報レポート（キャッシュ含む実データ）はログイン成功確認後にのみ反映する
+      if (statusData.logged_in && statusData.has_preliminary_report && statusData.preliminary_version > lastPreliminaryVersion) {
         var prelimRes = await fetch('/result/' + jobId);
         var prelimData = await prelimRes.json();
         if (prelimData.report && prelimData.preliminary) {


### PR DESCRIPTION
## 概要
ログイン成功確認後にスケルトンを表示していたため、ログイン中はスピナーのみで骨組みが出ず即時性に欠けていた。スケルトンは実データではないため遷移待ちをやめ、ジョブ開始直後に即表示する。

## 背景
スケルトン表示を `logged_in` 確認後に限定していた（実データ保護のため）。しかしスケルトンはローディング骨組みであり実データではないので、ログイン前に出しても情報漏れにはならない。ログイン失敗時は既存の catch がスケルトンを畳んでログイン画面へ戻す。

## 変更点
- `showSkeleton()` をジョブID取得直後に移動（3秒の初回ポーリング待ちもなく即表示）
- 不要になった `switched` ゲートを削除
- 実データ（キャッシュ速報レポート）の差し替えは `logged_in` 確認後に限定（保護ゲートは維持）

## テスト
- [x] `node --check static/app.js`
- [ ] 実ブラウザ確認（`make restart` 後、ログイン→即スケルトン→ログイン後に実データ差し替えの流れ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)