### PR TITLE
fix: 使用機体フィルタ時に固定相方分析が絞り込まれない

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1353,6 +1353,7 @@ def build_period_report(all_data, ms_data, tag_partners=None):
             "fall_order": data_fall_order(data),
             "burst_hold_death": data_burst_hold_death(data),
             "burst_count": data_burst_count(data),
+            "fixed_partners": data_fixed_partners(data, tag_partners),
         }
 
     return {

--- a/static/app.js
+++ b/static/app.js
@@ -1731,7 +1731,9 @@ function OverviewPane({ pd, selectedMs, lens, allPd }) {
     return { name: name, winRate: (msStats[name].basic_stats && msStats[name].basic_stats.win_rate) || 0 };
   });
 
-  var fp = allPd.fixed_partners;
+  var fp = (selectedMs && msStats[selectedMs] && msStats[selectedMs].fixed_partners)
+    ? msStats[selectedMs].fixed_partners
+    : allPd.fixed_partners;
   var fpList = fp ? (fp.partners || fp) : [];
   var fpItems = Array.isArray(fpList) ? fpList : [];
 


### PR DESCRIPTION
## Summary
- `build_period_report`で各MS別に`fixed_partners`データを生成するように変更
- フロントエンドの`OverviewPane`で`selectedMs`時にMS別の固定相方データを参照

## 変更内容
- `scripts/analyze.py`: `ms_stats[ms_name]`に`data_fixed_partners(data, tag_partners)`を追加
- `static/app.js`: `fp`変数の参照先をMS選択時に切り替え

## Test plan
- [ ] MS未選択時: 固定相方パネルが従来通り全機体の集計を表示すること
- [ ] MS選択時: そのMSの試合に絞った固定相方データが表示されること
- [ ] 固定相方がいないMSを選択した場合: パネルが非表示になること

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)