### PR TITLE
fix: ログイン保持チェックボックスをダークテーマに統一

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -301,8 +301,13 @@
 
     /* ===== Remember checkbox ===== */
     .remember-group { margin-bottom: 16px; }
-    .remember-label { display: flex; align-items: center; gap: 8px; color: var(--text); font-size: 0.9em; cursor: pointer; }
-    .remember-label input[type="checkbox"] { width: 18px; height: 18px; accent-color: var(--accent); cursor: pointer; }
+    .remember-label { display: flex; align-items: center; gap: 10px; color: var(--text); font-size: 0.9em; cursor: pointer; user-select: none; }
+    .remember-label input[type="checkbox"] { position: absolute; opacity: 0; width: 0; height: 0; }
+    .remember-check { width: 20px; height: 20px; border: 2px solid var(--line); border-radius: 5px; background: var(--bg); flex-shrink: 0; display: flex; align-items: center; justify-content: center; transition: all 0.15s; }
+    .remember-label:hover .remember-check { border-color: var(--accent); }
+    .remember-label input:checked + .remember-check { background: var(--accent); border-color: var(--accent); }
+    .remember-label input:checked + .remember-check::after { content: ''; display: block; width: 5px; height: 10px; border: solid #062536; border-width: 0 2.5px 2.5px 0; transform: rotate(45deg) translateY(-1px); }
+    .remember-label input:focus-visible + .remember-check { box-shadow: 0 0 0 2px var(--accent-2); }
     .info-icon { background: none; border: none; color: var(--accent); font-size: 1.1em; cursor: pointer; padding: 0 4px; line-height: 1; width: auto; }
     .info-icon:hover { color: var(--accent-2); }
 
@@ -370,6 +375,7 @@
       <div class="form-group remember-group">
         <label class="remember-label">
           <input type="checkbox" id="remember" name="remember">
+          <span class="remember-check"></span>
           <span>ログイン状態を保持する</span>
           <button type="button" class="info-icon" id="rememberInfoBtn" aria-label="詳細情報">ⓘ</button>
         </label>


### PR DESCRIPTION
## Summary
- ネイティブcheckboxを非表示にし、CSSカスタムチェックボックスでサイトのダークテーマに統一
- ホバー・チェック済み・キーボードフォーカス(focus-visible)のスタイルを追加

## Test plan
- [ ] 未チェック状態: ダーク背景+グレーボーダーのチェックボックスが表示される
- [ ] ホバー: ボーダーがアクセントカラー(水色)に変化する
- [ ] チェック済み: 水色背景+チェックマークが表示される
- [ ] Tabキーでフォーカス移動時にアウトラインが表示される
- [ ] クリック/タップでチェック状態が切り替わる
- [ ] モバイルでのタップ操作が問題なく動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6WoSemCevjW93ytejrzm