### PR TITLE
feat: ログイン状態の保持機能（Cookie永続化）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 クライアントは GET /status/{id} でポーリング後、GET /result/{id} で結果取得
 ```
 
-**主要エンドポイント:** `POST /analyze`, `GET /status/{id}`, `GET /result/{id}`, `GET /result/{id}/period`, `GET /period`, `GET /health`, `GET /`（静的UI）
+**主要エンドポイント:** `POST /analyze`, `GET /status/{id}`, `GET /result/{id}`, `GET /result/{id}/period`, `GET /period`, `GET /session`, `DELETE /session`, `POST /reanalyze`, `GET /health`, `GET /`（静的UI）
 
 ## コード構成
 
@@ -81,9 +81,10 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 - `internal/mslist/` — MSリストの読み書き・マージ（`LoadMSList`, `SaveMSList`, `MergeMSList`, `BuildMSNameMap`, `FillMsNames`, `CheckUnknownMS`）
 - `internal/gradelist/` — グレードリストの読み込み・未知URL検出（`LoadGradeList`, `BuildGradeMap`, `CheckUnknownGrades`）
 - `internal/scraper/` — Collyベースのスクレイパー（`scraper.go`）+ バンダイナムコID認証（`login.go`）
-- `internal/firestore/` — Firestoreクライアント初期化（`client.go`）+ matches/tag_partnersの読み書き（タイムラインはmatches内に埋め込み）
-- `internal/pipeline/` — 分析パイプライン（`Job`型、ジョブストア、`Run`関数、JSON生成）
-- `internal/server/` — HTTPハンドラ（`server.go`）+ IPベースレート制限（`ratelimit.go`）+ Basic認証（`basicauth.go`）+ 403一時ブロック（`block403.go`）
+- `internal/session/` — セッション暗号化（AES-256-GCM）とCookieJarシリアライズ（`crypto.go`, `jar.go`）
+- `internal/firestore/` — Firestoreクライアント初期化（`client.go`）+ matches/tag_partnersの読み書き（タイムラインはmatches内に埋め込み）+ セッション保存（`session.go`）
+- `internal/pipeline/` — 分析パイプライン（`Job`型、ジョブストア、`Run`関数、JSON生成、セッション永続化）
+- `internal/server/` — HTTPハンドラ（`server.go`）+ IPベースレート制限（`ratelimit.go`）+ Basic認証（`basicauth.go`）+ 403一時ブロック（`block403.go`）+ セッション管理エンドポイント
 - `scripts/analyze.py` — Python分析: 勝率、与被ダメ比、固定相方検出（K/D・EXダメ・覚醒回数・勝敗パターン付き）、JSON構造化レポート生成
 - `static/index.html` — SPA フロントエンド（ダークテーマ、レスポンシブ対応、カスタムドロップダウン）
 - `static/app.js` — フロントエンドJS（CSP対応で外部化。htm/Preactでレンダリング）。主要コンポーネント: Report（状態管理）、HamburgerMenu（左ドロワー）、MsSelector/LensToggle（トップバーフィルタ）、5タブ構成（OverviewPane/PlaystylePane/BurstPane/MatchupPane/TimePane）、FixedPartnerPanel（レンズ対応6軸レーダー）、各種Chart/集計関数
@@ -128,6 +129,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
   - `SCRAPER_MAX_DETAIL`: 詳細取得件数の上限。0または未設定で無制限（既定 0）
   - 例（バースト無効・全件低レート）: `SCRAPER_BURST_COUNT=0 SCRAPER_THROTTLE_DELAY_MS=1200`
 - 速報レポートは初回 `prelimFirstBatchSize`(5)試合、以降 `prelimBatchSize`(20)試合ごとに段階更新される（`onBatchReady`→`PreliminaryVersion++`、フロントがポーリングで再描画）
+- セッション保持機能: `SESSION_ENCRYPTION_KEY`（64文字hex、AES-256-GCM鍵）設定時に有効化。バンナムCookieJarを暗号化してFirestoreに保存し、次回アクセス時にパスワード不要で再分析。user_session Cookie（HttpOnly/Secure/SameSite=Strict、30日有効）でセッション識別。レポートはlocalStorageにもキャッシュし即時表示
 
 ## Goコーディング規約
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,10 @@
 | `internal/mslist/` | MSリストの読み書き・マージ |
 | `internal/gradelist/` | グレードリストの読み込み・未知URL検出 |
 | `internal/scraper/` | スクレイピング・ログイン処理 |
-| `internal/firestore/` | Firestoreクライアント・データの読み書き |
-| `internal/pipeline/` | 分析パイプライン（ジョブ管理・実行・CSV生成） |
-| `internal/server/` | HTTPハンドラ・レート制限・Basic認証・403ブロック |
+| `internal/session/` | セッション暗号化（AES-256-GCM）・CookieJarシリアライズ |
+| `internal/firestore/` | Firestoreクライアント・データの読み書き・セッション保存 |
+| `internal/pipeline/` | 分析パイプライン（ジョブ管理・実行・CSV生成・セッション永続化） |
+| `internal/server/` | HTTPハンドラ・レート制限・Basic認証・403ブロック・セッション管理 |
 | `scripts/` | Go以外のスクリプト（Python分析等） |
 | `static/` | フロントエンドHTML/JS/CSS |
 | `data/` | 静的データファイル（MSリスト等） |

--- a/internal/firestore/session.go
+++ b/internal/firestore/session.go
@@ -1,0 +1,92 @@
+package firestore
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log"
+
+	"cloud.google.com/go/firestore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// SaveSession は暗号化されたCookieJarをFirestoreに保存する。
+// token はセッション識別子（ランダムUUID）、userKey はユーザー識別子。
+func SaveSession(token, userKey string, encryptedJar []byte) error {
+	c := getClient()
+	if c == nil {
+		return fmt.Errorf("firestore client not initialized")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	ref := c.Collection("sessions").Doc(token)
+	_, err := ref.Set(ctx, map[string]interface{}{
+		"user_key":   userKey,
+		"jar":        base64.StdEncoding.EncodeToString(encryptedJar),
+		"updated_at": firestore.ServerTimestamp,
+	})
+	if err != nil {
+		return fmt.Errorf("save session: %w", err)
+	}
+
+	log.Printf("[INFO] Firestore: saved session for user %s", userKey)
+	return nil
+}
+
+// LoadSession はFirestoreからセッション情報を読み取る。
+// 存在しない場合はuserKey=""、jar=nilを返す。
+func LoadSession(token string) (userKey string, encryptedJar []byte, err error) {
+	c := getClient()
+	if c == nil {
+		return "", nil, fmt.Errorf("firestore client not initialized")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	ref := c.Collection("sessions").Doc(token)
+	doc, err := ref.Get(ctx)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return "", nil, nil
+		}
+		return "", nil, fmt.Errorf("get session: %w", err)
+	}
+
+	data := doc.Data()
+	uk, _ := data["user_key"].(string)
+	jarStr, _ := data["jar"].(string)
+	if uk == "" || jarStr == "" {
+		return "", nil, nil
+	}
+
+	jarBytes, err := base64.StdEncoding.DecodeString(jarStr)
+	if err != nil {
+		return "", nil, fmt.Errorf("decode jar: %w", err)
+	}
+
+	return uk, jarBytes, nil
+}
+
+// DeleteSession はFirestoreからセッション情報を削除する。
+func DeleteSession(token string) error {
+	c := getClient()
+	if c == nil {
+		return fmt.Errorf("firestore client not initialized")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	ref := c.Collection("sessions").Doc(token)
+	_, err := ref.Delete(ctx)
+	if err != nil {
+		return fmt.Errorf("delete session: %w", err)
+	}
+
+	log.Printf("[INFO] Firestore: deleted session (token: %s...)", token[:8])
+	return nil
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -19,6 +19,7 @@ import (
 	"github.com/yuki9431/catalyzer/internal/model"
 	"github.com/yuki9431/catalyzer/internal/mslist"
 	"github.com/yuki9431/catalyzer/internal/scraper"
+	"github.com/yuki9431/catalyzer/internal/session"
 )
 
 // DefaultMSListPath はデフォルトのMSリストパス
@@ -48,6 +49,9 @@ type Job struct {
 	PartialData        bool             `json:"partial_data,omitempty"`
 	LoggedIn           bool             `json:"logged_in,omitempty"`
 	UserKey            string           `json:"-"`
+	Remember           bool             `json:"-"`
+	SessionToken       string           `json:"-"`
+	SavedJar           http.CookieJar   `json:"-"`
 	completedAt        time.Time
 }
 
@@ -103,7 +107,9 @@ type On403Func func(userHash string)
 // Run はスクレイピング→分析を実行し、レポートをジョブに保存する
 func Run(j *Job, username, password string, on403 ...On403Func) {
 	jobsMu.Lock()
-	j.UserKey = model.UserKey(username)
+	if j.UserKey == "" {
+		j.UserKey = model.UserKey(username)
+	}
 	jobsMu.Unlock()
 	updateStatus(j, model.StatusScraping)
 
@@ -192,7 +198,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	}
 
 	// スクレイピング
-	log.Printf("[INFO] Scraping for user (hash: %s)", model.UserKey(username))
+	log.Printf("[INFO] Scraping for user (hash: %s)", j.UserKey)
 	onProgress := func(current, total int) {
 		jobsMu.Lock()
 		j.Message = "戦歴データを取得中"
@@ -262,6 +268,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 			jobsMu.Unlock()
 			log.Printf("[INFO] Job %s: login succeeded", j.ID)
 		},
+		SavedJar: j.SavedJar,
 	}
 	if len(backfillDates) > 0 {
 		scrapingOpt.BackfillDates = backfillDates
@@ -269,17 +276,33 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 
 	var datedScores model.DatedScores
 	var jar http.CookieJar
+	usingSession := j.SavedJar != nil
+
 	datedScores, jar, err = scraper.ScrapingWithOption(username, password, since, scrapingOpt)
 	// 403の場合でも途中データがあれば保存・分析を続行する
 	is403WithPartialData := errors.Is(err, scraper.ErrAccessDenied) && len(datedScores) > 0
 	if err != nil && !is403WithPartialData {
+		// 保存済みセッション使用時にスクレイピング失敗 → セッション削除
+		if usingSession && j.SessionToken != "" {
+			if delErr := fs.DeleteSession(j.SessionToken); delErr != nil {
+				log.Printf("[WARN] Failed to delete expired session: %v", delErr)
+			}
+		}
 		switch {
 		case errors.Is(err, scraper.ErrLoginFailed):
-			setError(j, "ログインに失敗しました。メールアドレスとパスワードを確認してください。", err.Error())
+			if usingSession {
+				setError(j, "セッションの有効期限が切れました。再度ログインしてください。", err.Error())
+			} else {
+				setError(j, "ログインに失敗しました。メールアドレスとパスワードを確認してください。", err.Error())
+			}
 		case errors.Is(err, scraper.ErrAccessDenied):
-			setError(j, "対戦履歴ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。", err.Error())
-			if len(on403) > 0 && on403[0] != nil {
-				on403[0](model.UserKey(username))
+			if usingSession {
+				setError(j, "セッションの有効期限が切れました。再度ログインしてください。", err.Error())
+			} else {
+				setError(j, "対戦履歴ページへのアクセスが拒否されました。ブラウザからガンダムモバイル(https://web.vsmobile.jp)にログインし、対戦履歴が閲覧できるか確認してください。", err.Error())
+				if len(on403) > 0 && on403[0] != nil {
+					on403[0](j.UserKey)
+				}
 			}
 		case errors.Is(err, scraper.ErrUnauthorized):
 			setError(j, "認証の有効期限が切れました。再度ログインしてお試しください。", err.Error())
@@ -295,8 +318,27 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	if is403WithPartialData {
 		log.Printf("[WARN] Job %s: 403 occurred but %d partial scores available, saving partial data", j.ID, len(datedScores))
 		if len(on403) > 0 && on403[0] != nil {
-			on403[0](model.UserKey(username))
+			on403[0](j.UserKey)
 		}
+	}
+
+	// remember=true でログイン成功時、CookieJarを暗号化してFirestoreに保存
+	if j.Remember && jar != nil && session.Enabled() && j.SessionToken != "" {
+		go func() {
+			jarData, err := session.SerializeJar(jar)
+			if err != nil {
+				log.Printf("[WARN] Failed to serialize CookieJar: %v", err)
+				return
+			}
+			encData, err := session.Encrypt(jarData)
+			if err != nil {
+				log.Printf("[WARN] Failed to encrypt CookieJar: %v", err)
+				return
+			}
+			if err := fs.SaveSession(j.SessionToken, j.UserKey, encData); err != nil {
+				log.Printf("[WARN] Failed to save session: %v", err)
+			}
+		}()
 	}
 	if len(datedScores) == 0 && !exists {
 		setError(j, "戦績データが見つかりませんでした", "no scores found")

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -134,6 +134,7 @@ type ScrapingOption struct {
 	BatchSize      int                             // OnBatchReady発火間隔（試合数）。0の場合は通知しない
 	FirstBatchSize int                             // 初回OnBatchReadyを発火する試合数。0でBatchSizeと同じ。初回だけ早めに速報を出す用途
 	OnLoginSuccess func()                          // ログイン成功直後に1度だけ呼ばれる
+	SavedJar       http.CookieJar                  // 保存済みCookieJar。非nilの場合はログインをスキップ
 }
 
 // Scraping はスクレイピング処理を実行し、DatedScoresとログイン済みCookieJarを返す
@@ -159,16 +160,22 @@ func ScrapingWithOption(username, password string, since time.Time, opt Scraping
 		}
 	}
 
-	m := NewClient(username, password)
-	if err := m.Login(); err != nil {
-		return nil, nil, fmt.Errorf("ログインに失敗: %w", err)
+	var jar http.CookieJar
+	if opt.SavedJar != nil {
+		jar = opt.SavedJar
+	} else {
+		m := NewClient(username, password)
+		if err := m.Login(); err != nil {
+			return nil, nil, fmt.Errorf("ログインに失敗: %w", err)
+		}
+		jar = m.HTTPClient.Jar
 	}
 	if opt.OnLoginSuccess != nil {
 		opt.OnLoginSuccess()
 	}
 
 	// Phase 1: rankpageから日別ページURLを収集
-	dailyLinks, err := collectDailyLinks(m.HTTPClient.Jar, since)
+	dailyLinks, err := collectDailyLinks(jar, since)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -196,10 +203,10 @@ func ScrapingWithOption(username, password string, since time.Time, opt Scraping
 
 	go func() {
 		defer close(entryCh)
-		streamErr = streamMatchEntries(ctx, cancel, m.HTTPClient.Jar, dailyLinks, since, entryCh)
+		streamErr = streamMatchEntries(ctx, cancel, jar, dailyLinks, since, entryCh)
 	}()
 
-	scores, detailErr := fetchDetailPagesStreaming(ctx, cancel, m.HTTPClient.Jar, entryCh, notify, opt.OnBatchReady, opt.BatchSize, opt.FirstBatchSize)
+	scores, detailErr := fetchDetailPagesStreaming(ctx, cancel, jar, entryCh, notify, opt.OnBatchReady, opt.BatchSize, opt.FirstBatchSize)
 
 	// 403の場合は途中データがあればエラーと一緒に返す（呼び出し元で途中保存できるようにする）
 	if streamErr != nil || detailErr != nil {
@@ -209,7 +216,7 @@ func ScrapingWithOption(username, password string, since time.Time, opt Scraping
 		}
 		if errors.Is(err, ErrAccessDenied) && len(scores) > 0 {
 			log.Printf("[INFO] Returning %d partial scores despite 403 error", len(scores))
-			return scores, m.HTTPClient.Jar, err
+			return scores, jar, err
 		}
 		if streamErr != nil {
 			return nil, nil, streamErr
@@ -225,7 +232,7 @@ func ScrapingWithOption(username, password string, since time.Time, opt Scraping
 		return scores[i].PlayerNo < scores[j].PlayerNo
 	})
 
-	return scores, m.HTTPClient.Jar, nil
+	return scores, jar, nil
 }
 
 // collectDailyLinks はrankpageから日別ページのURLを収集する

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,15 +11,21 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/yuki9431/catalyzer/internal/firestore"
 	"github.com/yuki9431/catalyzer/internal/model"
 	"github.com/yuki9431/catalyzer/internal/pipeline"
+	"github.com/yuki9431/catalyzer/internal/session"
 	"golang.org/x/time/rate"
 )
+
+const sessionCookieName = "catalyzer_session"
+const sessionMaxAge = 30 * 24 * 60 * 60 // 30 days
 
 type analyzeRequest struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
+	Remember bool   `json:"remember"`
 }
 
 var requestLimiter = make(chan struct{}, 3)
@@ -120,6 +126,12 @@ func StartServer() {
 		// ジョブ作成
 		j := pipeline.NewJob()
 
+		// remember=true かつセッション暗号化が有効な場合、セッショントークンを生成
+		if req.Remember && session.Enabled() {
+			j.Remember = true
+			j.SessionToken = uuid.New().String()
+		}
+
 		// バックグラウンドで実行
 		go func() {
 			defer func() { <-requestLimiter }()
@@ -189,6 +201,27 @@ func StartServer() {
 		handlePeriod(w, r)
 	})
 
+	// GET /session → セッションの有効性チェック（キャッシュレポート付き）
+	http.HandleFunc("/session", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			handleSessionCheck(w, r)
+		case http.MethodDelete:
+			handleSessionDelete(w, r)
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	// POST /reanalyze → 保存済みセッションで再分析
+	http.HandleFunc("/reanalyze", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		handleReanalyze(w, r, rl)
+	})
+
 	// 静的ファイル（フロントエンド）
 	fs := http.FileServer(http.Dir("static"))
 	http.Handle("/", fs)
@@ -221,6 +254,11 @@ func handleResult(w http.ResponseWriter, r *http.Request, id string) {
 	if snap.Status == model.StatusError {
 		sendJSON(w, http.StatusInternalServerError, map[string]string{"error": snap.Error})
 		return
+	}
+
+	// remember=true でジョブ完了時、セッションCookieを発行
+	if j.Remember && j.SessionToken != "" {
+		setSessionCookie(w, j.SessionToken)
 	}
 
 	sendRawReport(w, http.StatusOK, snap.Report, "", snap.UserKey, false, snap.PartialData)
@@ -340,4 +378,163 @@ func sendRawReport(w http.ResponseWriter, code int, reportJSON, status, userKey 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	json.NewEncoder(w).Encode(resp)
+}
+
+func setSessionCookie(w http.ResponseWriter, token string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    token,
+		Path:     "/",
+		MaxAge:   sessionMaxAge,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+	})
+}
+
+func clearSessionCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+	})
+}
+
+func getSessionToken(r *http.Request) string {
+	c, err := r.Cookie(sessionCookieName)
+	if err != nil {
+		return ""
+	}
+	return c.Value
+}
+
+// handleSessionCheck はセッションの有効性を確認し、キャッシュ済みレポートを返す
+func handleSessionCheck(w http.ResponseWriter, r *http.Request) {
+	token := getSessionToken(r)
+	if token == "" {
+		sendJSON(w, http.StatusOK, map[string]interface{}{"valid": false})
+		return
+	}
+
+	userKey, encJar, err := firestore.LoadSession(token)
+	if err != nil {
+		log.Printf("[WARN] Failed to load session: %v", err)
+		sendJSON(w, http.StatusOK, map[string]interface{}{"valid": false})
+		return
+	}
+	if userKey == "" || encJar == nil {
+		sendJSON(w, http.StatusOK, map[string]interface{}{"valid": false})
+		return
+	}
+
+	resp := map[string]interface{}{
+		"valid":    true,
+		"user_key": userKey,
+	}
+
+	// キャッシュ済みレポートがあれば返す（localStorage消失時のフォールバック）
+	cachedReport, err := firestore.LoadReportCache(userKey)
+	if err == nil && cachedReport != "" {
+		resp["report"] = json.RawMessage(cachedReport)
+	}
+
+	sendJSON(w, http.StatusOK, resp)
+}
+
+// handleSessionDelete はセッションを削除する（ログアウト）
+func handleSessionDelete(w http.ResponseWriter, r *http.Request) {
+	token := getSessionToken(r)
+	if token == "" {
+		sendJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+		return
+	}
+
+	if err := firestore.DeleteSession(token); err != nil {
+		log.Printf("[WARN] Failed to delete session: %v", err)
+	}
+
+	clearSessionCookie(w)
+	sendJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+}
+
+// handleReanalyze は保存済みセッションを使って再分析を実行する
+func handleReanalyze(w http.ResponseWriter, r *http.Request, rl *rateLimiter) {
+	token := getSessionToken(r)
+	if token == "" {
+		sendJSON(w, http.StatusUnauthorized, map[string]string{"error": "セッションが見つかりません。再度ログインしてください。"})
+		return
+	}
+
+	// レート制限チェック
+	if rl != nil {
+		ip := clientIP(r)
+		if !rl.getLimiter(ip).Allow() {
+			sendJSON(w, http.StatusTooManyRequests, map[string]string{"error": "リクエスト回数の上限に達しました。しばらく時間をおいてから再度お試しください"})
+			return
+		}
+	}
+
+	// Firestoreからセッションを読み込み
+	userKey, encJar, err := firestore.LoadSession(token)
+	if err != nil {
+		log.Printf("[WARN] Failed to load session for reanalyze: %v", err)
+		clearSessionCookie(w)
+		sendJSON(w, http.StatusUnauthorized, map[string]string{"error": "セッションの読み込みに失敗しました。再度ログインしてください。"})
+		return
+	}
+	if userKey == "" || encJar == nil {
+		clearSessionCookie(w)
+		sendJSON(w, http.StatusUnauthorized, map[string]string{"error": "セッションの有効期限が切れました。再度ログインしてください。"})
+		return
+	}
+
+	// CookieJarを復号
+	jarData, err := session.Decrypt(encJar)
+	if err != nil {
+		log.Printf("[WARN] Failed to decrypt session jar: %v", err)
+		_ = firestore.DeleteSession(token)
+		clearSessionCookie(w)
+		sendJSON(w, http.StatusUnauthorized, map[string]string{"error": "セッションの復号に失敗しました。再度ログインしてください。"})
+		return
+	}
+
+	jar, err := session.DeserializeJar(jarData)
+	if err != nil {
+		log.Printf("[WARN] Failed to deserialize session jar: %v", err)
+		_ = firestore.DeleteSession(token)
+		clearSessionCookie(w)
+		sendJSON(w, http.StatusUnauthorized, map[string]string{"error": "セッションの復元に失敗しました。再度ログインしてください。"})
+		return
+	}
+
+	// 403ブロックチェック
+	if forbidden403.IsBlocked(userKey) {
+		sendJSON(w, http.StatusTooManyRequests, map[string]string{"error": "対戦履歴ページへのアクセスが拒否されました。しばらく時間をおいてから再度お試しください。"})
+		return
+	}
+
+	// 同時実行数制限
+	select {
+	case requestLimiter <- struct{}{}:
+	default:
+		sendJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "Server is busy, please try again later"})
+		return
+	}
+
+	j := pipeline.NewJob()
+	j.UserKey = userKey
+	j.SavedJar = jar
+	j.SessionToken = token
+	j.Remember = true
+
+	go func() {
+		defer func() { <-requestLimiter }()
+		pipeline.Run(j, "", "", forbidden403.Block)
+	}()
+
+	sendJSON(w, http.StatusAccepted, map[string]string{"id": j.ID})
 }

--- a/internal/session/crypto.go
+++ b/internal/session/crypto.go
@@ -1,0 +1,98 @@
+package session
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sync"
+)
+
+var (
+	encryptionKey []byte
+	keyOnce       sync.Once
+	keyEnabled    bool
+)
+
+func initKey() {
+	keyHex := os.Getenv("SESSION_ENCRYPTION_KEY")
+	if keyHex == "" {
+		return
+	}
+	key, err := hex.DecodeString(keyHex)
+	if err != nil {
+		log.Printf("[WARN] SESSION_ENCRYPTION_KEY: invalid hex encoding")
+		return
+	}
+	if len(key) != 32 {
+		log.Printf("[WARN] SESSION_ENCRYPTION_KEY: must be 32 bytes (64 hex chars), got %d bytes", len(key))
+		return
+	}
+	encryptionKey = key
+	keyEnabled = true
+	log.Printf("[INFO] Session encryption enabled")
+}
+
+// Enabled はセッション暗号化が有効かどうかを返す。
+// SESSION_ENCRYPTION_KEY 環境変数が正しく設定されている場合に true を返す。
+func Enabled() bool {
+	keyOnce.Do(initKey)
+	return keyEnabled
+}
+
+// Encrypt はAES-256-GCMで平文を暗号化する。
+// 戻り値は nonce + ciphertext の結合バイト列。
+func Encrypt(plaintext []byte) ([]byte, error) {
+	keyOnce.Do(initKey)
+	if !keyEnabled {
+		return nil, fmt.Errorf("session encryption not configured")
+	}
+
+	block, err := aes.NewCipher(encryptionKey)
+	if err != nil {
+		return nil, fmt.Errorf("create cipher: %w", err)
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create GCM: %w", err)
+	}
+
+	nonce := make([]byte, aesGCM.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+
+	return aesGCM.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// Decrypt はAES-256-GCMで暗号文を復号する。
+// ciphertext は nonce + 暗号データ の結合バイト列であること。
+func Decrypt(ciphertext []byte) ([]byte, error) {
+	keyOnce.Do(initKey)
+	if !keyEnabled {
+		return nil, fmt.Errorf("session encryption not configured")
+	}
+
+	block, err := aes.NewCipher(encryptionKey)
+	if err != nil {
+		return nil, fmt.Errorf("create cipher: %w", err)
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create GCM: %w", err)
+	}
+
+	nonceSize := aesGCM.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, ct := ciphertext[:nonceSize], ciphertext[nonceSize:]
+	return aesGCM.Open(nil, nonce, ct, nil)
+}

--- a/internal/session/crypto_test.go
+++ b/internal/session/crypto_test.go
@@ -1,0 +1,106 @@
+package session
+
+import (
+	"encoding/hex"
+	"os"
+	"sync"
+	"testing"
+)
+
+func resetCrypto() {
+	encryptionKey = nil
+	keyEnabled = false
+	keyOnce = sync.Once{}
+}
+
+func TestEncryptDecrypt(t *testing.T) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	os.Setenv("SESSION_ENCRYPTION_KEY", hex.EncodeToString(key))
+	t.Cleanup(func() {
+		os.Unsetenv("SESSION_ENCRYPTION_KEY")
+		resetCrypto()
+	})
+	resetCrypto()
+
+	plaintext := []byte("hello, session cookies!")
+
+	encrypted, err := Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	if string(encrypted) == string(plaintext) {
+		t.Fatal("encrypted data should differ from plaintext")
+	}
+
+	decrypted, err := Decrypt(encrypted)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+
+	if string(decrypted) != string(plaintext) {
+		t.Fatalf("got %q, want %q", decrypted, plaintext)
+	}
+}
+
+func TestEncryptDifferentNonce(t *testing.T) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 10)
+	}
+	os.Setenv("SESSION_ENCRYPTION_KEY", hex.EncodeToString(key))
+	t.Cleanup(func() {
+		os.Unsetenv("SESSION_ENCRYPTION_KEY")
+		resetCrypto()
+	})
+	resetCrypto()
+
+	plaintext := []byte("test data")
+
+	enc1, _ := Encrypt(plaintext)
+	enc2, _ := Encrypt(plaintext)
+
+	if string(enc1) == string(enc2) {
+		t.Fatal("two encryptions of same plaintext should produce different ciphertext (different nonce)")
+	}
+
+	dec1, _ := Decrypt(enc1)
+	dec2, _ := Decrypt(enc2)
+	if string(dec1) != string(dec2) {
+		t.Fatal("both should decrypt to same plaintext")
+	}
+}
+
+func TestDecryptTampered(t *testing.T) {
+	key := make([]byte, 32)
+	os.Setenv("SESSION_ENCRYPTION_KEY", hex.EncodeToString(key))
+	t.Cleanup(func() {
+		os.Unsetenv("SESSION_ENCRYPTION_KEY")
+		resetCrypto()
+	})
+	resetCrypto()
+
+	encrypted, _ := Encrypt([]byte("secret"))
+	encrypted[len(encrypted)-1] ^= 0xff
+
+	_, err := Decrypt(encrypted)
+	if err == nil {
+		t.Fatal("Decrypt should fail on tampered ciphertext")
+	}
+}
+
+func TestNotEnabled(t *testing.T) {
+	os.Unsetenv("SESSION_ENCRYPTION_KEY")
+	resetCrypto()
+
+	if Enabled() {
+		t.Fatal("should not be enabled without env var")
+	}
+	_, err := Encrypt([]byte("test"))
+	if err == nil {
+		t.Fatal("Encrypt should fail when not enabled")
+	}
+}

--- a/internal/session/jar.go
+++ b/internal/session/jar.go
@@ -1,0 +1,91 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+)
+
+var cookieURLs = []*url.URL{
+	{Scheme: "https", Host: "web.vsmobile.jp"},
+	{Scheme: "https", Host: "www.bandainamcoid.com"},
+	{Scheme: "https", Host: "account.bandainamcoid.com"},
+	{Scheme: "https", Host: "account-api.bandainamcoid.com"},
+}
+
+type serializedCookie struct {
+	URL     string        `json:"url"`
+	Cookies []cookieEntry `json:"cookies"`
+}
+
+type cookieEntry struct {
+	Name     string `json:"name"`
+	Value    string `json:"value"`
+	Path     string `json:"path,omitempty"`
+	Domain   string `json:"domain,omitempty"`
+	Secure   bool   `json:"secure,omitempty"`
+	HttpOnly bool   `json:"http_only,omitempty"`
+}
+
+// SerializeJar はCookieJarの内容をJSONバイト列にシリアライズする。
+func SerializeJar(jar http.CookieJar) ([]byte, error) {
+	var entries []serializedCookie
+	for _, u := range cookieURLs {
+		cookies := jar.Cookies(u)
+		if len(cookies) == 0 {
+			continue
+		}
+		ce := make([]cookieEntry, len(cookies))
+		for i, c := range cookies {
+			ce[i] = cookieEntry{
+				Name:     c.Name,
+				Value:    c.Value,
+				Path:     c.Path,
+				Domain:   c.Domain,
+				Secure:   c.Secure,
+				HttpOnly: c.HttpOnly,
+			}
+		}
+		entries = append(entries, serializedCookie{
+			URL:     u.String(),
+			Cookies: ce,
+		})
+	}
+	return json.Marshal(entries)
+}
+
+// DeserializeJar はJSONバイト列からCookieJarを復元する。
+func DeserializeJar(data []byte) (http.CookieJar, error) {
+	var entries []serializedCookie
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("unmarshal cookies: %w", err)
+	}
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("create cookie jar: %w", err)
+	}
+
+	for _, entry := range entries {
+		u, err := url.Parse(entry.URL)
+		if err != nil {
+			continue
+		}
+		cookies := make([]*http.Cookie, len(entry.Cookies))
+		for i, c := range entry.Cookies {
+			cookies[i] = &http.Cookie{
+				Name:     c.Name,
+				Value:    c.Value,
+				Path:     c.Path,
+				Domain:   c.Domain,
+				Secure:   c.Secure,
+				HttpOnly: c.HttpOnly,
+			}
+		}
+		jar.SetCookies(u, cookies)
+	}
+
+	return jar, nil
+}

--- a/internal/session/jar_test.go
+++ b/internal/session/jar_test.go
@@ -1,0 +1,81 @@
+package session
+
+import (
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"testing"
+)
+
+func TestSerializeDeserializeJar(t *testing.T) {
+	jar, _ := cookiejar.New(nil)
+
+	vsURL, _ := url.Parse("https://web.vsmobile.jp/")
+	jar.SetCookies(vsURL, []*http.Cookie{
+		{Name: "session_id", Value: "abc123"},
+		{Name: "token", Value: "xyz789", Path: "/", Domain: "web.vsmobile.jp"},
+	})
+
+	bnURL, _ := url.Parse("https://www.bandainamcoid.com/")
+	jar.SetCookies(bnURL, []*http.Cookie{
+		{Name: "auth", Value: "bnid_token"},
+	})
+
+	data, err := SerializeJar(jar)
+	if err != nil {
+		t.Fatalf("SerializeJar: %v", err)
+	}
+
+	restored, err := DeserializeJar(data)
+	if err != nil {
+		t.Fatalf("DeserializeJar: %v", err)
+	}
+
+	vsCookies := restored.Cookies(vsURL)
+	if len(vsCookies) < 2 {
+		t.Fatalf("expected at least 2 vsmobile cookies, got %d", len(vsCookies))
+	}
+
+	found := false
+	for _, c := range vsCookies {
+		if c.Name == "session_id" && c.Value == "abc123" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("session_id cookie not found in restored jar")
+	}
+
+	bnCookies := restored.Cookies(bnURL)
+	if len(bnCookies) == 0 {
+		t.Fatal("expected bandainamcoid cookies")
+	}
+	found = false
+	for _, c := range bnCookies {
+		if c.Name == "auth" && c.Value == "bnid_token" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("auth cookie not found in restored jar")
+	}
+}
+
+func TestSerializeEmptyJar(t *testing.T) {
+	jar, _ := cookiejar.New(nil)
+
+	data, err := SerializeJar(jar)
+	if err != nil {
+		t.Fatalf("SerializeJar: %v", err)
+	}
+
+	restored, err := DeserializeJar(data)
+	if err != nil {
+		t.Fatalf("DeserializeJar: %v", err)
+	}
+
+	vsURL, _ := url.Parse("https://web.vsmobile.jp/")
+	if len(restored.Cookies(vsURL)) != 0 {
+		t.Fatal("expected no cookies in empty jar")
+	}
+}

--- a/static/app.js
+++ b/static/app.js
@@ -2071,6 +2071,9 @@ async function reanalyzeWithSession() {
         var resultData = await resultRes.json();
         if (resultData.error) throw new Error(resultData.error);
         renderReport(resultData.report, resultData.user_key);
+        if (resultData.user_key) {
+          fetchAndCacheMatches(resultData.user_key);
+        }
         break;
       }
     }

--- a/static/app.js
+++ b/static/app.js
@@ -1239,7 +1239,7 @@ function ShareArea({ shareData }) {
 
 // --- Hamburger menu & topbar controls ---
 
-function HamburgerMenu({ isOpen, onClose, shareData, onReAnalyze }) {
+function HamburgerMenu({ isOpen, onClose, shareData, onReAnalyze, hasSession, onLogout }) {
   useEffect(function () {
     if (isOpen) {
       document.body.style.overflow = 'hidden';
@@ -1256,6 +1256,10 @@ function HamburgerMenu({ isOpen, onClose, shareData, onReAnalyze }) {
       <div class="menu-header">catalyzer</div>
       <div class="menu-body">
         <button class="menu-item" onClick=${function () { onClose(); onReAnalyze(); }}>再分析</button>
+        ${hasSession ? [
+          html`<div class="menu-divider" />`,
+          html`<button class="menu-item" style="color: var(--bad)" onClick=${function () { onClose(); onLogout(); }}>ログアウト</button>`
+        ] : null}
         <div class="menu-divider" />
         <div style="padding: 8px 16px;">
           <${ShareArea} shareData=${shareData} />
@@ -1856,6 +1860,12 @@ var TAB_DEFS = [
 ];
 
 function reAnalyze() {
+  // セッション保持中はパスワード不要で再分析
+  if (localStorage.getItem('catalyzer_user_key')) {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    reanalyzeWithSession();
+    return;
+  }
   var u = document.getElementById('username');
   var p = document.getElementById('password');
   if (u && p && u.value && p.value) {
@@ -1865,6 +1875,122 @@ function reAnalyze() {
   }
   var rep = document.getElementById('report');
   if (rep) rep.style.display = 'none';
+  var lf = document.getElementById('loginForm');
+  if (lf) lf.style.display = 'block';
+  var t = document.getElementById('pageTitle');
+  if (t) t.style.display = '';
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+async function reanalyzeWithSession() {
+  var status = document.getElementById('status');
+  var statusText = document.getElementById('statusText');
+  var error = document.getElementById('error');
+
+  status.style.display = 'block';
+  statusText.textContent = STATUS_MESSAGES.pending;
+  error.style.display = 'none';
+
+  var lastPreliminaryVersion = 0;
+
+  try {
+    var res = await fetch('/reanalyze', { method: 'POST' });
+    var data = await res.json();
+
+    if (data.error) {
+      // セッション失効
+      if (res.status === 401) {
+        localStorage.removeItem('catalyzer_user_key');
+        var lf = document.getElementById('loginForm');
+        if (lf) lf.style.display = 'block';
+        error.style.display = 'block';
+        error.textContent = data.error;
+        status.style.display = 'none';
+        return;
+      }
+      throw new Error(data.error);
+    }
+
+    var jobId = data.id;
+
+    while (true) {
+      await new Promise(function (r) { setTimeout(r, 3000); });
+
+      var statusRes = await fetch('/status/' + jobId);
+      var statusData = await statusRes.json();
+
+      if (statusData.error && statusData.status !== 'error') {
+        throw new Error(statusData.error);
+      }
+
+      statusText.textContent = statusData.message || STATUS_MESSAGES[statusData.status] || statusData.status;
+
+      var progressWrap = document.getElementById('progressWrap');
+      var progressFill = document.getElementById('progressFill');
+      if (statusData.progress_total > 0) {
+        var p = Math.round(100 * statusData.progress / statusData.progress_total);
+        progressFill.classList.remove('indeterminate');
+        progressFill.style.width = p + '%';
+        document.getElementById('progressPct').textContent = p + '%';
+        document.getElementById('progressCount').textContent = statusData.progress + '/' + statusData.progress_total + '件';
+        progressWrap.style.display = 'block';
+      } else if (statusData.status === 'scraping') {
+        progressFill.classList.add('indeterminate');
+        document.getElementById('progressPct').textContent = '戦歴を検索中…';
+        document.getElementById('progressCount').textContent = statusData.progress ? statusData.progress + '件' : '';
+        progressWrap.style.display = 'block';
+      } else {
+        progressFill.classList.remove('indeterminate');
+        progressWrap.style.display = 'none';
+      }
+
+      if (statusData.logged_in && statusData.has_preliminary_report && statusData.preliminary_version > lastPreliminaryVersion) {
+        var prelimRes = await fetch('/result/' + jobId);
+        var prelimData = await prelimRes.json();
+        if (prelimData.report && prelimData.preliminary) {
+          renderReport(prelimData.report, prelimData.user_key);
+          statusText.textContent = '最新データを取得中...';
+          lastPreliminaryVersion = statusData.preliminary_version;
+        }
+      }
+
+      if (statusData.status === 'error') {
+        // セッション失効エラーの場合はログイン画面を表示
+        if (statusData.error && statusData.error.indexOf('セッション') >= 0) {
+          localStorage.removeItem('catalyzer_user_key');
+          var lf = document.getElementById('loginForm');
+          if (lf) lf.style.display = 'block';
+        }
+        throw new Error(statusData.error || '分析に失敗しました');
+      }
+
+      if (statusData.status === 'done') {
+        var resultRes = await fetch('/result/' + jobId);
+        var resultData = await resultRes.json();
+        if (resultData.error) throw new Error(resultData.error);
+        renderReport(resultData.report, resultData.user_key);
+        break;
+      }
+    }
+  } catch (e) {
+    error.style.display = 'block';
+    error.textContent = e.message;
+  } finally {
+    status.style.display = 'none';
+  }
+}
+
+async function logout() {
+  try {
+    await fetch('/session', { method: 'DELETE' });
+  } catch (e) {}
+  localStorage.removeItem('catalyzer_report');
+  localStorage.removeItem('catalyzer_user_key');
+  localStorage.removeItem('catalyzer_has_session');
+  try { sessionStorage.removeItem('catalyzer_cred'); } catch (e) {}
+
+  var rep = document.getElementById('report');
+  if (rep) { render(null, rep); rep.style.display = 'none'; }
   var lf = document.getElementById('loginForm');
   if (lf) lf.style.display = 'block';
   var t = document.getElementById('pageTitle');
@@ -1959,7 +2085,9 @@ function Report({ data, userKey }) {
     </div>
 
     <${HamburgerMenu} isOpen=${menuOpen} onClose=${function () { setMenuOpen(false); }}
-      shareData=${shareData} onReAnalyze=${reAnalyze} />
+      shareData=${shareData} onReAnalyze=${reAnalyze}
+      hasSession=${!!localStorage.getItem('catalyzer_user_key')}
+      onLogout=${logout} />
 
     <${KpiGrid} stats=${effectivePd.basic_stats} />
 
@@ -2019,10 +2147,15 @@ function showSkeleton() {
 function renderReport(data, userKey) {
   var reportEl = document.getElementById('report');
   reportEl.style.display = 'block';
-  // ダッシュボードのtopbarがブランド表示を担うため、静的な見出しは隠す
   var pageTitle = document.getElementById('pageTitle');
   if (pageTitle) pageTitle.style.display = 'none';
   render(html`<${Report} data=${data} userKey=${userKey} />`, reportEl);
+
+  // レポートをlocalStorageにキャッシュ（次回アクセス時の即時表示用）
+  try {
+    localStorage.setItem('catalyzer_report', JSON.stringify(data));
+    if (userKey) localStorage.setItem('catalyzer_user_key', userKey);
+  } catch (e) {}
 }
 
 async function analyze() {
@@ -2063,10 +2196,13 @@ async function analyze() {
   showSkeleton();
 
   try {
+    var rememberEl = document.getElementById('remember');
+    var remember = rememberEl ? rememberEl.checked : false;
+
     var res = await fetch('/analyze', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username: username, password: password }),
+      body: JSON.stringify({ username: username, password: password, remember: remember }),
     });
 
     var data = await res.json();
@@ -2136,6 +2272,10 @@ async function analyze() {
 
         renderReport(resultData.report, resultData.user_key);
         renderedReal = true;
+        // remember=trueで分析成功 → セッションフラグをセット
+        if (remember) {
+          try { localStorage.setItem('catalyzer_has_session', '1'); } catch (e) {}
+        }
         if (resultData.partial) {
           var warning = document.getElementById('error');
           warning.style.display = 'block';
@@ -2177,6 +2317,66 @@ if (loginForm) {
     }
   } catch (e) {}
 }
+
+// セッション保持の説明モーダル
+var rememberInfoBtn = document.getElementById('rememberInfoBtn');
+var rememberModal = document.getElementById('rememberModal');
+var rememberModalClose = document.getElementById('rememberModalClose');
+if (rememberInfoBtn && rememberModal) {
+  rememberInfoBtn.addEventListener('click', function (e) {
+    e.preventDefault();
+    rememberModal.style.display = 'flex';
+  });
+  rememberModal.addEventListener('click', function (e) {
+    if (e.target === rememberModal) rememberModal.style.display = 'none';
+  });
+  if (rememberModalClose) {
+    rememberModalClose.addEventListener('click', function () {
+      rememberModal.style.display = 'none';
+    });
+  }
+}
+
+// ページロード時: localStorageにキャッシュレポートがあれば即時表示
+(function initSession() {
+  var cachedReport = null;
+  var cachedUserKey = null;
+  var hasSession = false;
+  try {
+    var reportStr = localStorage.getItem('catalyzer_report');
+    cachedUserKey = localStorage.getItem('catalyzer_user_key');
+    hasSession = !!localStorage.getItem('catalyzer_has_session');
+    if (reportStr) cachedReport = JSON.parse(reportStr);
+  } catch (e) {}
+
+  // キャッシュレポートがあれば即時表示
+  if (cachedReport && cachedUserKey) {
+    renderReport(cachedReport, cachedUserKey);
+  }
+
+  if (hasSession) {
+    // セッション保持ユーザー: ログインフォームを隠し、バックグラウンドでセッション確認
+    if (loginForm) loginForm.style.display = 'none';
+
+    fetch('/session').then(function (r) { return r.json(); }).then(function (data) {
+      if (!data.valid) {
+        // セッション失効
+        localStorage.removeItem('catalyzer_has_session');
+        if (loginForm) loginForm.style.display = 'block';
+        // レポートキャッシュがない場合はサーバーのレポートキャッシュなしで通常ログインへ
+      } else if (!cachedReport && data.report) {
+        // localStorageにレポートがないがサーバーにはある場合
+        renderReport(data.report, data.user_key);
+        if (loginForm) loginForm.style.display = 'none';
+        try { localStorage.setItem('catalyzer_report', JSON.stringify(data.report)); } catch (e) {}
+      }
+    }).catch(function () {
+      // ネットワークエラー: ログインフォームを表示
+      if (loginForm) loginForm.style.display = 'block';
+    });
+  }
+  // セッションなし + キャッシュありの場合: レポートは表示済み、ログインフォームも表示（デフォルト）
+})();
 
 // preview.html用: windowにrenderReportを公開
 window.renderReport = renderReport;

--- a/static/index.html
+++ b/static/index.html
@@ -299,6 +299,23 @@
     /* ===== Info note ===== */
     .info-note { padding: 10px 14px; margin-bottom: 12px; font-size: 0.85em; color: var(--muted); background: rgba(79,195,247,0.06); border-radius: 8px; border-left: 3px solid var(--accent); }
 
+    /* ===== Remember checkbox ===== */
+    .remember-group { margin-bottom: 16px; }
+    .remember-label { display: flex; align-items: center; gap: 8px; color: var(--text); font-size: 0.9em; cursor: pointer; }
+    .remember-label input[type="checkbox"] { width: 18px; height: 18px; accent-color: var(--accent); cursor: pointer; }
+    .info-icon { background: none; border: none; color: var(--accent); font-size: 1.1em; cursor: pointer; padding: 0 4px; line-height: 1; width: auto; }
+    .info-icon:hover { color: var(--accent-2); }
+
+    /* ===== Modal ===== */
+    .modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 300; display: flex; align-items: center; justify-content: center; }
+    .modal-content { background: var(--panel); border: 1px solid var(--line); border-radius: 12px; padding: 24px; max-width: 400px; margin: 16px; box-shadow: 0 16px 48px rgba(0,0,0,0.5); }
+    .modal-content p { color: var(--text); font-size: 0.9em; line-height: 1.7; margin-bottom: 10px; }
+    .modal-close { margin-top: 12px; padding: 10px 24px; border: none; border-radius: 8px; background: var(--accent); color: #062536; font-size: 0.95em; font-weight: bold; cursor: pointer; }
+    .modal-close:hover { background: var(--accent-2); }
+
+    /* ===== Session expired banner ===== */
+    .session-expired-banner { background: #4a3800; border: 1px solid #d4a017; border-radius: 8px; padding: 12px; margin-bottom: 16px; color: #ffd54f; font-size: 0.9em; text-align: center; }
+
     .disclaimer { margin-top: 30px; padding: 16px 0; border-top: 1px solid var(--line); text-align: center; font-size: 0.72em; color: #5a6b7a; line-height: 1.8; }
 
     @media (max-width: 720px) {
@@ -344,6 +361,13 @@
         <label for="password">パスワード</label>
         <input type="password" id="password" name="password" autocomplete="current-password" placeholder="パスワード">
       </div>
+      <div class="form-group remember-group">
+        <label class="remember-label">
+          <input type="checkbox" id="remember" name="remember">
+          <span>ログイン状態を保持する</span>
+          <button type="button" class="info-icon" id="rememberInfoBtn" aria-label="詳細情報">ⓘ</button>
+        </label>
+      </div>
       <p class="security-note">パスワードはガンダムモバイルへのログインにのみ使用し、サーバーには保存しません。通信はHTTPSで暗号化されています。</p>
       <button type="submit" id="analyzeBtn">分析開始</button>
       <p class="note">公式サイトから直近30日分の戦績を取得して分析します。初回は全データを取得するため5〜10分ほどかかりますが、2回目以降は前回からの差分のみ取得するため短時間で完了します。</p>
@@ -360,6 +384,17 @@
 
     <div class="error" id="error" style="display:none;"></div>
     <div class="report" id="report" style="display:none;"></div>
+
+    <!-- セッション保持の説明モーダル -->
+    <div class="modal-backdrop" id="rememberModal" style="display:none;">
+      <div class="modal-content">
+        <p>サーバーにセッション情報を暗号化して保存します。パスワードは保存されません。</p>
+        <p>次回アクセス時にログインなしでデータを取得できます。</p>
+        <p>セッションの有効期限が切れた場合は再ログインが必要です。</p>
+        <p>セッション情報はいつでも削除できます。</p>
+        <button class="modal-close" id="rememberModalClose">閉じる</button>
+      </div>
+    </div>
 
     <footer class="disclaimer">
       <p>本サービスは非公式のファンツールです。<br>サンライズ、バンダイナムコエクスペリエンス、バンダイナムコエンターテインメントとは一切関係ありません。</p>


### PR DESCRIPTION
## Summary
- CookieJarをAES-256-GCM暗号化しFirestoreに保存、パスワードなしで再分析可能にする
- `POST /reanalyze`、`GET /session`、`DELETE /session` エンドポイントを追加
- フロントエンドに「ログイン状態を保持する」チェックボックス、ログアウト機能、localStorageレポートキャッシュを追加
- `SESSION_ENCRYPTION_KEY` 環境変数未設定時は機能無効（既存動作に影響なし）

## 変更概要

### バックエンド
- `internal/session/`: AES-256-GCM暗号化 (`crypto.go`) + CookieJarシリアライズ (`jar.go`) + テスト
- `internal/firestore/session.go`: Firestoreへのセッション保存・読込・削除
- `internal/scraper/scraper.go`: `SavedJar`フィールド追加。保存済みJarがある場合はログインをスキップ
- `internal/pipeline/pipeline.go`: セッション永続化（暗号化→Firestore保存）、セッション失敗時の自動削除
- `internal/server/server.go`: セッション管理エンドポイント（`GET /session`, `DELETE /session`, `POST /reanalyze`）、HttpOnly/Secure/SameSite=Strict Cookie設定

### フロントエンド
- `static/index.html`: 「ログイン状態を保持する」チェックボックス + 情報モーダル
- `static/app.js`: セッション管理（initSession, reanalyze, logout）、localStorageレポートキャッシュ、ハンバーガーメニューにログアウト追加

### セキュリティ
- パスワードは保存しない（暗号化CookieJarのみ保存）
- ランダムUUIDセッショントークンでuserKey推測攻撃を防止
- HttpOnly / Secure / SameSite=Strict Cookie属性
- スクレイピング失敗時はセッションを自動削除

## Test plan
- [ ] `go build ./...` / `go vet ./...` / `go test ./...` がパスすること ✅
- [ ] `SESSION_ENCRYPTION_KEY` 未設定時に既存動作が変わらないこと
- [ ] 「ログイン状態を保持する」チェックを入れてログイン → Cookie保存 → ページリロードでログイン画面スキップ
- [ ] 「再分析」ボタンでパスワードなし再分析
- [ ] ハンバーガーメニューからログアウト → セッション削除 → ログイン画面表示
- [ ] セッション期限切れ → ログイン画面表示
- [ ] 情報モーダル (ⓘ) の表示・非表示

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6WoSemCevjW93ytejrzm