### PR TITLE
fix: レーダーチャートの被ダメ・被撃墜の評価方向を修正

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1388,19 +1388,20 @@ function BasicLensSection({ basic, pattern, lens }) {
   if (!basic) return null;
   if (!lens) lens = 'all';
   var metrics = (pattern && pattern.metrics) || [];
-  function wm(label) {
-    return metrics.find(function (m) { return m.label === label; }) || { win_avg: 0, loss_avg: 0 };
+  function wmVal(label) {
+    var m = metrics.find(function (m) { return m.label === label; });
+    if (!m) return null;
+    return lens === 'win' ? m.win_avg : m.loss_avg;
   }
   // 攻めを上半分・守りを下半分に固めつつ3ペアを対極配置: 与ダメ↔被ダメ, 撃墜↔被撃墜, EXダメ↔覚醒回数
   // 軸順(idx): 0=与ダメ(上), 1=撃墜(右上), 2=覚醒回数(右下), 3=被ダメ(下), 4=被撃墜(左下), 5=EXダメ(左上)
-  // 覚醒回数は2回で上等だが3回まで伸びる特殊キャラもいるため0〜2.5でクランプ
   function vec(dgv, kv, bv, dtv, dthv, exv) {
-    return [clampN(dgv, 600, 1200), clampN(kv, 0.5, 2.5), clampN(bv, 0, 2.5), clampN(dtv, 600, 1200), clampN(dthv, 0.5, 2.5), clampN(exv, 80, 250)];
+    return [clampN(dgv, 600, 1200), clampN(kv, 0.5, 2.5), clampN(bv, 0, 2.5), clampN(dtv, 1200, 600), clampN(dthv, 2.5, 0.5), clampN(exv, 80, 250)];
   }
   var seriesByLens = {
     all: { label: '全体', color: '#81d4fa', bg: 'rgba(129,212,250,.2)', data: vec(basic.avg_dmg_given, basic.avg_kills, basic.avg_bursts, basic.avg_dmg_taken, basic.avg_deaths, basic.avg_ex_dmg) },
-    win: { label: '勝利時', color: '#69f0ae', bg: 'rgba(105,240,174,.2)', data: vec(wm('平均与ダメージ').win_avg, wm('平均撃墜').win_avg, wm('平均覚醒回数').win_avg, wm('平均被ダメージ').win_avg, wm('平均被撃墜').win_avg, wm('平均EXダメージ').win_avg) },
-    loss: { label: '敗北時', color: '#ef5350', bg: 'rgba(239,83,80,.18)', data: vec(wm('平均与ダメージ').loss_avg, wm('平均撃墜').loss_avg, wm('平均覚醒回数').loss_avg, wm('平均被ダメージ').loss_avg, wm('平均被撃墜').loss_avg, wm('平均EXダメージ').loss_avg) },
+    win: { label: '勝利時', color: '#69f0ae', bg: 'rgba(105,240,174,.2)', data: vec(wmVal('平均与ダメージ'), wmVal('平均撃墜'), wmVal('平均覚醒回数'), wmVal('平均被ダメージ'), wmVal('平均被撃墜'), wmVal('平均EXダメージ')) },
+    loss: { label: '敗北時', color: '#ef5350', bg: 'rgba(239,83,80,.18)', data: vec(wmVal('平均与ダメージ'), wmVal('平均撃墜'), wmVal('平均覚醒回数'), wmVal('平均被ダメージ'), wmVal('平均被撃墜'), wmVal('平均EXダメージ')) },
   };
 
   // [ラベル, 全体値, 色関数]。勝敗時はwin_loss_patternの同名metricから値を引く
@@ -1416,8 +1417,7 @@ function BasicLensSection({ basic, pattern, lens }) {
   ];
   function valFor(label, allVal) {
     if (lens === 'all') return allVal;
-    var m = wm(label);
-    return lens === 'win' ? m.win_avg : m.loss_avg;
+    return wmVal(label);
   }
   var matchesLabel = lens === 'all' ? '試合数' : lens === 'win' ? '勝利数' : '敗北数';
   var matchesVal = lens === 'all' ? (basic.matches + '戦')
@@ -1583,8 +1583,8 @@ function FixedPartnerPanel({ fp, fpItems, lens }) {
       clampN(v('平均与ダメージ', stats.avg_dmg_given), 600, 1200),
       clampN(v('平均撃墜', stats.avg_kills), 0.5, 2.5),
       clampN(v('平均覚醒回数', stats.avg_bursts), 0, 2.5),
-      clampN(v('平均被ダメージ', stats.avg_dmg_taken), 600, 1200),
-      clampN(v('平均被撃墜', stats.avg_deaths), 0.5, 2.5),
+      clampN(v('平均被ダメージ', stats.avg_dmg_taken), 1200, 600),
+      clampN(v('平均被撃墜', stats.avg_deaths), 2.5, 0.5),
       clampN(v('平均EXダメージ', stats.avg_ex_dmg), 80, 250),
     ];
   }


### PR DESCRIPTION
## Summary
- レーダーチャートで被ダメージ・被撃墜の正規化が逆だった（高値=高スコアになっていた）のを修正
- `clampN`のmin/maxを反転し、低値=高スコア（外側=優秀）に修正
- BasicLensSectionの`wm()`がメトリクス未発見時に`{win_avg:0, loss_avg:0}`を返していた問題も修正。`null`を返す`wmVal()`に統一し、FixedPartnerPanelと同じパターンに

## 修正箇所
| コンポーネント | 修正内容 |
|---|---|
| BasicLensSection (総合タブ) | `vec`の被ダメ`(600,1200)`→`(1200,600)`, 被撃墜`(0.5,2.5)`→`(2.5,0.5)` + `wm()`→`wmVal()` |
| FixedPartnerPanel (固定相方) | `pVec`の被ダメ`(600,1200)`→`(1200,600)`, 被撃墜`(0.5,2.5)`→`(2.5,0.5)` |

## Test plan
- [ ] 総合タブ: レーダーで被ダメ・被撃墜が低いほど外側（良い評価）に表示される
- [ ] 総合タブ: 勝利/敗北レンズでメトリクス未発見時に`-`表示（0ではない）
- [ ] 固定相方: 同様にレーダーの被ダメ・被撃墜が正しい方向
- [ ] 両レーダーの軸順・範囲・反転が完全に統一されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpWa3cmYn17WNUwP3p1oZh