### PR TITLE
feat: MatchData拡張と時間帯分析のフロント集計移行

### DIFF
--- a/internal/pipeline/matchdata.go
+++ b/internal/pipeline/matchdata.go
@@ -12,23 +12,46 @@ import (
 
 // MatchData はフロントエンド向けの試合データ（プレイヤー視点）
 type MatchData struct {
-	Date         string `json:"date"`
-	MS           string `json:"ms"`
-	MSCost       int    `json:"ms_cost,omitempty"`
-	PartnerMS    string `json:"partner_ms"`
-	PartnerCost  int    `json:"partner_cost,omitempty"`
-	Opponent1MS  string `json:"opponent1_ms"`
-	Opponent1Cost int   `json:"opponent1_cost,omitempty"`
-	Opponent2MS  string `json:"opponent2_ms"`
-	Opponent2Cost int   `json:"opponent2_cost,omitempty"`
-	Win          bool   `json:"win"`
-	Score        int    `json:"score"`
-	Kills        int    `json:"kills"`
-	Deaths       int    `json:"deaths"`
-	DmgGiven     int    `json:"dmg_given"`
-	DmgTaken     int    `json:"dmg_taken"`
-	ExDmg        int    `json:"ex_dmg"`
-	GameEndSec   float64 `json:"game_end_sec,omitempty"`
+	Date          string  `json:"date"`
+	MS            string  `json:"ms"`
+	MSCost        int     `json:"ms_cost,omitempty"`
+	PartnerMS     string  `json:"partner_ms"`
+	PartnerCost   int     `json:"partner_cost,omitempty"`
+	Opponent1MS   string  `json:"opponent1_ms"`
+	Opponent1Cost int     `json:"opponent1_cost,omitempty"`
+	Opponent2MS   string  `json:"opponent2_ms"`
+	Opponent2Cost int     `json:"opponent2_cost,omitempty"`
+	Win           bool    `json:"win"`
+	Score         int     `json:"score"`
+	Kills         int     `json:"kills"`
+	Deaths        int     `json:"deaths"`
+	DmgGiven      int     `json:"dmg_given"`
+	DmgTaken      int     `json:"dmg_taken"`
+	ExDmg         int     `json:"ex_dmg"`
+	PartnerName   string  `json:"partner_name"`
+	PartnerScore  int     `json:"partner_score"`
+	PartnerKills  int     `json:"partner_kills"`
+	PartnerDeaths int     `json:"partner_deaths"`
+	PartnerDmgGiven int  `json:"partner_dmg_given"`
+	PartnerDmgTaken int  `json:"partner_dmg_taken"`
+	PartnerExDmg  int     `json:"partner_ex_dmg"`
+	Bursts        int     `json:"bursts"`
+	PartnerBursts int     `json:"partner_bursts"`
+	GameEndSec    float64 `json:"game_end_sec,omitempty"`
+}
+
+// countBursts はタイムラインから指定グループの覚醒回数を数える。
+func countBursts(timeline *model.MatchTimeline, group string) int {
+	if timeline == nil {
+		return 0
+	}
+	count := 0
+	for _, e := range timeline.Events {
+		if e.Group == group && (e.ClassName == "exbst-f" || e.ClassName == "exbst-s" || e.ClassName == "exbst-e") {
+			count++
+		}
+	}
+	return count
 }
 
 // BuildMatchData はDatedScoresをフロントエンド向けの試合データに変換する。
@@ -65,31 +88,42 @@ func BuildMatchData(ds model.DatedScores, costsMap map[string]int, after time.Ti
 		opp2 := entries[3].PlayerScore   // PlayerNo 4
 
 		var gameEndSec float64
+		var timeline *model.MatchTimeline
 		for _, e := range entries {
 			if e.MatchTimeline != nil {
 				gameEndSec = e.MatchTimeline.GameEndSec
+				timeline = e.MatchTimeline
 				break
 			}
 		}
 
 		matches = append(matches, MatchData{
-			Date:          entries[0].Datetime.Format("2006-01-02 15:04"),
-			MS:            me.MsName,
-			MSCost:        costsMap[mslist.StripQuery(me.MsImageURL)],
-			PartnerMS:     partner.MsName,
-			PartnerCost:   costsMap[mslist.StripQuery(partner.MsImageURL)],
-			Opponent1MS:   opp1.MsName,
-			Opponent1Cost: costsMap[mslist.StripQuery(opp1.MsImageURL)],
-			Opponent2MS:   opp2.MsName,
-			Opponent2Cost: costsMap[mslist.StripQuery(opp2.MsImageURL)],
-			Win:           me.Win,
-			Score:         me.Score,
-			Kills:         me.Kills,
-			Deaths:        me.Deaths,
-			DmgGiven:      me.GiveDamage,
-			DmgTaken:      me.ReceiveDamage,
-			ExDmg:         me.ExDamage,
-			GameEndSec:    gameEndSec,
+			Date:            entries[0].Datetime.Format("2006-01-02 15:04"),
+			MS:              me.MsName,
+			MSCost:          costsMap[mslist.StripQuery(me.MsImageURL)],
+			PartnerMS:       partner.MsName,
+			PartnerCost:     costsMap[mslist.StripQuery(partner.MsImageURL)],
+			Opponent1MS:     opp1.MsName,
+			Opponent1Cost:   costsMap[mslist.StripQuery(opp1.MsImageURL)],
+			Opponent2MS:     opp2.MsName,
+			Opponent2Cost:   costsMap[mslist.StripQuery(opp2.MsImageURL)],
+			Win:             me.Win,
+			Score:           me.Score,
+			Kills:           me.Kills,
+			Deaths:          me.Deaths,
+			DmgGiven:        me.GiveDamage,
+			DmgTaken:        me.ReceiveDamage,
+			ExDmg:           me.ExDamage,
+			PartnerName:     partner.Name,
+			PartnerScore:    partner.Score,
+			PartnerKills:    partner.Kills,
+			PartnerDeaths:   partner.Deaths,
+			PartnerDmgGiven: partner.GiveDamage,
+			PartnerDmgTaken: partner.ReceiveDamage,
+			PartnerExDmg:    partner.ExDamage,
+			Bursts:          countBursts(timeline, "team1-1"),
+			PartnerBursts:   countBursts(timeline, "team1-2"),
+			GameEndSec:      gameEndSec,
 		})
 	}
 

--- a/internal/pipeline/matchdata.go
+++ b/internal/pipeline/matchdata.go
@@ -12,32 +12,32 @@ import (
 
 // MatchData はフロントエンド向けの試合データ（プレイヤー視点）
 type MatchData struct {
-	Date          string  `json:"date"`
-	MS            string  `json:"ms"`
-	MSCost        int     `json:"ms_cost,omitempty"`
-	PartnerMS     string  `json:"partner_ms"`
-	PartnerCost   int     `json:"partner_cost,omitempty"`
-	Opponent1MS   string  `json:"opponent1_ms"`
-	Opponent1Cost int     `json:"opponent1_cost,omitempty"`
-	Opponent2MS   string  `json:"opponent2_ms"`
-	Opponent2Cost int     `json:"opponent2_cost,omitempty"`
-	Win           bool    `json:"win"`
-	Score         int     `json:"score"`
-	Kills         int     `json:"kills"`
-	Deaths        int     `json:"deaths"`
-	DmgGiven      int     `json:"dmg_given"`
-	DmgTaken      int     `json:"dmg_taken"`
-	ExDmg         int     `json:"ex_dmg"`
-	PartnerName   string  `json:"partner_name"`
-	PartnerScore  int     `json:"partner_score"`
-	PartnerKills  int     `json:"partner_kills"`
-	PartnerDeaths int     `json:"partner_deaths"`
-	PartnerDmgGiven int  `json:"partner_dmg_given"`
-	PartnerDmgTaken int  `json:"partner_dmg_taken"`
-	PartnerExDmg  int     `json:"partner_ex_dmg"`
-	Bursts        int     `json:"bursts"`
-	PartnerBursts int     `json:"partner_bursts"`
-	GameEndSec    float64 `json:"game_end_sec,omitempty"`
+	Date            string  `json:"date"`
+	MS              string  `json:"ms"`
+	MSCost          int     `json:"ms_cost,omitempty"`
+	PartnerMS       string  `json:"partner_ms"`
+	PartnerCost     int     `json:"partner_cost,omitempty"`
+	Opponent1MS     string  `json:"opponent1_ms"`
+	Opponent1Cost   int     `json:"opponent1_cost,omitempty"`
+	Opponent2MS     string  `json:"opponent2_ms"`
+	Opponent2Cost   int     `json:"opponent2_cost,omitempty"`
+	Win             bool    `json:"win"`
+	Score           int     `json:"score"`
+	Kills           int     `json:"kills"`
+	Deaths          int     `json:"deaths"`
+	DmgGiven        int     `json:"dmg_given"`
+	DmgTaken        int     `json:"dmg_taken"`
+	ExDmg           int     `json:"ex_dmg"`
+	PartnerName     string  `json:"partner_name"`
+	PartnerScore    int     `json:"partner_score"`
+	PartnerKills    int     `json:"partner_kills"`
+	PartnerDeaths   int     `json:"partner_deaths"`
+	PartnerDmgGiven int     `json:"partner_dmg_given"`
+	PartnerDmgTaken int     `json:"partner_dmg_taken"`
+	PartnerExDmg    int     `json:"partner_ex_dmg"`
+	Bursts          int     `json:"bursts"`
+	PartnerBursts   int     `json:"partner_bursts"`
+	GameEndSec      float64 `json:"game_end_sec,omitempty"`
 }
 
 // countBursts はタイムラインから指定グループの覚醒回数を数える。
@@ -82,10 +82,10 @@ func BuildMatchData(ds model.DatedScores, costsMap map[string]int, after time.Ti
 			return entries[i].PlayerNo < entries[j].PlayerNo
 		})
 
-		me := entries[0].PlayerScore    // PlayerNo 1
+		me := entries[0].PlayerScore      // PlayerNo 1
 		partner := entries[1].PlayerScore // PlayerNo 2
-		opp1 := entries[2].PlayerScore   // PlayerNo 3
-		opp2 := entries[3].PlayerScore   // PlayerNo 4
+		opp1 := entries[2].PlayerScore    // PlayerNo 3
+		opp2 := entries[3].PlayerScore    // PlayerNo 4
 
 		var gameEndSec float64
 		var timeline *model.MatchTimeline

--- a/static/app.js
+++ b/static/app.js
@@ -99,6 +99,131 @@ function fetchAndCacheMatches(userKey) {
   }).catch(function () {});
 }
 
+// --- Frontend Aggregation Helpers ---
+var PERIOD_DAYS = { '90d': 90, '60d': 60, '30d': 30, '14d': 14, '7d': 7, '3d': 3, '1d': 1 };
+
+function jsWinRate(matches) {
+  if (!matches.length) return 0;
+  var w = 0;
+  for (var i = 0; i < matches.length; i++) { if (matches[i].win) w++; }
+  return w / matches.length * 100;
+}
+
+function jsDmgEfficiency(matches) {
+  if (!matches.length) return 0;
+  var g = 0, t = 0;
+  for (var i = 0; i < matches.length; i++) { g += matches[i].dmg_given; t += matches[i].dmg_taken; }
+  return t > 0 ? g / t : 0;
+}
+
+function round1(n) { return Math.round(n * 10) / 10; }
+function round3(n) { return Math.round(n * 1000) / 1000; }
+
+function filterByPlayDays(matches, days) {
+  if (!matches.length) return [];
+  var dateSet = {};
+  for (var i = 0; i < matches.length; i++) {
+    dateSet[matches[i].date.substring(0, 10)] = true;
+  }
+  var playDates = Object.keys(dateSet).sort().reverse();
+  var targetDates = {};
+  for (var i = 0; i < Math.min(days, playDates.length); i++) {
+    targetDates[playDates[i]] = true;
+  }
+  return matches.filter(function (m) { return targetDates[m.date.substring(0, 10)]; });
+}
+
+function computeTimeOfDay(matches) {
+  var hourly = {};
+  for (var i = 0; i < matches.length; i++) {
+    var hour = parseInt(matches[i].date.substring(11, 13), 10);
+    if (!hourly[hour]) hourly[hour] = [];
+    hourly[hour].push(matches[i]);
+  }
+  var hours = [];
+  for (var h = 0; h < 24; h++) {
+    if (!hourly[h]) continue;
+    var ms = hourly[h];
+    var wr = jsWinRate(ms);
+    hours.push({ hour: h, matches: ms.length, win_rate: round1(wr), dmg_efficiency: round3(jsDmgEfficiency(ms)), mark: wr >= 70 ? 'good' : wr <= 40 ? 'bad' : '' });
+  }
+  var tips = [];
+  var good = [], bad = [];
+  for (var h in hourly) {
+    if (hourly[h].length >= 5) {
+      var wr = jsWinRate(hourly[h]);
+      if (wr >= 70) good.push(Number(h));
+      if (wr <= 40) bad.push(Number(h));
+    }
+  }
+  good.sort(function (a, b) { return a - b; });
+  bad.sort(function (a, b) { return a - b; });
+  if (good.length) tips.push('好調 → **' + good.map(function (h) { return h + '時台'; }).join('、') + '**');
+  if (bad.length) tips.push('不調 → **' + bad.map(function (h) { return h + '時台'; }).join('、') + '**（強豪が多い or 疲労の影響）');
+  return { hours: hours, tips: tips };
+}
+
+function computeDayOfWeek(matches) {
+  var DOW_NAMES = ['月', '火', '水', '木', '金', '土', '日'];
+  var daily = {};
+  var weekdayData = [], weekendData = [];
+  for (var i = 0; i < matches.length; i++) {
+    var m = matches[i];
+    var d = new Date(m.date.replace(' ', 'T'));
+    var dow = (d.getDay() + 6) % 7;
+    if (!daily[dow]) daily[dow] = [];
+    daily[dow].push(m);
+    if (dow < 5) weekdayData.push(m); else weekendData.push(m);
+  }
+  var days = [];
+  for (var dow = 0; dow < 7; dow++) {
+    if (daily[dow]) {
+      days.push({ dow: dow, name: DOW_NAMES[dow], matches: daily[dow].length, win_rate: round1(jsWinRate(daily[dow])), dmg_efficiency: round3(jsDmgEfficiency(daily[dow])) });
+    }
+  }
+  var wdWr = weekdayData.length ? jsWinRate(weekdayData) : 0;
+  var weWr = weekendData.length ? jsWinRate(weekendData) : 0;
+  var diff = Math.abs(wdWr - weWr);
+  var tips = [];
+  if (diff >= 10) {
+    var better = wdWr > weWr ? '平日' : '土日';
+    var worse = wdWr > weWr ? '土日' : '平日';
+    tips.push('**' + better + '**が' + worse + 'より勝率 **' + Math.round(diff) + '%** 高い');
+  }
+  return {
+    weekday: weekdayData.length ? { matches: weekdayData.length, win_rate: round1(wdWr), dmg_efficiency: round3(jsDmgEfficiency(weekdayData)) } : { matches: 0, win_rate: 0, dmg_efficiency: 0 },
+    weekend: weekendData.length ? { matches: weekendData.length, win_rate: round1(weWr), dmg_efficiency: round3(jsDmgEfficiency(weekendData)) } : { matches: 0, win_rate: 0, dmg_efficiency: 0 },
+    days: days,
+    tips: tips,
+  };
+}
+
+function computeDailyTrend(matches) {
+  var DOW_NAMES = ['月', '火', '水', '木', '金', '土', '日'];
+  var daily = {};
+  var dateOrder = {};
+  for (var i = 0; i < matches.length; i++) {
+    var m = matches[i];
+    var dateKey = m.date.substring(5, 10).replace('-', '/');
+    if (!daily[dateKey]) { daily[dateKey] = []; dateOrder[dateKey] = m.date.substring(0, 10); }
+    daily[dateKey].push(m);
+  }
+  var sortedKeys = Object.keys(daily).sort(function (a, b) {
+    return dateOrder[a] < dateOrder[b] ? -1 : dateOrder[a] > dateOrder[b] ? 1 : 0;
+  });
+  var results = sortedKeys.map(function (dateStr) {
+    var ms = daily[dateStr];
+    var wr = jsWinRate(ms);
+    var d = new Date(ms[0].date.replace(' ', 'T'));
+    var dow = (d.getDay() + 6) % 7;
+    return { date: dateStr, dow_name: DOW_NAMES[dow], matches: ms.length, win_rate: round1(wr), dmg_efficiency: round3(jsDmgEfficiency(ms)), mark: wr >= 70 ? 'good' : wr <= 45 ? 'bad' : '' };
+  });
+  var tips = [];
+  var badDays = sortedKeys.filter(function (ds) { return jsWinRate(daily[ds]) <= 40 && daily[ds].length >= 5; });
+  if (badDays.length) tips.push('不調日（勝率40%以下）→ **' + badDays.join(', ') + '**。早めの切り上げが有効');
+  return { days: results, tips: tips };
+}
+
 // --- Utility ---
 function esc(s) {
   if (s == null) return '';
@@ -1765,7 +1890,7 @@ function OverviewPane({ pd, selectedMs, lens, allPd }) {
   </div>`;
 }
 
-function TimePane({ pd, selectedMs }) {
+function TimePane({ pd, selectedMs, usingFrontend }) {
   var time = pd.time_of_day, dow = pd.day_of_week, daily = pd.daily_trend;
   var timeRows = time && time.hours ? time.hours.map(function (h) {
     return [{ sortValue: h.hour, display: h.hour + '時' }, h.matches, colorPct(h.win_rate), colorDE(h.dmg_efficiency, 3)];
@@ -1781,7 +1906,7 @@ function TimePane({ pd, selectedMs }) {
   });
 
   return html`<div class="tabpane">
-    ${selectedMs && html`<div class="info-note">※ 時間帯データは全機体の集計です（機体別の時間帯分析は今後対応予定）</div>`}
+    ${selectedMs && !usingFrontend && html`<div class="info-note">※ 時間帯データは全機体の集計です（機体別の時間帯分析は今後対応予定）</div>`}
     ${time && time.hours && time.hours.length > 0 && html`<${Panel} title="時間帯別の勝率">
       <${TimeOfDayChart} hours=${time.hours} />
       <${Tips} tips=${time.tips} />
@@ -2117,7 +2242,16 @@ function Report({ data, userKey }) {
   var lens = lensRef[0], setLens = lensRef[1];
   var menuRef = useState(false);
   var menuOpen = menuRef[0], setMenuOpen = menuRef[1];
+  var matchesRef = useState(null);
+  var allMatches = matchesRef[0], setAllMatches = matchesRef[1];
   var topbarRef = useRef(null);
+
+  useEffect(function () {
+    if (!userKey) return;
+    loadMatchesFromDB(userKey).then(function (matches) {
+      if (matches && matches.length > 0) setAllMatches(matches);
+    }).catch(function () {});
+  }, [userKey]);
 
   useEffect(function () {
     var row = topbarRef.current && topbarRef.current.querySelector('.controls-row');
@@ -2163,6 +2297,21 @@ function Report({ data, userKey }) {
     return { basic_stats: ms.basic_stats, win_loss_pattern: ms.win_loss_pattern };
   }, [pd, selectedMs]);
 
+  var frontendTimeData = useMemo(function () {
+    if (!allMatches || !allMatches.length) return null;
+    if (selectedPeriod === 'custom') return null;
+    var filtered = allMatches;
+    var days = PERIOD_DAYS[selectedPeriod];
+    if (days) filtered = filterByPlayDays(allMatches, days);
+    if (selectedMs) filtered = filtered.filter(function (m) { return m.ms === selectedMs; });
+    if (!filtered.length) return null;
+    return {
+      time_of_day: computeTimeOfDay(filtered),
+      day_of_week: computeDayOfWeek(filtered),
+      daily_trend: computeDailyTrend(filtered),
+    };
+  }, [allMatches, selectedPeriod, selectedMs]);
+
   var shareData = selectedPeriod === 'custom' && customData ? customData.share_data : data.share_data;
 
   function handleCustomReport(report) {
@@ -2178,7 +2327,8 @@ function Report({ data, userKey }) {
   } else if (activeTab === 'matchup') {
     pane = html`<${MatchupPane} msStats=${msStats} selectedMs=${selectedMs} />`;
   } else if (activeTab === 'time') {
-    pane = html`<${TimePane} pd=${pd} selectedMs=${selectedMs} />`;
+    var timePd = frontendTimeData ? { time_of_day: frontendTimeData.time_of_day, day_of_week: frontendTimeData.day_of_week, daily_trend: frontendTimeData.daily_trend } : pd;
+    pane = html`<${TimePane} pd=${timePd} selectedMs=${selectedMs} usingFrontend=${!!frontendTimeData} />`;
   } else {
     pane = html`<${OverviewPane} pd=${effectivePd} selectedMs=${selectedMs} lens=${lens} allPd=${pd} />`;
   }


### PR DESCRIPTION
## Summary
- `MatchData`に相方スタッツ（name/score/kills/deaths/dmg/ex_dmg）と覚醒回数（bursts/partner_bursts）を追加し、FirestoreとIndexedDBのデータを統一
- フロントエンドにIndexedDB試合データからの時間帯・曜日・日別集計を実装
- MS選択時にも時間帯分析がフィルタされるように改善（「全機体の集計です」注記が不要に）

## 変更内容

### Go側（`internal/pipeline/matchdata.go`）
- `MatchData`に9フィールド追加（partner_name, partner_score/kills/deaths/dmg_given/dmg_taken/ex_dmg, bursts, partner_bursts）
- `countBursts()` — タイムラインから覚醒イベント（exbst-f/s/e）をカウント
- `BuildMatchData`で新フィールドをセット

### JS側（`static/app.js`）
- 集計ヘルパー: `jsWinRate`, `jsDmgEfficiency`, `filterByPlayDays`（Pythonのプレイ日ベースフィルタを再現）
- `computeTimeOfDay`, `computeDayOfWeek`, `computeDailyTrend`（Python版と閾値・tips文面を完全一致）
- `Report`コンポーネント: IndexedDBからマッチデータ読込 → 期間/MSフィルタ → フロント集計
- `TimePane`: フロント集計データがあればそれを使い、なければPythonデータにフォールバック

## フォールバック
- IndexedDB未キャッシュ（初回分析）→ Pythonレポートを表示
- カスタム期間 → Pythonレポートを表示
- フィルタ後0件 → Pythonレポートにフォールバック

## Test plan
- [ ] `go vet ./...` / `go build ./...` がパスすること
- [ ] `/matches`エンドポイントのレスポンスに新フィールド（partner_name等）が含まれること
- [ ] 全期間+全機体で、時間帯タブのデータがPythonレポートと一致すること
- [ ] MS選択時: 時間帯タブがそのMSの試合に絞った集計を表示し、注記が非表示になること
- [ ] IndexedDBを削除して再読込 → Pythonデータにフォールバックすること

Refs #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)