### PR TITLE
fix: モバイルでcontrols-rowが3行に折り返される問題を修正

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -316,7 +316,9 @@
       .container { padding: 10px; padding-left: max(10px, env(safe-area-inset-left)); padding-right: max(10px, env(safe-area-inset-right)); padding-bottom: max(10px, env(safe-area-inset-bottom)); }
       .topbar { margin: -10px -10px 16px; padding: calc(12px + env(safe-area-inset-top)) 10px 6px; }
       .topbar .brand { top: calc(env(safe-area-inset-top) + 14px); }
-      .controls-row { flex-wrap: wrap; }
+      .period-trigger { padding: 7px 12px; font-size: 0.82em; }
+      .ms-topbar-trigger { padding: 7px 12px; font-size: 0.82em; }
+      .lens-btn { padding: 7px 10px; font-size: 0.8em; }
       h1 { font-size: 1.4em; margin: 20px 0 8px; }
       .login-form { padding: 20px; }
       .report h1 { font-size: 1.2em; }


### PR DESCRIPTION
## Summary
- iPhone 16 (393px) でtopbarの2段目(controls-row)が3行に折り返され、レンズトグル(全体/勝利時/敗北時)が3行目にずれ、全機体ボタンが右端に寄る問題を修正
- `flex-wrap: wrap` を削除し、600px以下でボタンのパディングとフォントサイズを縮小して3要素を1行に収める

## Test plan
- [ ] iPhone 16 (393px) 実機またはDevToolsで3要素が1行に収まることを確認
- [ ] iPhone SE (375px) でも崩れないことを確認
- [ ] デスクトップ表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6WoSemCevjW93ytejrzm