### PR TITLE
fix: topbarのコントロールを2段目に集約しスクロールで折りたたみ

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1886,6 +1886,23 @@ function Report({ data, userKey }) {
   var lens = lensRef[0], setLens = lensRef[1];
   var menuRef = useState(false);
   var menuOpen = menuRef[0], setMenuOpen = menuRef[1];
+  var topbarRef = useRef(null);
+
+  useEffect(function () {
+    var lastY = window.scrollY;
+    function onScroll() {
+      if (!topbarRef.current) return;
+      var y = window.scrollY;
+      if (y > lastY && y > 80) {
+        topbarRef.current.classList.add('scrolled-down');
+      } else if (y < lastY) {
+        topbarRef.current.classList.remove('scrolled-down');
+      }
+      lastY = y;
+    }
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return function () { window.removeEventListener('scroll', onScroll); };
+  }, []);
 
   var periods = data.periods || {};
   var allPeriods = customData ? Object.assign({}, periods, { custom: customData.periods.custom }) : periods;
@@ -1930,14 +1947,15 @@ function Report({ data, userKey }) {
   }
 
   return html`
-    <div class="topbar">
+    <div class="topbar" ref=${topbarRef}>
       <button class="hamburger" onClick=${function () { setMenuOpen(true); }}>☰</button>
       <span class="brand"><img src="logo.svg" alt="catalyzer" /></span>
-      <div class="spacer" />
-      <${MsSelector} entries=${msEntries} selected=${selectedMs} onSelect=${setSelectedMs} />
-      <${LensToggle} lens=${lens} onSelect=${setLens} />
-      <${PeriodSelector} periods=${allPeriods} selected=${selectedPeriod} onSelect=${setSelectedPeriod}
-        userKey=${userKey} onCustomReport=${handleCustomReport} />
+      <div class="controls-row">
+        <${PeriodSelector} periods=${allPeriods} selected=${selectedPeriod} onSelect=${setSelectedPeriod}
+          userKey=${userKey} onCustomReport=${handleCustomReport} />
+        <${MsSelector} entries=${msEntries} selected=${selectedMs} onSelect=${setSelectedMs} />
+        <${LensToggle} lens=${lens} onSelect=${setLens} />
+      </div>
     </div>
 
     <${HamburgerMenu} isOpen=${menuOpen} onClose=${function () { setMenuOpen(false); }}
@@ -1966,9 +1984,11 @@ function Skeleton() {
     <div class="topbar">
       <div class="skel" style=${{ width: '28px', height: '28px', borderRadius: '6px' }}></div>
       <span class="brand"><img src="logo.svg" alt="catalyzer" /></span>
-      <div class="skel skel-pill" style=${{ marginLeft: 'auto' }}></div>
-      <div class="skel skel-pill" style=${{ width: '160px' }}></div>
-      <div class="skel skel-pill"></div>
+      <div class="controls-row">
+        <div class="skel skel-pill"></div>
+        <div class="skel skel-pill" style=${{ width: '160px' }}></div>
+        <div class="skel skel-pill"></div>
+      </div>
     </div>
     <div class="kpi-grid">
       ${[0, 1, 2, 3, 4, 5].map(function () {

--- a/static/index.html
+++ b/static/index.html
@@ -80,7 +80,7 @@
     /* ===== Topbar ===== */
     .topbar {
       position: sticky; top: 0; z-index: 50;
-      display: flex; align-items: center; gap: 12px;
+      display: flex; flex-wrap: wrap; align-items: center; gap: 12px;
       padding: calc(28px + env(safe-area-inset-top)) 16px 12px; margin: -16px -16px 16px;
       background: rgba(13,22,32,.82);
       border-bottom: 1px solid var(--line);
@@ -91,9 +91,14 @@
       content: ''; position: absolute; inset: 0; z-index: -1;
       -webkit-backdrop-filter: blur(10px); backdrop-filter: blur(10px);
     }
-    .brand { font-size: 1.05em; font-weight: 800; color: var(--accent); white-space: nowrap; }
+    .brand { position: absolute; left: 50%; transform: translateX(-50%); font-size: 1.05em; font-weight: 800; color: var(--accent); white-space: nowrap; pointer-events: none; }
     .brand img { height: 24px; width: auto; display: block; }
-    .topbar .spacer { flex: 1; }
+    .controls-row {
+      display: flex; align-items: center; gap: 8px; flex-basis: 100%;
+      padding-top: 8px; max-height: 60px; overflow: hidden;
+      transition: max-height .3s ease, padding-top .3s ease, opacity .3s ease; opacity: 1;
+    }
+    .topbar.scrolled-down .controls-row { max-height: 0; padding-top: 0; opacity: 0; pointer-events: none; }
     /* ===== KPI cards ===== */
     .kpi-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 16px; }
     .kpi {
@@ -127,7 +132,7 @@
     .tabs {
       display: flex; gap: 6px; overflow-x: auto; -webkit-overflow-scrolling: touch;
       padding: 4px; margin-bottom: 14px; background: var(--panel); border: 1px solid var(--line);
-      border-radius: 14px; position: sticky; top: calc(80px + env(safe-area-inset-top)); z-index: 40;
+      border-radius: 14px; position: sticky; top: calc(68px + env(safe-area-inset-top)); z-index: 40;
     }
     .tab {
       flex: 0 0 auto; padding: 9px 16px; border: none; border-radius: 10px;
@@ -301,20 +306,14 @@
       .two-col { grid-template-columns: 1fr; }
       .card-grid { grid-template-columns: 1fr; }
       .kpi .kpi-value { font-size: 1.6em; }
-      .topbar { flex-wrap: wrap; }
-      .topbar > .spacer { order: 3; }
-      .topbar > .period-selector { order: 4; min-width: 0; }
       .period-dropdown { min-width: 0; }
-      .topbar::after { content: ''; order: 4; flex-basis: 100%; height: 0; }
-      .ms-topbar-wrap { order: 5; flex: 1 1 0%; min-width: 0; }
       .ms-topbar-trigger { max-width: 50vw; }
       .ms-topbar-dropdown { min-width: 0; left: 0; width: calc(100vw - 32px); }
-      .lens-toggle { order: 6; flex: 0 0 auto; }
-      .tabs { top: calc(126px + env(safe-area-inset-top)); }
     }
     @media (max-width: 600px) {
       .container { padding: 10px; padding-left: max(10px, env(safe-area-inset-left)); padding-right: max(10px, env(safe-area-inset-right)); padding-bottom: max(10px, env(safe-area-inset-bottom)); }
-      .topbar { margin: -10px -10px 16px; padding: calc(22px + env(safe-area-inset-top)) 10px 12px; }
+      .topbar { margin: -10px -10px 16px; padding: calc(22px + env(safe-area-inset-top)) 10px 10px; }
+      .controls-row { flex-wrap: wrap; }
       h1 { font-size: 1.4em; margin: 20px 0 8px; }
       .login-form { padding: 20px; }
       .report h1 { font-size: 1.2em; }

--- a/static/index.html
+++ b/static/index.html
@@ -95,10 +95,10 @@
     .brand img { height: 24px; width: auto; display: block; }
     .controls-row {
       display: flex; align-items: center; gap: 8px; flex-basis: 100%;
-      padding-top: 8px; max-height: 60px; overflow: hidden;
+      padding-top: 8px; max-height: 60px;
       transition: max-height .3s ease, padding-top .3s ease, opacity .3s ease; opacity: 1;
     }
-    .topbar.scrolled-down .controls-row { max-height: 0; padding-top: 0; opacity: 0; pointer-events: none; }
+    .topbar.scrolled-down .controls-row { max-height: 0; padding-top: 0; opacity: 0; overflow: hidden; pointer-events: none; }
     /* ===== KPI cards ===== */
     .kpi-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 16px; }
     .kpi {


### PR DESCRIPTION
## Summary
- topbar 1段目をハンバーガー + ブランドロゴ(中央配置)のみに簡素化
- 全データ・全機体・レンズ切替を2段目(controls-row)に集約
- スクロール↓で controls-row を折りたたみ、↑で展開するスマートヘッダー実装
- 720px breakpoint の flex-wrap/order 系CSSを削除（controls-rowで不要に）
- Skeleton topbar も同構造に統一

## Test plan
- [ ] topbar 1段目にロゴが中央表示されること
- [ ] 2段目に全データ・全機体・レンズ切替が並んでいること
- [ ] スクロール↓で2段目が折りたたまれること
- [ ] スクロール↑で2段目が再表示されること
- [ ] モバイル表示で横スクロールが発生しないこと
- [ ] スケルトン表示が正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)