### PR TITLE
fix: モバイル表示の横スクロール防止とtopbar改善

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1934,7 +1934,7 @@ function Report({ data, userKey }) {
   return html`
     <div class="topbar">
       <button class="hamburger" onClick=${function () { setMenuOpen(true); }}>☰</button>
-      <span class="brand">catalyzer<small>EXVS2IB Stats</small></span>
+      <span class="brand"><img src="logo.svg" alt="catalyzer" /></span>
       <div class="spacer" />
       <${MsSelector} entries=${msEntries} selected=${selectedMs} onSelect=${setSelectedMs} />
       <${LensToggle} lens=${lens} onSelect=${setLens} />
@@ -1967,9 +1967,9 @@ function Skeleton() {
   return html`
     <div class="topbar">
       <div class="skel" style=${{ width: '28px', height: '28px', borderRadius: '6px' }}></div>
-      <span class="brand">catalyzer<small>EXVS2IB Stats</small></span>
+      <span class="brand"><img src="logo.svg" alt="catalyzer" /></span>
       <div class="spacer" />
-      <div class="skel skel-pill"></div>
+      <div class="skel skel-pill" style=${{ marginLeft: 'auto' }}></div>
       <div class="skel skel-pill" style=${{ width: '160px' }}></div>
       <div class="skel skel-pill"></div>
     </div>

--- a/static/index.html
+++ b/static/index.html
@@ -27,7 +27,7 @@
       --shadow: 0 6px 20px rgba(0,0,0,.35);
     }
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    html { background: var(--bg); }
+    html { background: var(--bg); overflow-x: hidden; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       background: var(--bg) radial-gradient(1200px 600px at 50% -200px, #14283a 0%, var(--bg) 60%) no-repeat;
@@ -81,7 +81,7 @@
     .topbar {
       position: sticky; top: 0; z-index: 50;
       display: flex; align-items: center; gap: 12px;
-      padding: calc(12px + env(safe-area-inset-top)) 16px 12px; margin: 0 -16px 16px;
+      padding: calc(28px + env(safe-area-inset-top)) 16px 12px; margin: -16px -16px 16px;
       background: rgba(13,22,32,.82);
       border-bottom: 1px solid var(--line);
     }
@@ -92,7 +92,7 @@
       -webkit-backdrop-filter: blur(10px); backdrop-filter: blur(10px);
     }
     .brand { font-size: 1.05em; font-weight: 800; color: var(--accent); white-space: nowrap; }
-    .brand small { display: block; font-size: .62em; font-weight: 500; color: var(--muted); letter-spacing: .04em; }
+    .brand img { height: 24px; width: auto; display: block; }
     .topbar .spacer { flex: 1; }
     /* ===== KPI cards ===== */
     .kpi-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 16px; }
@@ -313,7 +313,8 @@
       .tabs { top: calc(110px + env(safe-area-inset-top)); }
     }
     @media (max-width: 600px) {
-      .container { padding: 10px; }
+      .container { padding: 10px; padding-left: max(10px, env(safe-area-inset-left)); padding-right: max(10px, env(safe-area-inset-right)); padding-bottom: max(10px, env(safe-area-inset-bottom)); }
+      .topbar { margin: -10px -10px 16px; padding: calc(22px + env(safe-area-inset-top)) 10px 12px; }
       h1 { font-size: 1.4em; margin: 20px 0 8px; }
       .login-form { padding: 20px; }
       .report h1 { font-size: 1.2em; }
@@ -323,6 +324,7 @@
       .chart-container { height: 240px; }
       .period-backdrop { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99; }
       .period-dropdown { position: fixed; bottom: 0; top: auto; left: 0; right: 0; min-width: 0; width: 100%; max-height: 85vh; overflow: visible; overflow-y: auto; border-radius: 12px 12px 0 0; z-index: 100; margin-top: 0; }
+      .ms-topbar-dropdown { width: calc(100vw - 20px); }
       .ms-topbar-item { padding: 14px 16px; font-size: 1em; }
       .panel-select-item { padding: 14px 16px; font-size: 1em; }
       .period-custom-range { flex-direction: column; }


### PR DESCRIPTION
## Summary
- モバイル表示時の横スクロールを防止（topbarの負マージンとコンテナpaddingの不整合を修正）
- iPhoneのステータスバーとtopbar間の不自然なラインを解消（topbarを負margin-topでコンテナpadding領域まで拡張）
- topbarのブランド表示をテキスト「catalyzer / EXVS2IB Stats」からSVGロゴに変更
- モバイル(600px以下)でsafe-area-insetを復元、Skeleton topbarのpill右寄せを修正

## Test plan
- [ ] iPhone実機でモバイル表示時に横スクロールが発生しないこと
- [ ] topbarにSVGロゴが表示され「EXVS2IB Stats」テキストが消えていること
- [ ] iPhoneのステータスバーとtopbar間に不自然なラインがないこと
- [ ] デスクトップ表示でレイアウトが崩れていないこと
- [ ] スケルトン表示時にtopbarのpillが右寄せされていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)