### PR TITLE
feat: autocomplete+sessionStorageによるログイン情報の保持

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -11,57 +11,6 @@ var STATUS_MESSAGES = {
 
 var PERIOD_KEYS = ['all', '90d', '60d', '30d', '14d', '7d', '3d', '1d'];
 
-// --- IndexedDB credential storage ---
-var CREDENTIALS_DB = 'catalyzer';
-var CREDENTIALS_STORE = 'credentials';
-var CREDENTIALS_KEY = 'default';
-
-function openCredentialsDB() {
-  return new Promise(function (resolve, reject) {
-    var req = indexedDB.open(CREDENTIALS_DB, 1);
-    req.onupgradeneeded = function () {
-      if (!req.result.objectStoreNames.contains(CREDENTIALS_STORE)) {
-        req.result.createObjectStore(CREDENTIALS_STORE);
-      }
-    };
-    req.onsuccess = function () { resolve(req.result); };
-    req.onerror = function () { reject(req.error); };
-  });
-}
-
-function saveCredentials(username, password) {
-  return openCredentialsDB().then(function (db) {
-    return new Promise(function (resolve, reject) {
-      var tx = db.transaction(CREDENTIALS_STORE, 'readwrite');
-      tx.objectStore(CREDENTIALS_STORE).put({ username: username, password: password }, CREDENTIALS_KEY);
-      tx.oncomplete = function () { resolve(); };
-      tx.onerror = function () { reject(tx.error); };
-    });
-  });
-}
-
-function loadCredentials() {
-  return openCredentialsDB().then(function (db) {
-    return new Promise(function (resolve, reject) {
-      var tx = db.transaction(CREDENTIALS_STORE, 'readonly');
-      var req = tx.objectStore(CREDENTIALS_STORE).get(CREDENTIALS_KEY);
-      req.onsuccess = function () { resolve(req.result || null); };
-      req.onerror = function () { reject(req.error); };
-    });
-  });
-}
-
-function deleteCredentials() {
-  return openCredentialsDB().then(function (db) {
-    return new Promise(function (resolve, reject) {
-      var tx = db.transaction(CREDENTIALS_STORE, 'readwrite');
-      tx.objectStore(CREDENTIALS_STORE).delete(CREDENTIALS_KEY);
-      tx.oncomplete = function () { resolve(); };
-      tx.onerror = function () { reject(tx.error); };
-    });
-  });
-}
-
 // --- Utility ---
 function esc(s) {
   if (s == null) return '';
@@ -1724,12 +1673,7 @@ async function analyze() {
     return;
   }
 
-  var saveCheck = document.getElementById('saveCredentials');
-  if (saveCheck && saveCheck.checked) {
-    saveCredentials(username, password).catch(function () {});
-  } else {
-    deleteCredentials().catch(function () {});
-  }
+  try { sessionStorage.setItem('catalyzer_cred', JSON.stringify({ u: username, p: password })); } catch (e) {}
 
   btn.disabled = true;
   status.style.display = 'block';
@@ -1852,18 +1796,19 @@ async function analyze() {
   }
 }
 
-if (document.getElementById('analyzeBtn')) {
-  document.getElementById('analyzeBtn').addEventListener('click', analyze);
-  document.getElementById('password').addEventListener('keypress', function (e) {
-    if (e.key === 'Enter') analyze();
+var loginForm = document.getElementById('loginForm');
+if (loginForm) {
+  loginForm.addEventListener('submit', function (e) {
+    e.preventDefault();
+    analyze();
   });
-  loadCredentials().then(function (cred) {
-    if (!cred) return;
-    document.getElementById('username').value = cred.username;
-    document.getElementById('password').value = cred.password;
-    var saveCheck = document.getElementById('saveCredentials');
-    if (saveCheck) saveCheck.checked = true;
-  }).catch(function () {});
+  try {
+    var cred = JSON.parse(sessionStorage.getItem('catalyzer_cred'));
+    if (cred) {
+      document.getElementById('username').value = cred.u;
+      document.getElementById('password').value = cred.p;
+    }
+  } catch (e) {}
 }
 
 // preview.html用: windowにrenderReportを公開

--- a/static/app.js
+++ b/static/app.js
@@ -11,6 +11,57 @@ var STATUS_MESSAGES = {
 
 var PERIOD_KEYS = ['all', '90d', '60d', '30d', '14d', '7d', '3d', '1d'];
 
+// --- IndexedDB credential storage ---
+var CREDENTIALS_DB = 'catalyzer';
+var CREDENTIALS_STORE = 'credentials';
+var CREDENTIALS_KEY = 'default';
+
+function openCredentialsDB() {
+  return new Promise(function (resolve, reject) {
+    var req = indexedDB.open(CREDENTIALS_DB, 1);
+    req.onupgradeneeded = function () {
+      if (!req.result.objectStoreNames.contains(CREDENTIALS_STORE)) {
+        req.result.createObjectStore(CREDENTIALS_STORE);
+      }
+    };
+    req.onsuccess = function () { resolve(req.result); };
+    req.onerror = function () { reject(req.error); };
+  });
+}
+
+function saveCredentials(username, password) {
+  return openCredentialsDB().then(function (db) {
+    return new Promise(function (resolve, reject) {
+      var tx = db.transaction(CREDENTIALS_STORE, 'readwrite');
+      tx.objectStore(CREDENTIALS_STORE).put({ username: username, password: password }, CREDENTIALS_KEY);
+      tx.oncomplete = function () { resolve(); };
+      tx.onerror = function () { reject(tx.error); };
+    });
+  });
+}
+
+function loadCredentials() {
+  return openCredentialsDB().then(function (db) {
+    return new Promise(function (resolve, reject) {
+      var tx = db.transaction(CREDENTIALS_STORE, 'readonly');
+      var req = tx.objectStore(CREDENTIALS_STORE).get(CREDENTIALS_KEY);
+      req.onsuccess = function () { resolve(req.result || null); };
+      req.onerror = function () { reject(req.error); };
+    });
+  });
+}
+
+function deleteCredentials() {
+  return openCredentialsDB().then(function (db) {
+    return new Promise(function (resolve, reject) {
+      var tx = db.transaction(CREDENTIALS_STORE, 'readwrite');
+      tx.objectStore(CREDENTIALS_STORE).delete(CREDENTIALS_KEY);
+      tx.oncomplete = function () { resolve(); };
+      tx.onerror = function () { reject(tx.error); };
+    });
+  });
+}
+
 // --- Utility ---
 function esc(s) {
   if (s == null) return '';
@@ -1530,6 +1581,13 @@ var TAB_DEFS = [
 ];
 
 function reAnalyze() {
+  var u = document.getElementById('username');
+  var p = document.getElementById('password');
+  if (u && p && u.value && p.value) {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    analyze();
+    return;
+  }
   var rep = document.getElementById('report');
   if (rep) rep.style.display = 'none';
   var lf = document.getElementById('loginForm');
@@ -1666,6 +1724,13 @@ async function analyze() {
     return;
   }
 
+  var saveCheck = document.getElementById('saveCredentials');
+  if (saveCheck && saveCheck.checked) {
+    saveCredentials(username, password).catch(function () {});
+  } else {
+    deleteCredentials().catch(function () {});
+  }
+
   btn.disabled = true;
   status.style.display = 'block';
   statusText.textContent = STATUS_MESSAGES.pending;
@@ -1792,6 +1857,13 @@ if (document.getElementById('analyzeBtn')) {
   document.getElementById('password').addEventListener('keypress', function (e) {
     if (e.key === 'Enter') analyze();
   });
+  loadCredentials().then(function (cred) {
+    if (!cred) return;
+    document.getElementById('username').value = cred.username;
+    document.getElementById('password').value = cred.password;
+    var saveCheck = document.getElementById('saveCredentials');
+    if (saveCheck) saveCheck.checked = true;
+  }).catch(function () {});
 }
 
 // preview.html用: windowにrenderReportを公開

--- a/static/index.html
+++ b/static/index.html
@@ -53,6 +53,11 @@
     }
     button:hover { background: var(--accent-2); }
     button:disabled { background: #333; color: #666; cursor: not-allowed; }
+    .save-credentials { display: inline-flex; align-items: center; gap: 8px; margin: -8px 0 0; color: #aaa; font-size: 0.85em; cursor: pointer; user-select: none; }
+    .save-credentials input[type="checkbox"] { position: absolute; opacity: 0; width: 0; height: 0; }
+    .save-credentials .check-icon { position: relative; width: 16px; height: 16px; border: 1.5px solid #444; border-radius: 3px; background: transparent; flex-shrink: 0; transition: background .15s, border-color .15s; }
+    .save-credentials input:checked + .check-icon { background: var(--accent); border-color: var(--accent); }
+    .save-credentials input:checked + .check-icon::after { content: ''; position: absolute; left: 4.5px; top: 1.5px; width: 4px; height: 8px; border: solid #062536; border-width: 0 2px 2px 0; transform: rotate(45deg); }
     .security-note { margin: 16px 0; padding: 12px; font-size: 0.8em; color: #aaa; line-height: 1.6; background: #162029; border-radius: 8px; border-left: 3px solid var(--accent); }
     .note { margin-top: 16px; font-size: 0.8em; color: #777; line-height: 1.6; }
     .status { text-align: center; margin: 20px 0; color: #aaa; }
@@ -306,6 +311,7 @@
         <label for="password">パスワード</label>
         <input type="password" id="password" placeholder="パスワード">
       </div>
+      <label class="save-credentials"><input type="checkbox" id="saveCredentials"><span class="check-icon"></span>ログイン情報を保存する</label>
       <p class="security-note">パスワードはガンダムモバイルへのログインにのみ使用し、サーバーには保存しません。通信はHTTPSで暗号化されています。</p>
       <button id="analyzeBtn">分析開始</button>
       <p class="note">公式サイトから直近30日分の戦績を取得して分析します。初回は全データを取得するため5〜10分ほどかかりますが、2回目以降は前回からの差分のみ取得するため短時間で完了します。</p>

--- a/static/index.html
+++ b/static/index.html
@@ -53,11 +53,6 @@
     }
     button:hover { background: var(--accent-2); }
     button:disabled { background: #333; color: #666; cursor: not-allowed; }
-    .save-credentials { display: inline-flex; align-items: center; gap: 8px; margin: -8px 0 0; color: #aaa; font-size: 0.85em; cursor: pointer; user-select: none; }
-    .save-credentials input[type="checkbox"] { position: absolute; opacity: 0; width: 0; height: 0; }
-    .save-credentials .check-icon { position: relative; width: 16px; height: 16px; border: 1.5px solid #444; border-radius: 3px; background: transparent; flex-shrink: 0; transition: background .15s, border-color .15s; }
-    .save-credentials input:checked + .check-icon { background: var(--accent); border-color: var(--accent); }
-    .save-credentials input:checked + .check-icon::after { content: ''; position: absolute; left: 4.5px; top: 1.5px; width: 4px; height: 8px; border: solid #062536; border-width: 0 2px 2px 0; transform: rotate(45deg); }
     .security-note { margin: 16px 0; padding: 12px; font-size: 0.8em; color: #aaa; line-height: 1.6; background: #162029; border-radius: 8px; border-left: 3px solid var(--accent); }
     .note { margin-top: 16px; font-size: 0.8em; color: #777; line-height: 1.6; }
     .status { text-align: center; margin: 20px 0; color: #aaa; }
@@ -301,21 +296,20 @@
   <div class="container">
     <h1 class="brand" id="pageTitle"><img src="logo.svg" alt="catalyzer"></h1>
 
-    <div class="login-form" id="loginForm">
+    <form class="login-form" id="loginForm" autocomplete="on">
       <p class="login-lead">バンダイナムコIDでログインして戦績を分析</p>
       <div class="form-group">
         <label for="username">バンダイナムコID (メールアドレス)</label>
-        <input type="text" id="username" placeholder="example@email.com">
+        <input type="text" id="username" name="username" autocomplete="username" placeholder="example@email.com">
       </div>
       <div class="form-group">
         <label for="password">パスワード</label>
-        <input type="password" id="password" placeholder="パスワード">
+        <input type="password" id="password" name="password" autocomplete="current-password" placeholder="パスワード">
       </div>
-      <label class="save-credentials"><input type="checkbox" id="saveCredentials"><span class="check-icon"></span>ログイン情報を保存する</label>
       <p class="security-note">パスワードはガンダムモバイルへのログインにのみ使用し、サーバーには保存しません。通信はHTTPSで暗号化されています。</p>
-      <button id="analyzeBtn">分析開始</button>
+      <button type="submit" id="analyzeBtn">分析開始</button>
       <p class="note">公式サイトから直近30日分の戦績を取得して分析します。初回は全データを取得するため5〜10分ほどかかりますが、2回目以降は前回からの差分のみ取得するため短時間で完了します。</p>
-    </div>
+    </form>
 
     <div class="status" id="status" style="display:none;">
       <span class="spinner"></span>


### PR DESCRIPTION
## Summary
- ログインフォームを`<form>`に変更し`autocomplete`属性を追加、ブラウザのパスワードマネージャーと連携
- sessionStorageで認証情報をタブ内に保持し、ページリロード時に自動入力（タブを閉じたら消える）
- 再分析ボタン押下時、認証情報がDOMに残っていればログイン画面をスキップして即座に再分析を開始
- form submitハンドリングによりEnterキー・ボタンクリックの処理を統一

## Test plan
- [ ] 分析実行後、ページをリロードして認証情報がsessionStorageから自動入力されることを確認
- [ ] タブを閉じて新しいタブで開くと認証情報が消えていることを確認
- [ ] ブラウザのパスワード保存ダイアログが表示されることを確認（ブラウザ依存）
- [ ] 再分析ボタンで認証情報が残っていればログイン画面をスキップすることを確認
- [ ] プライベートブラウジングでエラーなく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)