### PR TITLE
fix(ui): スケルトンをPOST応答前に即表示する

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1683,6 +1683,9 @@ async function analyze() {
   var lastPreliminaryVersion = 0;
   var renderedReal = false;
 
+  // スケルトンはPOSTの応答を待たず即表示する（実データではないので遷移待ち不要）
+  showSkeleton();
+
   try {
     var res = await fetch('/analyze', {
       method: 'POST',
@@ -1696,9 +1699,6 @@ async function analyze() {
     }
 
     var jobId = data.id;
-
-    // スケルトンは即表示する（実データではないので遷移待ち不要）
-    showSkeleton();
 
     while (true) {
       await new Promise(function (r) { setTimeout(r, 3000); });


### PR DESCRIPTION
## 概要

分析開始時、ログインフォームを消した直後にステータスバーの文言（「準備中...」「戦績を取得中...」）だけが先に見えて、スケルトンが遅れて出る挙動を修正する。

`showSkeleton()` を `POST /analyze` の `await` の前に移動した。スケルトン表示は jobId を必要としないため、POSTのネットワーク往復を待たず即時にダッシュボードの骨組みを描画できる。

## 変更

- `static/app.js`: `showSkeleton()` の呼び出しをポーリングループ前から POST 前へ移動

## 確認

- [ ] スマホ実機でログインフォーム送信直後にスケルトンが即出ること
- [ ] 実データ（速報レポート）はログイン成功後に反映されること（既存挙動維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)