### PR TITLE
fix: topbar/ドロップダウンのモバイル表示を改善

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -33,7 +33,13 @@ func StartServer() {
 
 	// Firestore初期化（FIRESTORE_DATABASE未設定時はスキップ）
 	if os.Getenv("FIRESTORE_DATABASE") != "" {
-		if err := firestore.Init(context.Background()); err != nil {
+		var err error
+		if p := os.Getenv("GOOGLE_CLOUD_PROJECT"); p != "" {
+			err = firestore.InitWithProjectID(context.Background(), p)
+		} else {
+			err = firestore.Init(context.Background())
+		}
+		if err != nil {
 			log.Printf("[WARN] Firestore initialization failed, continuing without Firestore: %v", err)
 		} else {
 			defer firestore.Close()

--- a/static/app.js
+++ b/static/app.js
@@ -1259,7 +1259,7 @@ function HamburgerMenu({ isOpen, onClose, shareData, onReAnalyze }) {
   return html`<div>
     <div class="menu-backdrop" onClick=${onClose} />
     <div class=${'menu-drawer' + (isOpen ? ' open' : '')}>
-      <div class="menu-header">catalyzer</div>
+      <div class="menu-header"><img src="logo.svg" alt="catalyzer" style="height:24px;width:auto;" /></div>
       <div class="menu-body">
         <button class="menu-item" onClick=${function () { onClose(); onReAnalyze(); }}>再分析</button>
         <div class="menu-divider" />

--- a/static/app.js
+++ b/static/app.js
@@ -377,10 +377,9 @@ function PeriodSelector({ periods, selected, onSelect, userKey, onCustomReport }
     return function () { document.body.style.overflow = ''; };
   }, [isOpen]);
 
-  var dropTop = 0;
-  if (isOpen && triggerRef.current) {
-    var rect = triggerRef.current.getBoundingClientRect();
-    dropTop = rect.bottom + 4;
+  var dropStyle = {};
+  if (isOpen && triggerRef.current && window.innerWidth <= 720) {
+    dropStyle.top = triggerRef.current.getBoundingClientRect().bottom + 4 + 'px';
   }
 
   var currentLabel = selected === 'custom'
@@ -428,7 +427,7 @@ function PeriodSelector({ periods, selected, onSelect, userKey, onCustomReport }
       ${currentLabel} <span class="period-arrow">${isOpen ? '\u25B2' : '\u25BC'}</span>
     </button>
     ${isOpen && html`<div class="period-backdrop" onClick=${function () { setIsOpen(false); }} />`}
-    ${isOpen && html`<div class="period-dropdown" style=${{ top: dropTop + 'px' }}>
+    ${isOpen && html`<div class="period-dropdown" style=${dropStyle}>
       <div class="period-dropdown-list">
         ${keys.map(function (k) {
           return html`<button class=${'period-dropdown-item' + (selected === k ? ' active' : '')}
@@ -1284,16 +1283,16 @@ function MsSelector({ entries, selected, onSelect }) {
   var label = selected ? '1機選択' : '全機体';
   var isSelected = !!selected;
   var triggerRef = useRef(null);
-  var dropTop = 0;
-  if (isOpen && triggerRef.current) {
-    var rect = triggerRef.current.getBoundingClientRect();
-    dropTop = rect.bottom + 4;
+  var dropStyle = {};
+  if (isOpen && triggerRef.current && window.innerWidth <= 720) {
+    dropStyle.top = triggerRef.current.getBoundingClientRect().bottom + 4 + 'px';
   }
   return html`<div class="ms-topbar-wrap" ref=${containerRef}>
     <button class=${'ms-topbar-trigger' + (isSelected ? ' selected' : '')} ref=${triggerRef} onClick=${function () { setIsOpen(!isOpen); }}>
       ${esc(label)} <span class="period-arrow">${isOpen ? '▲' : '▼'}</span>
     </button>
-    ${isOpen && html`<div class="ms-topbar-dropdown" style=${{ top: dropTop + 'px' }}>
+    ${isOpen && html`<div class="ms-topbar-backdrop" onClick=${function () { setIsOpen(false); }} />`}
+    ${isOpen && html`<div class="ms-topbar-dropdown" style=${dropStyle}>
       <button class=${'ms-topbar-item' + (!selected ? ' active' : '')}
         onClick=${function () { onSelect(null); setIsOpen(false); }}>全機体</button>
       ${entries.map(function (e) {

--- a/static/app.js
+++ b/static/app.js
@@ -1910,6 +1910,12 @@ function Report({ data, userKey }) {
         row.style.paddingTop = '0';
         row.style.overflow = 'hidden';
         row.style.pointerEvents = 'none';
+      } else {
+        row.style.maxHeight = '';
+        row.style.opacity = '';
+        row.style.paddingTop = '';
+        row.style.overflow = '';
+        row.style.pointerEvents = '';
       }
     }
     window.addEventListener('scroll', onScroll, { passive: true });

--- a/static/app.js
+++ b/static/app.js
@@ -356,6 +356,7 @@ function PeriodSelector({ periods, selected, onSelect, userKey, onCustomReport }
   var showTime = timeRef[0], setShowTime = timeRef[1];
 
   var containerRef = useRef(null);
+  var triggerRef = useRef(null);
 
   useEffect(function () {
     function handleClick(e) {
@@ -367,15 +368,20 @@ function PeriodSelector({ periods, selected, onSelect, userKey, onCustomReport }
     return function () { document.removeEventListener('mousedown', handleClick); };
   }, []);
 
-  // スマホでドロップダウン表示中はbodyスクロールを止める
   useEffect(function () {
-    if (isOpen && window.innerWidth <= 600) {
+    if (isOpen && window.innerWidth <= 720) {
       document.body.style.overflow = 'hidden';
     } else {
       document.body.style.overflow = '';
     }
     return function () { document.body.style.overflow = ''; };
   }, [isOpen]);
+
+  var dropTop = 0;
+  if (isOpen && triggerRef.current) {
+    var rect = triggerRef.current.getBoundingClientRect();
+    dropTop = rect.bottom + 4;
+  }
 
   var currentLabel = selected === 'custom'
     ? (periods.custom ? periods.custom.label : '日付指定')
@@ -418,11 +424,11 @@ function PeriodSelector({ periods, selected, onSelect, userKey, onCustomReport }
   }
 
   return html`<div class="period-selector" ref=${containerRef}>
-    <button class="period-trigger" onClick=${function () { setIsOpen(!isOpen); }}>
+    <button class="period-trigger" ref=${triggerRef} onClick=${function () { setIsOpen(!isOpen); }}>
       ${currentLabel} <span class="period-arrow">${isOpen ? '\u25B2' : '\u25BC'}</span>
     </button>
     ${isOpen && html`<div class="period-backdrop" onClick=${function () { setIsOpen(false); }} />`}
-    ${isOpen && html`<div class="period-dropdown">
+    ${isOpen && html`<div class="period-dropdown" style=${{ top: dropTop + 'px' }}>
       <div class="period-dropdown-list">
         ${keys.map(function (k) {
           return html`<button class=${'period-dropdown-item' + (selected === k ? ' active' : '')}
@@ -1275,12 +1281,19 @@ function MsSelector({ entries, selected, onSelect }) {
     document.addEventListener('click', handleClick, true);
     return function () { document.removeEventListener('click', handleClick, true); };
   }, [isOpen]);
-  var label = selected || '全機体';
+  var label = selected ? '1機選択' : '全機体';
+  var isSelected = !!selected;
+  var triggerRef = useRef(null);
+  var dropTop = 0;
+  if (isOpen && triggerRef.current) {
+    var rect = triggerRef.current.getBoundingClientRect();
+    dropTop = rect.bottom + 4;
+  }
   return html`<div class="ms-topbar-wrap" ref=${containerRef}>
-    <button class="ms-topbar-trigger" onClick=${function () { setIsOpen(!isOpen); }}>
+    <button class=${'ms-topbar-trigger' + (isSelected ? ' selected' : '')} ref=${triggerRef} onClick=${function () { setIsOpen(!isOpen); }}>
       ${esc(label)} <span class="period-arrow">${isOpen ? '▲' : '▼'}</span>
     </button>
-    ${isOpen && html`<div class="ms-topbar-dropdown">
+    ${isOpen && html`<div class="ms-topbar-dropdown" style=${{ top: dropTop + 'px' }}>
       <button class=${'ms-topbar-item' + (!selected ? ' active' : '')}
         onClick=${function () { onSelect(null); setIsOpen(false); }}>全機体</button>
       ${entries.map(function (e) {
@@ -1956,17 +1969,16 @@ function Report({ data, userKey }) {
         <${MsSelector} entries=${msEntries} selected=${selectedMs} onSelect=${setSelectedMs} />
         <${LensToggle} lens=${lens} onSelect=${setLens} />
       </div>
+      <div class="tabs">${TAB_DEFS.map(function (t) {
+        return html`<button class=${'tab' + (activeTab === t[0] ? ' active' : '')}
+          onClick=${function () { setActiveTab(t[0]); }}>${t[1]}</button>`;
+      })}</div>
     </div>
 
     <${HamburgerMenu} isOpen=${menuOpen} onClose=${function () { setMenuOpen(false); }}
       shareData=${shareData} onReAnalyze=${reAnalyze} />
 
     <${KpiGrid} stats=${effectivePd.basic_stats} />
-
-    <div class="tabs">${TAB_DEFS.map(function (t) {
-      return html`<button class=${'tab' + (activeTab === t[0] ? ' active' : '')}
-        onClick=${function () { setActiveTab(t[0]); }}>${t[1]}</button>`;
-    })}</div>
 
     ${pane}
 
@@ -1977,26 +1989,32 @@ function Report({ data, userKey }) {
 
 // ログイン成功後、データ到着までのダッシュボード骨組み表示
 function Skeleton() {
+  var menuRef = useState(false);
+  var menuOpen = menuRef[0], setMenuOpen = menuRef[1];
   function bar(w, h, mb) {
     return html`<div class="skel" style=${{ width: w, height: h + 'px', marginBottom: (mb || 0) + 'px' }}></div>`;
   }
   return html`
     <div class="topbar">
-      <div class="skel" style=${{ width: '28px', height: '28px', borderRadius: '6px' }}></div>
+      <button class="hamburger" onClick=${function () { setMenuOpen(true); }}>☰</button>
       <span class="brand"><img src="logo.svg" alt="catalyzer" /></span>
-      <div class="controls-row">
-        <div class="skel skel-pill"></div>
-        <div class="skel skel-pill" style=${{ width: '160px' }}></div>
-        <div class="skel skel-pill"></div>
+      <div class="controls-row" style=${{ opacity: 0.5, pointerEvents: 'none' }}>
+        <button class="period-trigger" disabled>全データ <span class="period-arrow">▼</span></button>
+        <button class="ms-topbar-trigger" disabled>全機体 <span class="period-arrow">▼</span></button>
+        <${LensToggle} lens=${'all'} onSelect=${function () {}} />
+      </div>
+      <div class="tabs" style=${{ opacity: 0.5, pointerEvents: 'none' }}>
+        ${TAB_DEFS.map(function (t) {
+          return html`<button class=${'tab' + (t[0] === 'overview' ? ' active' : '')} disabled>${t[1]}</button>`;
+        })}
       </div>
     </div>
+    <${HamburgerMenu} isOpen=${menuOpen} onClose=${function () { setMenuOpen(false); }}
+      shareData=${null} onReAnalyze=${function () {}} />
     <div class="kpi-grid">
       ${[0, 1, 2, 3, 4, 5].map(function () {
         return html`<div class="kpi">${bar('50%', 12, 12)}${bar('70%', 28)}</div>`;
       })}
-    </div>
-    <div class="tabs">
-      ${TAB_DEFS.map(function (t) { return html`<div class="skel" style=${{ width: '60px', height: '32px', borderRadius: '10px' }}></div>`; })}
     </div>
     <div class="panel">
       ${bar('30%', 16, 14)}${bar('100%', 220)}

--- a/static/app.js
+++ b/static/app.js
@@ -1901,16 +1901,16 @@ function Report({ data, userKey }) {
   var topbarRef = useRef(null);
 
   useEffect(function () {
-    var lastY = window.scrollY;
+    var row = topbarRef.current && topbarRef.current.querySelector('.controls-row');
+    if (!row) return;
     function onScroll() {
-      if (!topbarRef.current) return;
-      var y = window.scrollY;
-      if (y > lastY && y > 80) {
-        topbarRef.current.classList.add('scrolled-down');
-      } else if (y < lastY) {
-        topbarRef.current.classList.remove('scrolled-down');
+      if (window.scrollY > 50) {
+        row.style.maxHeight = '0';
+        row.style.opacity = '0';
+        row.style.paddingTop = '0';
+        row.style.overflow = 'hidden';
+        row.style.pointerEvents = 'none';
       }
-      lastY = y;
     }
     window.addEventListener('scroll', onScroll, { passive: true });
     return function () { window.removeEventListener('scroll', onScroll); };

--- a/static/index.html
+++ b/static/index.html
@@ -277,6 +277,7 @@
     .ms-topbar-trigger { display: flex; align-items: center; gap: 8px; padding: 9px 16px; border: 1px solid var(--line); border-radius: 999px; background: var(--panel); color: var(--text); font-size: 0.85em; cursor: pointer; transition: all 0.2s; width: auto; max-width: 180px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .ms-topbar-trigger:hover { border-color: var(--accent); }
     .ms-topbar-trigger.selected { border-color: var(--accent); color: var(--accent); }
+    .ms-topbar-backdrop { display: none; }
     .ms-topbar-dropdown { position: absolute; top: 100%; left: 0; margin-top: 4px; background: var(--panel); border: 1px solid var(--line); border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.4); z-index: 100; min-width: 240px; max-height: 60vh; overflow-y: auto; }
     .ms-topbar-item { display: block; width: 100%; padding: 10px 16px; border: none; background: none; color: var(--text); font-size: 0.9em; cursor: pointer; text-align: left; transition: all 0.15s; }
     .ms-topbar-item:hover { background: var(--panel-2); }
@@ -310,6 +311,7 @@
       .period-dropdown { min-width: 0; position: fixed; left: 0; right: 0; width: 100%; border-radius: 0 0 8px 8px; margin: 0; }
       .period-backdrop { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99; }
       .ms-topbar-trigger { max-width: 50vw; }
+      .ms-topbar-backdrop { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99; }
       .ms-topbar-dropdown { min-width: 0; position: fixed; left: 0; right: 0; width: 100%; border-radius: 0 0 8px 8px; margin: 0; }
     }
     @media (max-width: 600px) {

--- a/static/index.html
+++ b/static/index.html
@@ -95,10 +95,8 @@
     .topbar .brand img { height: 24px; width: auto; display: block; }
     .controls-row {
       display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-basis: 100%;
-      padding-top: 4px; max-height: 60px;
-      transition: max-height .3s ease, padding-top .3s ease, opacity .3s ease; opacity: 1;
+      padding-top: 4px; max-height: 60px; opacity: 1;
     }
-    .topbar.scrolled-down .controls-row { max-height: 0; padding-top: 0; opacity: 0; overflow: hidden; pointer-events: none; }
     /* ===== KPI cards ===== */
     .kpi-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 16px; }
     .kpi {

--- a/static/index.html
+++ b/static/index.html
@@ -75,13 +75,13 @@
       background-size: 400% 100%; border-radius: 8px; animation: skel-shimmer 1.4s ease infinite;
     }
     @keyframes skel-shimmer { 0% { background-position: 100% 0; } 100% { background-position: -100% 0; } }
-    .skel-pill { width: 120px; height: 38px; border-radius: 999px; }
+    .skel-pill { flex: 1; min-width: 0; height: 38px; border-radius: 999px; }
 
     /* ===== Topbar ===== */
     .topbar {
       position: sticky; top: 0; z-index: 50;
-      display: flex; flex-wrap: wrap; align-items: center; gap: 12px;
-      padding: calc(28px + env(safe-area-inset-top)) 16px 12px; margin: -16px -16px 16px;
+      display: flex; flex-wrap: wrap; align-items: center; gap: 8px 12px;
+      padding: calc(16px + env(safe-area-inset-top)) 16px 6px; margin: -16px -16px 16px;
       background: rgba(13,22,32,.82);
       border-bottom: 1px solid var(--line);
     }
@@ -91,11 +91,11 @@
       content: ''; position: absolute; inset: 0; z-index: -1;
       -webkit-backdrop-filter: blur(10px); backdrop-filter: blur(10px);
     }
-    .brand { position: absolute; left: 50%; transform: translateX(-50%); font-size: 1.05em; font-weight: 800; color: var(--accent); white-space: nowrap; pointer-events: none; }
-    .brand img { height: 24px; width: auto; display: block; }
+    .topbar .brand { position: absolute; top: calc(env(safe-area-inset-top) + 18px); left: 50%; transform: translateX(-50%); font-size: 1.05em; font-weight: 800; color: var(--accent); white-space: nowrap; pointer-events: none; }
+    .topbar .brand img { height: 24px; width: auto; display: block; }
     .controls-row {
-      display: flex; align-items: center; gap: 8px; flex-basis: 100%;
-      padding-top: 8px; max-height: 60px;
+      display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-basis: 100%;
+      padding-top: 4px; max-height: 60px;
       transition: max-height .3s ease, padding-top .3s ease, opacity .3s ease; opacity: 1;
     }
     .topbar.scrolled-down .controls-row { max-height: 0; padding-top: 0; opacity: 0; overflow: hidden; pointer-events: none; }
@@ -131,8 +131,8 @@
     /* ===== Tabs ===== */
     .tabs {
       display: flex; gap: 6px; overflow-x: auto; -webkit-overflow-scrolling: touch;
-      padding: 4px; margin-bottom: 14px; background: var(--panel); border: 1px solid var(--line);
-      border-radius: 14px; position: sticky; top: calc(68px + env(safe-area-inset-top)); z-index: 40;
+      padding: 4px; background: var(--panel); border: 1px solid var(--line);
+      border-radius: 14px; flex-basis: 100%;
     }
     .tab {
       flex: 0 0 auto; padding: 9px 16px; border: none; border-radius: 10px;
@@ -221,8 +221,8 @@
     .period-arrow { font-size: 0.7em; color: var(--muted); }
     .period-dropdown { position: absolute; top: 100%; right: 0; margin-top: 4px; background: var(--panel); border: 1px solid var(--line); border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.4); z-index: 100; min-width: 240px; overflow: hidden; }
     .period-dropdown-list { display: flex; flex-direction: column; }
-    .period-dropdown-item { padding: 10px 16px; border: none; background: none; color: #aaa; font-size: 0.9em; cursor: pointer; text-align: left; transition: all 0.15s; width: 100%; }
-    .period-dropdown-item:hover { background: #162029; color: var(--text); }
+    .period-dropdown-item { padding: 10px 16px; border: none; background: none; color: var(--text); font-size: 0.9em; cursor: pointer; text-align: left; transition: all 0.15s; width: 100%; }
+    .period-dropdown-item:hover { background: var(--panel-2); }
     .period-dropdown-item.active { color: var(--accent); background: var(--bg); font-weight: bold; }
     .period-dropdown-custom { border-top: 1px solid var(--line); }
     .period-custom { padding: 12px 16px; border-top: 1px solid var(--line); display: flex; flex-direction: column; gap: 10px; }
@@ -274,8 +274,9 @@
 
     /* ===== Topbar MS selector (custom dropdown) ===== */
     .ms-topbar-wrap { position: relative; }
-    .ms-topbar-trigger { display: flex; align-items: center; gap: 8px; padding: 7px 14px; border: 1px solid var(--line); border-radius: 999px; background: var(--panel); color: var(--text); font-size: 0.85em; cursor: pointer; transition: all 0.2s; width: auto; max-width: 180px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .ms-topbar-trigger { display: flex; align-items: center; gap: 8px; padding: 9px 16px; border: 1px solid var(--line); border-radius: 999px; background: var(--panel); color: var(--text); font-size: 0.85em; cursor: pointer; transition: all 0.2s; width: auto; max-width: 180px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .ms-topbar-trigger:hover { border-color: var(--accent); }
+    .ms-topbar-trigger.selected { border-color: var(--accent); color: var(--accent); }
     .ms-topbar-dropdown { position: absolute; top: 100%; left: 0; margin-top: 4px; background: var(--panel); border: 1px solid var(--line); border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.4); z-index: 100; min-width: 240px; max-height: 60vh; overflow-y: auto; }
     .ms-topbar-item { display: block; width: 100%; padding: 10px 16px; border: none; background: none; color: var(--text); font-size: 0.9em; cursor: pointer; text-align: left; transition: all 0.15s; }
     .ms-topbar-item:hover { background: var(--panel-2); }
@@ -283,7 +284,7 @@
 
     /* ===== Lens toggle ===== */
     .lens-toggle { display: inline-flex; border: 1px solid var(--line); border-radius: 999px; overflow: hidden; }
-    .lens-btn { padding: 7px 12px; border: none; background: none; color: var(--muted); font-size: 0.82em; font-weight: 600; cursor: pointer; transition: all 0.15s; width: auto; white-space: nowrap; }
+    .lens-btn { padding: 9px 16px; border: none; background: none; color: var(--muted); font-size: 0.85em; font-weight: 600; cursor: pointer; transition: all 0.15s; width: auto; white-space: nowrap; }
     .lens-btn:hover { color: var(--text); }
     .lens-btn.active { background: var(--accent); color: #062536; }
 
@@ -306,13 +307,15 @@
       .two-col { grid-template-columns: 1fr; }
       .card-grid { grid-template-columns: 1fr; }
       .kpi .kpi-value { font-size: 1.6em; }
-      .period-dropdown { min-width: 0; }
+      .period-dropdown { min-width: 0; position: fixed; left: 0; right: 0; width: 100%; border-radius: 0 0 8px 8px; margin: 0; }
+      .period-backdrop { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99; }
       .ms-topbar-trigger { max-width: 50vw; }
-      .ms-topbar-dropdown { min-width: 0; left: 0; width: calc(100vw - 32px); }
+      .ms-topbar-dropdown { min-width: 0; position: fixed; left: 0; right: 0; width: 100%; border-radius: 0 0 8px 8px; margin: 0; }
     }
     @media (max-width: 600px) {
       .container { padding: 10px; padding-left: max(10px, env(safe-area-inset-left)); padding-right: max(10px, env(safe-area-inset-right)); padding-bottom: max(10px, env(safe-area-inset-bottom)); }
-      .topbar { margin: -10px -10px 16px; padding: calc(22px + env(safe-area-inset-top)) 10px 10px; }
+      .topbar { margin: -10px -10px 16px; padding: calc(12px + env(safe-area-inset-top)) 10px 6px; }
+      .topbar .brand { top: calc(env(safe-area-inset-top) + 14px); }
       .controls-row { flex-wrap: wrap; }
       h1 { font-size: 1.4em; margin: 20px 0 8px; }
       .login-form { padding: 20px; }
@@ -322,8 +325,9 @@
       .report blockquote { padding: 8px 10px; font-size: 0.85em; }
       .chart-container { height: 240px; }
       .period-backdrop { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99; }
-      .period-dropdown { position: fixed; bottom: 0; top: auto; left: 0; right: 0; min-width: 0; width: 100%; max-height: 85vh; overflow: visible; overflow-y: auto; border-radius: 12px 12px 0 0; z-index: 100; margin-top: 0; }
-      .ms-topbar-dropdown { width: calc(100vw - 20px); }
+      .period-dropdown { position: fixed; left: 0; right: 0; min-width: 0; width: 100%; max-height: 70vh; overflow: visible; overflow-y: auto; border-radius: 0 0 8px 8px; z-index: 100; margin-top: 0; }
+      .ms-topbar-dropdown { max-height: 70vh; }
+      .period-dropdown-item { padding: 14px 16px; font-size: 1em; }
       .ms-topbar-item { padding: 14px 16px; font-size: 1em; }
       .panel-select-item { padding: 14px 16px; font-size: 1em; }
       .period-custom-range { flex-direction: column; }


### PR DESCRIPTION
## Summary
- ログイン画面のロゴスタイル競合を修正(`.brand` → `.topbar .brand`)
- プルダウン/トグルのサイズ統一、controls-rowをspace-betweenで均等配置
- 両ドロップダウンをposition:fixedで画面幅展開に統一
- 機体選択時の表示を「1機選択」に変更(複数選択拡張を見据えた設計)
- タブをtopbar内に移動し常時固定表示
- スケルトンのメニュー/タブ/プルダウンを本物コンポーネントに変更(操作は無効)
- `GOOGLE_CLOUD_PROJECT`環境変数によるFirestore初期化をサポート

## Test plan
- [ ] スマホ表示でtopbar/プルダウン/タブのレイアウト確認
- [ ] 全データ/全機体プルダウンが画面幅で開くこと
- [ ] 機体選択時に「1機選択」と表示されること
- [ ] スクロールでcontrols-rowが折りたたまれ、タブは残ること
- [ ] ログイン画面のロゴが正常に表示されること
- [ ] スケルトン表示で☰メニューが開けること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6WoSemCevjW93ytejrzm