### PR TITLE
fix: 固定相方パネルの勝敗レンズで旧データ時に全値0になるバグを修正

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -303,8 +303,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		return
 	}
 
-	// 新規データがない場合はタッグ情報を付与して最終レポートにする
-	// jsonPathには速報レポート用に生成したJSONが残っており、ここでそのまま再利用する
+	// 新規データがない場合はタッグ情報を付与して再分析する
 	if len(datedScores) == 0 && j.PreliminaryReport != "" {
 		var tagPartnersPath string
 		tagPartners := scraper.ScrapeTagPartners(jar)
@@ -315,20 +314,24 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 				tagPartnersPath = ""
 			} else {
 				log.Printf("[INFO] Found %d tag partners (no new data path)", len(tagPartners))
-				// Firestoreにtag_partnersを書き込み
 				fs.SaveTagPartners(j.UserKey, tagPartners)
 			}
 		} else {
-			log.Printf("[INFO] No tag partners found (no new data path)")
+			log.Printf("[INFO] No tag partners found (no new data path), using cached")
+			tagPartnersPath = cachedTagPartnersPath
 		}
 
-		// タッグ情報がある場合は再分析、なければ速報レポートをそのまま使う
-		finalReport := j.PreliminaryReport
-		if tagPartnersPath != "" {
-			report := runAnalysis(jsonPath, tmpDir, tagPartnersPath)
-			if report != "" {
-				finalReport = report
+		// キャッシュ利用時はjsonPathが未生成なので既存データから生成
+		if _, err := os.Stat(jsonPath); os.IsNotExist(err) {
+			if err := saveScoresJSON(existingScores, jsonPath); err != nil {
+				log.Printf("[WARN] Failed to save scores JSON for re-analysis: %v", err)
 			}
+		}
+
+		finalReport := j.PreliminaryReport
+		report := runAnalysis(jsonPath, tmpDir, tagPartnersPath)
+		if report != "" {
+			finalReport = report
 		}
 
 		jobsMu.Lock()

--- a/static/app.js
+++ b/static/app.js
@@ -1556,12 +1556,10 @@ function FixedPartnerPanel({ fp, fpItems, lens }) {
 
   var myWl = (p.my_win_loss_pattern && p.my_win_loss_pattern.metrics) || [];
   var partnerWl = (p.partner_win_loss_pattern && p.partner_win_loss_pattern.metrics) || [];
-  function wm(metrics, label) {
-    return metrics.find(function (m) { return m.label === label; }) || { win_avg: 0, loss_avg: 0 };
-  }
   function valFor(metrics, label, allVal) {
     if (lens === 'all') return allVal;
-    var m = wm(metrics, label);
+    var m = metrics.find(function (m) { return m.label === label; });
+    if (!m) return null;
     return lens === 'win' ? m.win_avg : m.loss_avg;
   }
 


### PR DESCRIPTION
## Summary
- 固定相方パネルで勝利/敗北レンズに切り替えると全指標が0表示されるバグを修正
- 原因: `my_win_loss_pattern`が存在しない旧キャッシュデータの場合、`wm()`のデフォルト値`{win_avg:0, loss_avg:0}`が使われていた
- 修正: メトリクスが見つからない場合は`null`を返し、`-`表示にフォールバック
- `avg_ex_dmg`・`avg_bursts`の表示は新Pythonコードで生成されるため、再分析で反映される

## Test plan
- [ ] 旧データ: 勝利/敗北レンズで全指標が`-`表示（0ではない）
- [ ] 再分析後: 勝利/敗北レンズで正しい値が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpWa3cmYn17WNUwP3p1oZh