### PR TITLE
feat: トップバー右上に再分析ボタンを配置

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2352,6 +2352,7 @@ function Report({ data, userKey }) {
     <div class="topbar" ref=${topbarRef}>
       <button class="hamburger" onClick=${function () { setMenuOpen(true); }}>☰</button>
       <span class="brand"><img src="logo.svg" alt="catalyzer" /></span>
+      ${localStorage.getItem('catalyzer_has_session') && html`<button class="topbar-refresh" onClick=${reAnalyze}>再分析</button>`}
       <div class="controls-row">
         <${PeriodSelector} periods=${allPeriods} selected=${selectedPeriod} onSelect=${setSelectedPeriod}
           userKey=${userKey} onCustomReport=${handleCustomReport} />

--- a/static/index.html
+++ b/static/index.html
@@ -93,6 +93,8 @@
     }
     .topbar .brand { position: absolute; top: calc(env(safe-area-inset-top) + 18px); left: 50%; transform: translateX(-50%); font-size: 1.05em; font-weight: 800; color: var(--accent); white-space: nowrap; pointer-events: none; }
     .topbar .brand img { height: 24px; width: auto; display: block; }
+    .topbar-refresh { margin-left: auto; background: none; border: 1px solid var(--line); border-radius: 8px; color: var(--accent); font-size: 0.8em; padding: 5px 12px; cursor: pointer; width: auto; white-space: nowrap; transition: all 0.15s; }
+    .topbar-refresh:hover { border-color: var(--accent); background: rgba(79,195,247,0.1); }
     .controls-row {
       display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-basis: 100%;
       padding-top: 4px; max-height: 60px; opacity: 1;


### PR DESCRIPTION
## Summary
- セッション保持ユーザーのみ、トップバーのブランドロゴ右側に「再分析」ボタンを表示
- ハンバーガーメニューを開かずにワンタップで再分析を実行可能に

## Test plan
- [ ] セッションユーザー: トップバー右上に「再分析」ボタンが表示される
- [ ] 非セッションユーザー: ボタンは表示されない
- [ ] ボタンクリックで再分析が開始される
- [ ] モバイルでのボタン配置・タップが問題なく動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6WoSemCevjW93ytejrzm