### PR TITLE
feat: MatchDataにタイムラインアクション追加とtag-partnersエンドポイント新設

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 クライアントは GET /status/{id} でポーリング後、GET /result/{id} で結果取得
 ```
 
-**主要エンドポイント:** `POST /analyze`, `GET /status/{id}`, `GET /result/{id}`, `GET /result/{id}/period`, `GET /period`, `GET /matches`, `GET /session`, `DELETE /session`, `POST /reanalyze`, `GET /health`, `GET /`（静的UI）
+**主要エンドポイント:** `POST /analyze`, `GET /status/{id}`, `GET /result/{id}`, `GET /result/{id}/period`, `GET /period`, `GET /matches`, `GET /tag-partners`, `GET /session`, `DELETE /session`, `POST /reanalyze`, `GET /health`, `GET /`（静的UI）
 
 ## コード構成
 
@@ -83,7 +83,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 - `internal/scraper/` — Collyベースのスクレイパー（`scraper.go`）+ バンダイナムコID認証（`login.go`）
 - `internal/session/` — セッション暗号化（AES-256-GCM）とCookieJarシリアライズ（`crypto.go`, `jar.go`）
 - `internal/firestore/` — Firestoreクライアント初期化（`client.go`）+ matches/tag_partnersの読み書き（タイムラインはmatches内に埋め込み）+ セッション保存（`session.go`）
-- `internal/pipeline/` — 分析パイプライン（`Job`型、ジョブストア、`Run`関数、JSON生成、試合データ配信、セッション永続化）
+- `internal/pipeline/` — 分析パイプライン（`Job`型、ジョブストア、`Run`関数、JSON生成、試合データ配信（`ActionJSON`型でタイムラインイベント展開）、セッション永続化）
 - `internal/server/` — HTTPハンドラ（`server.go`）+ IPベースレート制限（`ratelimit.go`）+ Basic認証（`basicauth.go`）+ 403一時ブロック（`block403.go`）+ セッション管理エンドポイント
 - `scripts/analyze.py` — Python分析: 勝率、与被ダメ比、固定相方検出（K/D・EXダメ・覚醒回数・勝敗パターン付き）、JSON構造化レポート生成
 - `static/index.html` — SPA フロントエンド（ダークテーマ、レスポンシブ対応、カスタムドロップダウン）

--- a/internal/pipeline/matchdata.go
+++ b/internal/pipeline/matchdata.go
@@ -10,34 +10,43 @@ import (
 	"github.com/yuki9431/catalyzer/internal/mslist"
 )
 
+// ActionJSON はタイムラインの個別アクション（MatchData用）
+type ActionJSON struct {
+	Action         string  `json:"action"`
+	ActionStartSec float64 `json:"action_start_sec"`
+	ActionEndSec   float64 `json:"action_end_sec"`
+}
+
 // MatchData はフロントエンド向けの試合データ（プレイヤー視点）
 type MatchData struct {
-	Date            string  `json:"date"`
-	MS              string  `json:"ms"`
-	MSCost          int     `json:"ms_cost,omitempty"`
-	PartnerMS       string  `json:"partner_ms"`
-	PartnerCost     int     `json:"partner_cost,omitempty"`
-	Opponent1MS     string  `json:"opponent1_ms"`
-	Opponent1Cost   int     `json:"opponent1_cost,omitempty"`
-	Opponent2MS     string  `json:"opponent2_ms"`
-	Opponent2Cost   int     `json:"opponent2_cost,omitempty"`
-	Win             bool    `json:"win"`
-	Score           int     `json:"score"`
-	Kills           int     `json:"kills"`
-	Deaths          int     `json:"deaths"`
-	DmgGiven        int     `json:"dmg_given"`
-	DmgTaken        int     `json:"dmg_taken"`
-	ExDmg           int     `json:"ex_dmg"`
-	PartnerName     string  `json:"partner_name"`
-	PartnerScore    int     `json:"partner_score"`
-	PartnerKills    int     `json:"partner_kills"`
-	PartnerDeaths   int     `json:"partner_deaths"`
-	PartnerDmgGiven int     `json:"partner_dmg_given"`
-	PartnerDmgTaken int     `json:"partner_dmg_taken"`
-	PartnerExDmg    int     `json:"partner_ex_dmg"`
-	Bursts          int     `json:"bursts"`
-	PartnerBursts   int     `json:"partner_bursts"`
-	GameEndSec      float64 `json:"game_end_sec,omitempty"`
+	Date            string       `json:"date"`
+	MS              string       `json:"ms"`
+	MSCost          int          `json:"ms_cost,omitempty"`
+	PartnerMS       string       `json:"partner_ms"`
+	PartnerCost     int          `json:"partner_cost,omitempty"`
+	Opponent1MS     string       `json:"opponent1_ms"`
+	Opponent1Cost   int          `json:"opponent1_cost,omitempty"`
+	Opponent2MS     string       `json:"opponent2_ms"`
+	Opponent2Cost   int          `json:"opponent2_cost,omitempty"`
+	Win             bool         `json:"win"`
+	Score           int          `json:"score"`
+	Kills           int          `json:"kills"`
+	Deaths          int          `json:"deaths"`
+	DmgGiven        int          `json:"dmg_given"`
+	DmgTaken        int          `json:"dmg_taken"`
+	ExDmg           int          `json:"ex_dmg"`
+	PartnerName     string       `json:"partner_name"`
+	PartnerScore    int          `json:"partner_score"`
+	PartnerKills    int          `json:"partner_kills"`
+	PartnerDeaths   int          `json:"partner_deaths"`
+	PartnerDmgGiven int          `json:"partner_dmg_given"`
+	PartnerDmgTaken int          `json:"partner_dmg_taken"`
+	PartnerExDmg    int          `json:"partner_ex_dmg"`
+	Bursts          int          `json:"bursts"`
+	PartnerBursts   int          `json:"partner_bursts"`
+	Actions         []ActionJSON `json:"actions"`
+	PartnerActions  []ActionJSON `json:"partner_actions"`
+	GameEndSec      float64      `json:"game_end_sec,omitempty"`
 }
 
 // countBursts はタイムラインから指定グループの覚醒回数を数える。
@@ -52,6 +61,32 @@ func countBursts(timeline *model.MatchTimeline, group string) int {
 		}
 	}
 	return count
+}
+
+// buildActions はMatchTimelineから指定グループのアクションを抽出する。
+func buildActions(timeline *model.MatchTimeline, group string) []ActionJSON {
+	if timeline == nil {
+		return []ActionJSON{}
+	}
+	var actions []ActionJSON
+	for _, e := range timeline.Events {
+		if e.Group != group {
+			continue
+		}
+		action := e.ClassName
+		if e.IsPoint {
+			action = "death"
+		}
+		actions = append(actions, ActionJSON{
+			Action:         action,
+			ActionStartSec: e.StartSec,
+			ActionEndSec:   e.EndSec,
+		})
+	}
+	if actions == nil {
+		return []ActionJSON{}
+	}
+	return actions
 }
 
 // BuildMatchData はDatedScoresをフロントエンド向けの試合データに変換する。
@@ -123,6 +158,8 @@ func BuildMatchData(ds model.DatedScores, costsMap map[string]int, after time.Ti
 			PartnerExDmg:    partner.ExDamage,
 			Bursts:          countBursts(timeline, "team1-1"),
 			PartnerBursts:   countBursts(timeline, "team1-2"),
+			Actions:         buildActions(timeline, "team1-1"),
+			PartnerActions:  buildActions(timeline, "team1-2"),
 			GameEndSec:      gameEndSec,
 		})
 	}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -37,21 +37,21 @@ const prelimFirstBatchSize = 5
 
 // Job はバックグラウンドジョブの情報
 type Job struct {
-	ID                 string           `json:"id"`
-	Status             model.JobStatus  `json:"status"`
-	Message            string           `json:"message,omitempty"`
-	Progress           int              `json:"progress,omitempty"`
-	ProgressTotal      int              `json:"progress_total,omitempty"`
-	Report             string           `json:"report,omitempty"`
-	PreliminaryReport  string           `json:"preliminary_report,omitempty"`
-	PreliminaryVersion int              `json:"preliminary_version,omitempty"`
-	Error              string           `json:"error,omitempty"`
-	PartialData        bool             `json:"partial_data,omitempty"`
-	LoggedIn           bool             `json:"logged_in,omitempty"`
-	UserKey            string           `json:"-"`
-	Remember           bool             `json:"-"`
-	SessionToken       string           `json:"-"`
-	SavedJar           http.CookieJar   `json:"-"`
+	ID                 string          `json:"id"`
+	Status             model.JobStatus `json:"status"`
+	Message            string          `json:"message,omitempty"`
+	Progress           int             `json:"progress,omitempty"`
+	ProgressTotal      int             `json:"progress_total,omitempty"`
+	Report             string          `json:"report,omitempty"`
+	PreliminaryReport  string          `json:"preliminary_report,omitempty"`
+	PreliminaryVersion int             `json:"preliminary_version,omitempty"`
+	Error              string          `json:"error,omitempty"`
+	PartialData        bool            `json:"partial_data,omitempty"`
+	LoggedIn           bool            `json:"logged_in,omitempty"`
+	UserKey            string          `json:"-"`
+	Remember           bool            `json:"-"`
+	SessionToken       string          `json:"-"`
+	SavedJar           http.CookieJar  `json:"-"`
 	completedAt        time.Time
 	cachedScores       model.DatedScores
 	cachedTagPartners  []model.TagPartner
@@ -692,14 +692,7 @@ type playerJSON struct {
 	TeamGradeURL    string       `json:"team_grade_url"`
 	ScoreRanking    int          `json:"score_ranking"`
 	ArcadeName      string       `json:"arcade_name"`
-	Actions         []actionJSON `json:"actions"`
-}
-
-// actionJSON はタイムラインアクション
-type actionJSON struct {
-	Action         string  `json:"action"`
-	ActionStartSec float64 `json:"action_start_sec"`
-	ActionEndSec   float64 `json:"action_end_sec"`
+	Actions         []ActionJSON `json:"actions"`
 }
 
 // saveScoresJSON はDatedScoresを試合単位JSONファイルに保存する（Python分析用）。
@@ -780,11 +773,7 @@ func saveScoresJSON(ds model.DatedScores, path string) error {
 }
 
 // buildPlayerActions はMatchTimelineから特定プレイヤーのアクションを抽出する。
-func buildPlayerActions(timeline *model.MatchTimeline, playerNo int) []actionJSON {
-	if timeline == nil {
-		return []actionJSON{}
-	}
-
+func buildPlayerActions(timeline *model.MatchTimeline, playerNo int) []ActionJSON {
 	groupName := ""
 	switch playerNo {
 	case 1:
@@ -796,26 +785,7 @@ func buildPlayerActions(timeline *model.MatchTimeline, playerNo int) []actionJSO
 	case 4:
 		groupName = "team2-2"
 	}
-
-	var actions []actionJSON
-	for _, e := range timeline.Events {
-		if e.Group != groupName {
-			continue
-		}
-		action := e.ClassName
-		if e.IsPoint {
-			action = "death"
-		}
-		actions = append(actions, actionJSON{
-			Action:         action,
-			ActionStartSec: e.StartSec,
-			ActionEndSec:   e.EndSec,
-		})
-	}
-	if actions == nil {
-		return []actionJSON{}
-	}
-	return actions
+	return buildActions(timeline, groupName)
 }
 
 // mergeScores は既存のscoresに新規scoresをマージする。

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -207,6 +207,11 @@ func StartServer() {
 		handlePeriod(w, r)
 	})
 
+	// GET /tag-partners?user_key=... → タッグ相方情報
+	http.HandleFunc("/tag-partners", func(w http.ResponseWriter, r *http.Request) {
+		handleTagPartners(w, r)
+	})
+
 	// GET /matches?user_key=...&after=... → 試合データ配信（IndexedDBキャッシュ用）
 	http.HandleFunc("/matches", func(w http.ResponseWriter, r *http.Request) {
 		handleMatches(w, r)
@@ -349,6 +354,34 @@ func handlePeriod(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sendRawReport(w, http.StatusOK, report, "", userKey, false)
+}
+
+func handleTagPartners(w http.ResponseWriter, r *http.Request) {
+	userKey := r.URL.Query().Get("user_key")
+	if userKey == "" {
+		sendJSON(w, http.StatusBadRequest, map[string]string{"error": "user_key parameter is required"})
+		return
+	}
+
+	partners, err := firestore.LoadTagPartners(userKey)
+	if err != nil {
+		log.Printf("[ERROR] Failed to load tag partners: %v", err)
+		sendJSON(w, http.StatusInternalServerError, map[string]string{"error": "タッグ相方情報の取得に失敗しました"})
+		return
+	}
+
+	type partnerJSON struct {
+		TeamName   string `json:"team_name"`
+		PlayerName string `json:"player_name"`
+	}
+	result := make([]partnerJSON, len(partners))
+	for i, p := range partners {
+		result[i] = partnerJSON{TeamName: p.TeamName, PlayerName: p.PlayerName}
+	}
+
+	sendJSON(w, http.StatusOK, map[string]interface{}{
+		"tag_partners": result,
+	})
 }
 
 func handleMatches(w http.ResponseWriter, r *http.Request) {

--- a/static/app.js
+++ b/static/app.js
@@ -233,7 +233,7 @@ function jsAvg(arr) { return arr.length ? arr.reduce(function (a, b) { return a 
 function jsWinsLosses(ms) { var w = ms.filter(function (m) { return m.win; }).length; return [w, ms.length - w]; }
 function jsKdRatio(ms) { var k = 0, d = 0; ms.forEach(function (m) { k += m.kills; d += m.deaths; }); return d > 0 ? k / d : 0; }
 function jsAvgBursts(ms) {
-  var valid = ms.filter(function (m) { return m.game_end_sec > 0; });
+  var valid = ms.filter(function (m) { return m.actions && m.actions.length > 0; });
   if (!valid.length) return null;
   return jsAvg(valid.map(function (m) { return m.bursts; }));
 }
@@ -730,7 +730,7 @@ function computeSeason(matches) {
 function computeBurstCount(matches) {
   var byCount = {};
   matches.forEach(function (d) {
-    if (d.game_end_sec === 0) return;
+    if (!d.actions || !d.actions.length) return;
     var count = d.bursts || 0;
     if (!byCount[count]) byCount[count] = [];
     byCount[count].push(d);


### PR DESCRIPTION
## Summary
- MatchDataに`Actions`/`PartnerActions`（生タイムラインイベント配列）を追加し、IndexedDB経由でフロントエンドから先落ち/後落ち分析・抱え落ち分析が可能に
- `GET /tag-partners?user_key=...` エンドポイントを新設し、固定相方のフロント検出に必要なデータを配信
- CLAUDE.mdのエンドポイントリスト・コード構成を更新

## 変更ファイル
- `internal/pipeline/matchdata.go` — `ActionJSON`型、`buildActions`関数、MatchData拡張
- `internal/server/server.go` — `/tag-partners`エンドポイント追加
- `CLAUDE.md` — ドキュメント更新

## データサイズ影響
タイムラインイベントは1試合あたり平均20-40件×3フィールド。2000試合で+200-400KB程度、gzip後は微増。IndexedDBのスキーマバージョン変更不要（フィールド追加のみ）。

## Test plan
- [x] `gofmt` 適用済み
- [x] `go vet ./...` パス
- [x] `go build ./...` パス
- [ ] `/matches`レスポンスに`actions`/`partner_actions`が含まれることを確認
- [ ] `/tag-partners`がFirestoreからtag_partnersを返すことを確認

Refs #294

🤖 Generated with [Claude Code](https://claude.ai/code)