### PR TITLE
fix: Skeletonのpill右寄せとtabsのsticky offset修正

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1966,7 +1966,6 @@ function Skeleton() {
     <div class="topbar">
       <div class="skel" style=${{ width: '28px', height: '28px', borderRadius: '6px' }}></div>
       <span class="brand"><img src="logo.svg" alt="catalyzer" /></span>
-      <div class="spacer" />
       <div class="skel skel-pill" style=${{ marginLeft: 'auto' }}></div>
       <div class="skel skel-pill" style=${{ width: '160px' }}></div>
       <div class="skel skel-pill"></div>

--- a/static/index.html
+++ b/static/index.html
@@ -127,7 +127,7 @@
     .tabs {
       display: flex; gap: 6px; overflow-x: auto; -webkit-overflow-scrolling: touch;
       padding: 4px; margin-bottom: 14px; background: var(--panel); border: 1px solid var(--line);
-      border-radius: 14px; position: sticky; top: calc(64px + env(safe-area-inset-top)); z-index: 40;
+      border-radius: 14px; position: sticky; top: calc(80px + env(safe-area-inset-top)); z-index: 40;
     }
     .tab {
       flex: 0 0 auto; padding: 9px 16px; border: none; border-radius: 10px;
@@ -310,7 +310,7 @@
       .ms-topbar-trigger { max-width: 50vw; }
       .ms-topbar-dropdown { min-width: 0; left: 0; width: calc(100vw - 32px); }
       .lens-toggle { order: 6; flex: 0 0 auto; }
-      .tabs { top: calc(110px + env(safe-area-inset-top)); }
+      .tabs { top: calc(126px + env(safe-area-inset-top)); }
     }
     @media (max-width: 600px) {
       .container { padding: 10px; padding-left: max(10px, env(safe-area-inset-left)); padding-right: max(10px, env(safe-area-inset-right)); padding-bottom: max(10px, env(safe-area-inset-bottom)); }


### PR DESCRIPTION
## Summary
- Skeleton topbarのspacerを削除し`marginLeft: auto`で右寄せ（モバイルのflex-wrapでspacerがorder:3に移動しpillが右寄せされない問題を修正）
- `.tabs`のsticky topを#301のtopbar padding-top増加(+16px)に合わせて調整（base: 64→80px、720px: 110→126px）

## Test plan
- [ ] スケルトン表示時にtopbarのpillが右寄せされていること
- [ ] スクロール時にtabsがtopbarと重ならないこと（デスクトップ・モバイル両方）

🤖 Generated with [Claude Code](https://claude.com/claude-code)