### PR TITLE
fix(progress): 進捗バーを不定→確定の2段階表示に修正

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -197,7 +197,10 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		jobsMu.Lock()
 		j.Message = "戦歴データを取得中"
 		j.Progress = current
-		j.ProgressTotal = total
+		// totalは単調増加のみ反映。Phase2の遅延ゴルーチンがtotal=0を投げてもバーをちらつかせない
+		if total > j.ProgressTotal {
+			j.ProgressTotal = total
+		}
 		jobsMu.Unlock()
 	}
 

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -419,6 +419,8 @@ func fetchDetailPagesStreaming(ctx context.Context, cancel context.CancelFunc, j
 		processed  int
 		errorCount int
 		has403     bool
+		// エントリ収集(Phase2)完了までは総数不明=0。確定後にディスパッチ総数を入れ進捗バーの分母にする
+		knownTotal int
 	)
 
 	burst := burstCount()
@@ -496,10 +498,11 @@ collectLoop:
 				cancel()
 			}
 			current := processed
+			total := knownTotal
 			mu.Unlock()
 
-			// totalは不明なため0を渡す。app.js側はtotal=0で進捗バーを非表示にする
-			notify(current, 0)
+			// total=0(Phase2未完=不定表示) → 確定後は処理済み/総数の正確なバー
+			notify(current, total)
 			if shouldBatch {
 				onBatch(snapshot)
 			}
@@ -512,6 +515,13 @@ collectLoop:
 	// チャネルに残ったエントリを排出し、streamMatchEntries側のブロックを解く
 	for range entryCh {
 	}
+
+	// Phase2完了=総試合数確定。以降のnotifyで正確な分母を出す
+	mu.Lock()
+	knownTotal = dispatched
+	last := processed
+	mu.Unlock()
+	notify(last, dispatched)
 
 	wg.Wait()
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -147,8 +147,11 @@ func StartServer() {
 		if snap.Message != "" {
 			resp["message"] = snap.Message
 		}
-		if snap.ProgressTotal > 0 {
+		if snap.Progress > 0 {
 			resp["progress"] = snap.Progress
+		}
+		// 総数はPhase2確定後のみ。0の間はフロントが不定表示にする
+		if snap.ProgressTotal > 0 {
 			resp["progress_total"] = snap.ProgressTotal
 		}
 		if snap.Error != "" {

--- a/static/app.js
+++ b/static/app.js
@@ -1711,13 +1711,24 @@ async function analyze() {
       statusText.textContent = statusData.message || STATUS_MESSAGES[statusData.status] || statusData.status;
 
       var progressWrap = document.getElementById('progressWrap');
+      var progressFill = document.getElementById('progressFill');
+      var isScraping = statusData.status === 'scraping';
       if (statusData.progress_total > 0) {
+        // 総数確定: 処理済み/総数の正確なバー
         var p = Math.round(100 * statusData.progress / statusData.progress_total);
-        document.getElementById('progressFill').style.width = p + '%';
+        progressFill.classList.remove('indeterminate');
+        progressFill.style.width = p + '%';
         document.getElementById('progressPct').textContent = p + '%';
         document.getElementById('progressCount').textContent = statusData.progress + '/' + statusData.progress_total + '件';
         progressWrap.style.display = 'block';
+      } else if (isScraping) {
+        // 総数未確定(Phase2)中: 不定アニメーション + 取得済み件数
+        progressFill.classList.add('indeterminate');
+        document.getElementById('progressPct').textContent = '戦歴を検索中…';
+        document.getElementById('progressCount').textContent = statusData.progress ? statusData.progress + '件' : '';
+        progressWrap.style.display = 'block';
       } else {
+        progressFill.classList.remove('indeterminate');
         progressWrap.style.display = 'none';
       }
 

--- a/static/index.html
+++ b/static/index.html
@@ -61,6 +61,9 @@
     .progress-wrap { margin-top: 12px; max-width: 480px; margin-left: auto; margin-right: auto; }
     .progress-bar { width: 100%; height: 8px; background: var(--panel); border-radius: 4px; overflow: hidden; }
     .progress-fill { height: 100%; background: linear-gradient(90deg, var(--accent), var(--accent-2)); border-radius: 4px; transition: width 0.4s ease; width: 0%; }
+    /* 総数未確定(Phase2)中の不定アニメーション */
+    .progress-fill.indeterminate { width: 40% !important; transition: none; animation: prog-indeterminate 1.2s ease-in-out infinite; }
+    @keyframes prog-indeterminate { 0% { margin-left: -40%; } 100% { margin-left: 100%; } }
     .progress-label { display: flex; justify-content: space-between; margin-top: 6px; font-size: 0.85em; color: #aaa; }
 
     /* ===== Report container (dashboard) ===== */


### PR DESCRIPTION
## Summary
- ストリーミング化（drain-allバリア撤去）で `notify(current, 0)` 固定になり、進捗バーが表示されなくなった回帰を修正
- Phase2（エントリ収集）完了で総試合数が確定したら `処理済み/総数` の正確なバーへ切替。それまでは不定アニメーションで取得状況を提示
- `onProgress` の total を単調増加にし、Phase2 の遅延ゴルーチンが 0 を投げてもバーがちらつかないようにした

## 変更点
- `scraper.go`: `knownTotal`（mutex保護）を追加。Phase2完了後に分母を確定
- `pipeline.go`: `onProgress` の `ProgressTotal` を単調増加に
- `server.go`: `progress` は >0 で送信、`progress_total` は確定後のみ送信
- `app.js` / `index.html`: 不定（「戦歴を検索中…」＋取得済み件数）／確定（処理済み/総数バー）／非表示の3状態に分岐。不定用 CSS アニメーション追加

## Test plan
- [x] `go build ./...` / `go vet` / `go test ./internal/scraper/...` 通過（Docker golang:1.26-alpine）
- [ ] 実機（本番/stg）で初回スクレイプ時に「検索中…」→確定バーへ切り替わることをブラウザ確認
- [ ] 既存の確定済みバー（増分スクレイプ等）が従来通り動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)