### PR TITLE
feat: 試合データ配信エンドポイントとIndexedDBキャッシュ基盤

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 クライアントは GET /status/{id} でポーリング後、GET /result/{id} で結果取得
 ```
 
-**主要エンドポイント:** `POST /analyze`, `GET /status/{id}`, `GET /result/{id}`, `GET /result/{id}/period`, `GET /period`, `GET /health`, `GET /`（静的UI）
+**主要エンドポイント:** `POST /analyze`, `GET /status/{id}`, `GET /result/{id}`, `GET /result/{id}/period`, `GET /period`, `GET /matches`, `GET /health`, `GET /`（静的UI）
 
 ## コード構成
 
@@ -82,7 +82,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 - `internal/gradelist/` — グレードリストの読み込み・未知URL検出（`LoadGradeList`, `BuildGradeMap`, `CheckUnknownGrades`）
 - `internal/scraper/` — Collyベースのスクレイパー（`scraper.go`）+ バンダイナムコID認証（`login.go`）
 - `internal/firestore/` — Firestoreクライアント初期化（`client.go`）+ matches/tag_partnersの読み書き（タイムラインはmatches内に埋め込み）
-- `internal/pipeline/` — 分析パイプライン（`Job`型、ジョブストア、`Run`関数、JSON生成）
+- `internal/pipeline/` — 分析パイプライン（`Job`型、ジョブストア、`Run`関数、JSON生成、試合データ配信）
 - `internal/server/` — HTTPハンドラ（`server.go`）+ IPベースレート制限（`ratelimit.go`）+ Basic認証（`basicauth.go`）+ 403一時ブロック（`block403.go`）
 - `scripts/analyze.py` — Python分析: 勝率、与被ダメ比、固定相方検出（K/D・EXダメ・覚醒回数・勝敗パターン付き）、JSON構造化レポート生成
 - `static/index.html` — SPA フロントエンド（ダークテーマ、レスポンシブ対応、カスタムドロップダウン）

--- a/internal/mslist/mslist.go
+++ b/internal/mslist/mslist.go
@@ -10,8 +10,8 @@ import (
 	"github.com/yuki9431/catalyzer/internal/model"
 )
 
-// stripQuery はURLからクエリパラメータを除去する
-func stripQuery(rawURL string) string {
+// StripQuery はURLからクエリパラメータを除去する
+func StripQuery(rawURL string) string {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return rawURL
@@ -24,7 +24,18 @@ func stripQuery(rawURL string) string {
 func BuildMSNameMap(msList []model.MSInfo) map[string]string {
 	m := make(map[string]string, len(msList))
 	for _, ms := range msList {
-		m[stripQuery(ms.ImageURL)] = ms.Name
+		m[StripQuery(ms.ImageURL)] = ms.Name
+	}
+	return m
+}
+
+// BuildMSCostMap はMSInfoリストから画像URL→コストのマップを生成する（クエリパラメータを除去してマッチ）
+func BuildMSCostMap(msList []model.MSInfo) map[string]int {
+	m := make(map[string]int, len(msList))
+	for _, ms := range msList {
+		if ms.Cost > 0 {
+			m[StripQuery(ms.ImageURL)] = ms.Cost
+		}
 	}
 	return m
 }
@@ -32,7 +43,7 @@ func BuildMSNameMap(msList []model.MSInfo) map[string]string {
 // FillMsNames はDatedScoresの各スコアにMsNameをセットする（クエリパラメータを除去してマッチ）
 func FillMsNames(ds model.DatedScores, msMap map[string]string) {
 	for i := range ds {
-		if name, ok := msMap[stripQuery(ds[i].PlayerScore.MsImageURL)]; ok {
+		if name, ok := msMap[StripQuery(ds[i].PlayerScore.MsImageURL)]; ok {
 			ds[i].PlayerScore.MsName = name
 		}
 	}
@@ -68,7 +79,7 @@ func MergeMSList(scraped, existing []model.MSInfo) []model.MSInfo {
 	seen := make(map[string]bool)
 	var merged []model.MSInfo
 	for _, ms := range scraped {
-		key := stripQuery(ms.ImageURL)
+		key := StripQuery(ms.ImageURL)
 		if !seen[key] {
 			seen[key] = true
 			ms.ImageURL = key
@@ -76,7 +87,7 @@ func MergeMSList(scraped, existing []model.MSInfo) []model.MSInfo {
 		}
 	}
 	for _, ms := range existing {
-		key := stripQuery(ms.ImageURL)
+		key := StripQuery(ms.ImageURL)
 		if !seen[key] {
 			seen[key] = true
 			ms.ImageURL = key

--- a/internal/pipeline/matchdata.go
+++ b/internal/pipeline/matchdata.go
@@ -1,0 +1,115 @@
+package pipeline
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	fs "github.com/yuki9431/catalyzer/internal/firestore"
+	"github.com/yuki9431/catalyzer/internal/model"
+	"github.com/yuki9431/catalyzer/internal/mslist"
+)
+
+// MatchData はフロントエンド向けの試合データ（プレイヤー視点）
+type MatchData struct {
+	Date         string `json:"date"`
+	MS           string `json:"ms"`
+	MSCost       int    `json:"ms_cost,omitempty"`
+	PartnerMS    string `json:"partner_ms"`
+	PartnerCost  int    `json:"partner_cost,omitempty"`
+	Opponent1MS  string `json:"opponent1_ms"`
+	Opponent1Cost int   `json:"opponent1_cost,omitempty"`
+	Opponent2MS  string `json:"opponent2_ms"`
+	Opponent2Cost int   `json:"opponent2_cost,omitempty"`
+	Win          bool   `json:"win"`
+	Score        int    `json:"score"`
+	Kills        int    `json:"kills"`
+	Deaths       int    `json:"deaths"`
+	DmgGiven     int    `json:"dmg_given"`
+	DmgTaken     int    `json:"dmg_taken"`
+	ExDmg        int    `json:"ex_dmg"`
+	GameEndSec   float64 `json:"game_end_sec,omitempty"`
+}
+
+// BuildMatchData はDatedScoresをフロントエンド向けの試合データに変換する。
+// costsMap は画像URL→コストのマッピング。afterが非ゼロの場合、その日時より後の試合のみ返す。
+func BuildMatchData(ds model.DatedScores, costsMap map[string]int, after time.Time) []MatchData {
+	groups := make(map[string][]model.DatedScore)
+	for _, d := range ds {
+		if !after.IsZero() && !d.Datetime.After(after) {
+			continue
+		}
+		key := d.Datetime.Format(model.MatchKeyFormat)
+		groups[key] = append(groups[key], d)
+	}
+
+	keys := make([]string, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	matches := make([]MatchData, 0, len(keys))
+	for _, key := range keys {
+		entries := groups[key]
+		if len(entries) != 4 {
+			continue
+		}
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].PlayerNo < entries[j].PlayerNo
+		})
+
+		me := entries[0].PlayerScore    // PlayerNo 1
+		partner := entries[1].PlayerScore // PlayerNo 2
+		opp1 := entries[2].PlayerScore   // PlayerNo 3
+		opp2 := entries[3].PlayerScore   // PlayerNo 4
+
+		var gameEndSec float64
+		for _, e := range entries {
+			if e.MatchTimeline != nil {
+				gameEndSec = e.MatchTimeline.GameEndSec
+				break
+			}
+		}
+
+		matches = append(matches, MatchData{
+			Date:          entries[0].Datetime.Format("2006-01-02 15:04"),
+			MS:            me.MsName,
+			MSCost:        costsMap[mslist.StripQuery(me.MsImageURL)],
+			PartnerMS:     partner.MsName,
+			PartnerCost:   costsMap[mslist.StripQuery(partner.MsImageURL)],
+			Opponent1MS:   opp1.MsName,
+			Opponent1Cost: costsMap[mslist.StripQuery(opp1.MsImageURL)],
+			Opponent2MS:   opp2.MsName,
+			Opponent2Cost: costsMap[mslist.StripQuery(opp2.MsImageURL)],
+			Win:           me.Win,
+			Score:         me.Score,
+			Kills:         me.Kills,
+			Deaths:        me.Deaths,
+			DmgGiven:      me.GiveDamage,
+			DmgTaken:      me.ReceiveDamage,
+			ExDmg:         me.ExDamage,
+			GameEndSec:    gameEndSec,
+		})
+	}
+
+	return matches
+}
+
+// GetMatchData はFirestoreからscoresを読み取り、フロントエンド向けの試合データを返す。
+func GetMatchData(userKey string, after time.Time) ([]MatchData, error) {
+	scores, err := fs.LoadScores(userKey)
+	if err != nil {
+		return nil, fmt.Errorf("load scores: %w", err)
+	}
+
+	msList, err := mslist.LoadMSList(DefaultMSListPath)
+	if err != nil {
+		msList = nil
+	}
+	msMap := mslist.BuildMSNameMap(msList)
+	mslist.FillMsNames(scores, msMap)
+
+	costsMap := mslist.BuildMSCostMap(msList)
+	return BuildMatchData(scores, costsMap, after), nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -189,6 +189,11 @@ func StartServer() {
 		handlePeriod(w, r)
 	})
 
+	// GET /matches?user_key=...&after=... → 試合データ配信（IndexedDBキャッシュ用）
+	http.HandleFunc("/matches", func(w http.ResponseWriter, r *http.Request) {
+		handleMatches(w, r)
+	})
+
 	// 静的ファイル（フロントエンド）
 	fs := http.FileServer(http.Dir("static"))
 	http.Handle("/", fs)
@@ -300,6 +305,37 @@ func handlePeriod(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sendRawReport(w, http.StatusOK, report, "", userKey, false)
+}
+
+func handleMatches(w http.ResponseWriter, r *http.Request) {
+	userKey := r.URL.Query().Get("user_key")
+	if userKey == "" {
+		sendJSON(w, http.StatusBadRequest, map[string]string{"error": "user_key parameter is required"})
+		return
+	}
+
+	var after time.Time
+	if afterStr := r.URL.Query().Get("after"); afterStr != "" {
+		const layout = "2006-01-02 15:04"
+		var err error
+		after, err = time.Parse(layout, afterStr)
+		if err != nil {
+			sendJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid after datetime format (expected: YYYY-MM-DD HH:MM)"})
+			return
+		}
+	}
+
+	matches, err := pipeline.GetMatchData(userKey, after)
+	if err != nil {
+		log.Printf("[ERROR] Failed to get match data: %v", err)
+		sendJSON(w, http.StatusInternalServerError, map[string]string{"error": "試合データの取得に失敗しました"})
+		return
+	}
+
+	sendJSON(w, http.StatusOK, map[string]interface{}{
+		"matches": matches,
+		"total":   len(matches),
+	})
 }
 
 // securityHeaders は全レスポンスにセキュリティヘッダーを付与する

--- a/static/app.js
+++ b/static/app.js
@@ -11,6 +11,94 @@ var STATUS_MESSAGES = {
 
 var PERIOD_KEYS = ['all', '90d', '60d', '30d', '14d', '7d', '3d', '1d'];
 
+// --- IndexedDB Match Cache ---
+var MATCH_DB_NAME = 'catalyzer';
+var MATCH_DB_VERSION = 1;
+var MATCH_STORE = 'matches';
+
+function openMatchDB() {
+  return new Promise(function (resolve, reject) {
+    var req = indexedDB.open(MATCH_DB_NAME, MATCH_DB_VERSION);
+    req.onupgradeneeded = function (e) {
+      var db = e.target.result;
+      if (!db.objectStoreNames.contains(MATCH_STORE)) {
+        var store = db.createObjectStore(MATCH_STORE, { keyPath: 'id' });
+        store.createIndex('userKey', 'user_key', { unique: false });
+        store.createIndex('date', 'date', { unique: false });
+        store.createIndex('ms', 'ms', { unique: false });
+        store.createIndex('userKey_date', ['user_key', 'date'], { unique: false });
+      }
+    };
+    req.onsuccess = function (e) { resolve(e.target.result); };
+    req.onerror = function (e) { reject(e.target.error); };
+  });
+}
+
+function saveMatchesToDB(userKey, matches) {
+  return openMatchDB().then(function (db) {
+    return new Promise(function (resolve, reject) {
+      var tx = db.transaction(MATCH_STORE, 'readwrite');
+      var store = tx.objectStore(MATCH_STORE);
+      for (var i = 0; i < matches.length; i++) {
+        var m = Object.assign({}, matches[i], {
+          id: userKey + '_' + matches[i].date,
+          user_key: userKey
+        });
+        store.put(m);
+      }
+      tx.oncomplete = function () { resolve(); };
+      tx.onerror = function (e) { reject(e.target.error); };
+    });
+  });
+}
+
+function loadMatchesFromDB(userKey) {
+  return openMatchDB().then(function (db) {
+    return new Promise(function (resolve, reject) {
+      var tx = db.transaction(MATCH_STORE, 'readonly');
+      var store = tx.objectStore(MATCH_STORE);
+      var index = store.index('userKey');
+      var req = index.getAll(userKey);
+      req.onsuccess = function (e) { resolve(e.target.result || []); };
+      req.onerror = function (e) { reject(e.target.error); };
+    });
+  });
+}
+
+function getLatestMatchDate(userKey) {
+  return openMatchDB().then(function (db) {
+    return new Promise(function (resolve, reject) {
+      var tx = db.transaction(MATCH_STORE, 'readonly');
+      var store = tx.objectStore(MATCH_STORE);
+      var index = store.index('userKey_date');
+      var range = IDBKeyRange.bound([userKey, ''], [userKey, '￿']);
+      var req = index.openCursor(range, 'prev');
+      req.onsuccess = function (e) {
+        var cursor = e.target.result;
+        resolve(cursor ? cursor.value.date : null);
+      };
+      req.onerror = function (e) { reject(e.target.error); };
+    });
+  });
+}
+
+function fetchAndCacheMatches(userKey) {
+  getLatestMatchDate(userKey).then(function (latestDate) {
+    var url = '/matches?user_key=' + encodeURIComponent(userKey);
+    if (latestDate) {
+      url += '&after=' + encodeURIComponent(latestDate);
+    }
+    return fetch(url);
+  }).then(function (res) {
+    if (!res.ok) throw new Error('fetch failed');
+    return res.json();
+  }).then(function (data) {
+    if (data.matches && data.matches.length > 0) {
+      return saveMatchesToDB(userKey, data.matches);
+    }
+  }).catch(function () {});
+}
+
 // --- Utility ---
 function esc(s) {
   if (s == null) return '';
@@ -2136,6 +2224,9 @@ async function analyze() {
 
         renderReport(resultData.report, resultData.user_key);
         renderedReal = true;
+        if (resultData.user_key) {
+          fetchAndCacheMatches(resultData.user_key);
+        }
         if (resultData.partial) {
           var warning = document.getElementById('error');
           warning.style.display = 'block';


### PR DESCRIPTION
## Summary

Closes #293

- `GET /matches?user_key=<key>&after=<datetime>` エンドポイントを追加。Firestoreの試合データをプレイヤー視点のJSONで配信（差分取得対応）
- フロントエンドにIndexedDBキャッシュ基盤を構築。analyze完了後にバックグラウンドで試合データを取得・保存し、次回以降の差分取得に対応
- `mslist.StripQuery` をエクスポートし、`BuildMSCostMap` を追加（画像URL→コスト逆引き）

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `internal/pipeline/matchdata.go` | 新規: `MatchData`型、`BuildMatchData`、`GetMatchData` |
| `internal/mslist/mslist.go` | `StripQuery`エクスポート、`BuildMSCostMap`追加 |
| `internal/server/server.go` | `/matches` エンドポイント追加 |
| `static/app.js` | IndexedDB基盤（open/save/load/getLatest/fetchAndCache） |

## Test plan

- [ ] `go vet ./...` と `go build ./...` がパスすること
- [ ] `GET /matches?user_key=<key>` で試合データJSONが返ること
- [ ] `GET /matches?user_key=<key>&after=<datetime>` で差分取得できること
- [ ] ブラウザのDevToolsでIndexedDB `catalyzer.matches` にデータが保存されることを確認
- [ ] 2回目のanalyze時に差分取得（afterパラメータ付き）でリクエストされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6WoSemCevjW93ytejrzm