### PR TITLE
fix: カスタム期間分析の固定相方バグ修正とFirestore再読み取り最適化

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -404,6 +404,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 			}
 		} else {
 			log.Printf("[INFO] No tag partners found")
+			finalTagPartners = cachedPartners
 		}
 	}
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -49,6 +49,8 @@ type Job struct {
 	LoggedIn           bool             `json:"logged_in,omitempty"`
 	UserKey            string           `json:"-"`
 	completedAt        time.Time
+	cachedScores       model.DatedScores
+	cachedTagPartners  []model.TagPartner
 }
 
 // ジョブストア（インメモリ）
@@ -334,9 +336,17 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 			finalReport = report
 		}
 
+		// カスタム期間分析用にscoresとtag_partnersをキャッシュ
+		finalPartners := tagPartners
+		if len(finalPartners) == 0 {
+			finalPartners = cachedPartners
+		}
+
 		jobsMu.Lock()
 		j.Status = model.StatusDone
 		j.Report = finalReport
+		j.cachedScores = existingScores
+		j.cachedTagPartners = finalPartners
 		j.completedAt = time.Now()
 		jobsMu.Unlock()
 		fs.SaveReportCache(j.UserKey, finalReport)
@@ -372,9 +382,11 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 
 	// タッグ相方名を取得（403途中保存時はセッションが無効なのでキャッシュを使用）
 	var tagPartnersPath string
+	var finalTagPartners []model.TagPartner
 	if is403WithPartialData {
 		if cachedTagPartnersPath != "" {
 			tagPartnersPath = cachedTagPartnersPath
+			finalTagPartners = cachedPartners
 			log.Printf("[INFO] Using cached tag partners (403 partial save)")
 		}
 	} else {
@@ -388,6 +400,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 				log.Printf("[INFO] Found %d tag partners", len(tagPartners))
 				// Firestoreにtag_partnersを書き込み
 				fs.SaveTagPartners(j.UserKey, tagPartners)
+				finalTagPartners = tagPartners
 			}
 		} else {
 			log.Printf("[INFO] No tag partners found")
@@ -402,10 +415,13 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 		return
 	}
 
+	// カスタム期間分析用にscoresとtag_partnersをキャッシュ
 	jobsMu.Lock()
 	j.Status = model.StatusDone
 	j.Report = report
 	j.PartialData = is403WithPartialData
+	j.cachedScores = allScores
+	j.cachedTagPartners = finalTagPartners
 	j.completedAt = time.Now()
 	jobsMu.Unlock()
 	fs.SaveReportCache(j.UserKey, report)
@@ -445,6 +461,59 @@ func RunCustomPeriod(userKey, start, end string) (string, error) {
 	if err != nil {
 		log.Printf("[WARN] Failed to load tag partners for custom period: %v", err)
 	}
+	if len(partners) > 0 {
+		tagPartnersPath = filepath.Join(tmpDir, "tag_partners.json")
+		if err := saveTagPartners(partners, tagPartnersPath); err != nil {
+			log.Printf("[WARN] Failed to save tag partners for custom period: %v", err)
+			tagPartnersPath = ""
+		}
+	}
+
+	args := []string{"scripts/analyze.py", jsonPath, "--start", start, "--end", end, "--ms-list", DefaultMSListPath}
+	if tagPartnersPath != "" {
+		args = append(args, "--tag-partners", tagPartnersPath)
+	}
+
+	cmd := exec.Command("python3", args...)
+	cmd.Dir = "/app"
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("analysis failed: %v\n%s", err, string(output))
+	}
+
+	reportPath := filepath.Join(tmpDir, "report.json")
+	report, err := os.ReadFile(reportPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read report: %w", err)
+	}
+	return string(report), nil
+}
+
+// RunCustomPeriodFromJob はジョブにキャッシュされたscoresを使ってカスタム日時範囲の再分析を実行する。
+// キャッシュがない場合はFirestoreから読み直すRunCustomPeriodにフォールバックする。
+func RunCustomPeriodFromJob(j *Job, start, end string) (string, error) {
+	jobsMu.RLock()
+	scores := j.cachedScores
+	partners := j.cachedTagPartners
+	userKey := j.UserKey
+	jobsMu.RUnlock()
+
+	if len(scores) == 0 {
+		return RunCustomPeriod(userKey, start, end)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "exvs-period-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	jsonPath := filepath.Join(tmpDir, "scores.json")
+	if err := saveScoresJSON(scores, jsonPath); err != nil {
+		return "", fmt.Errorf("failed to generate JSON: %w", err)
+	}
+
+	var tagPartnersPath string
 	if len(partners) > 0 {
 		tagPartnersPath = filepath.Join(tmpDir, "tag_partners.json")
 		if err := saveTagPartners(partners, tagPartnersPath); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -262,7 +262,7 @@ func handleCustomPeriod(w http.ResponseWriter, r *http.Request, id string) {
 		return
 	}
 
-	report, err := pipeline.RunCustomPeriod(snap.UserKey, start, end)
+	report, err := pipeline.RunCustomPeriodFromJob(j, start, end)
 	if err != nil {
 		log.Printf("[ERROR] Custom period analysis failed: %v", err)
 		sendJSON(w, http.StatusInternalServerError, map[string]string{"error": "カスタム期間の分析に失敗しました"})

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1426,14 +1426,14 @@ def build_json_report(player_name, all_data, ms_data, tag_partners=None):
     }
 
 
-def build_custom_period_report(player_name, all_data, ms_data, start, end):
+def build_custom_period_report(player_name, all_data, ms_data, start, end, tag_partners=None):
     """カスタム日時範囲の構造化JSONレポートを生成する"""
     filtered = filter_by_datetime_range(all_data, start, end)
     if not filtered:
         return None
 
     ms_filtered = build_ms_data(filtered)
-    period_report = build_period_report(filtered, ms_filtered)
+    period_report = build_period_report(filtered, ms_filtered, tag_partners)
     start_str = start.strftime("%Y-%m-%d %H:%M")
     end_str = end.strftime("%Y-%m-%d %H:%M")
     period_report["label"] = f"{start_str} 〜 {end_str}"
@@ -1474,7 +1474,7 @@ def main():
     if args.start and args.end:
         start = datetime.strptime(args.start, "%Y-%m-%d %H:%M")
         end = datetime.strptime(args.end, "%Y-%m-%d %H:%M")
-        report_data = build_custom_period_report(player_name, all_data, ms_data, start, end)
+        report_data = build_custom_period_report(player_name, all_data, ms_data, start, end, tag_partners)
         if report_data is None:
             print("指定期間のデータが見つかりませんでした。")
             sys.exit(1)


### PR DESCRIPTION
## Summary

Closes #235

- **固定相方バグ修正**: 日付指定分析時に`build_custom_period_report`が`tag_partners`を`build_period_report`に渡していなかったため、固定相方分析が表示されなかった問題を修正
- **Firestore再読み取り最適化**: `Run()`完了時にscoresとtag_partnersをJob構造体にキャッシュし、`RunCustomPeriodFromJob`でFirestoreへの再読み取りを省略

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `scripts/analyze.py` | `build_custom_period_report`に`tag_partners`パラメータを追加・伝播 |
| `internal/pipeline/pipeline.go` | Job構造体にキャッシュフィールド追加、`RunCustomPeriodFromJob`追加 |
| `internal/server/server.go` | `handleCustomPeriod`でキャッシュ活用に変更 |

## Test plan

- [ ] `go vet ./...` と `go build ./...` がパスすること
- [ ] 日付指定分析で固定相方セクションが表示されること
- [ ] カスタム期間分析時にFirestoreへの再読み取りが発生しないこと（ログで確認）
- [ ] キャッシュがない場合（ジョブなしの`/period`エンドポイント）は従来通りFirestoreから読み取ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6WoSemCevjW93ytejrzm