### PR TITLE
feat: Python分析関数のフロントエンド集計移行 (Phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 - `internal/server/` — HTTPハンドラ（`server.go`）+ IPベースレート制限（`ratelimit.go`）+ Basic認証（`basicauth.go`）+ 403一時ブロック（`block403.go`）+ セッション管理エンドポイント
 - `scripts/analyze.py` — Python分析: 勝率、与被ダメ比、固定相方検出（K/D・EXダメ・覚醒回数・勝敗パターン付き）、JSON構造化レポート生成
 - `static/index.html` — SPA フロントエンド（ダークテーマ、レスポンシブ対応、カスタムドロップダウン）
-- `static/app.js` — フロントエンドJS（CSP対応で外部化。htm/Preactでレンダリング）。主要コンポーネント: Report（状態管理）、HamburgerMenu（左ドロワー）、MsSelector/LensToggle（トップバーフィルタ）、5タブ構成（OverviewPane/PlaystylePane/BurstPane/MatchupPane/TimePane）、FixedPartnerPanel（レンズ対応6軸レーダー）、各種Chart/集計関数
+- `static/app.js` — フロントエンドJS（CSP対応で外部化。htm/Preactでレンダリング）。主要コンポーネント: Report（状態管理）、HamburgerMenu（左ドロワー）、MsSelector/LensToggle（トップバーフィルタ）、5タブ構成（OverviewPane/PlaystylePane/BurstPane/MatchupPane/TimePane）、FixedPartnerPanel（レンズ対応6軸レーダー）、各種Chart/集計関数。フロントエンド集計（Phase 1: 時間帯/曜日/日別、Phase 2: 基本データ/勝敗パターン/敵相性/相方/コスト編成/MS編成/ダメージ貢献/被撃墜影響/シーズン/覚醒回数）でIndexedDBの試合データからリアルタイム集計、Python分析へのフォールバック付き
 - `static/htm-preact-standalone.js` — htm + Preact ライブラリ（スタンドアロン版）
 - `static/chart.umd.min.js` — Chart.js ライブラリ（グラフ描画用）
 - `static/preview.html` — フロントエンド開発用プレビュー（gitignore対象）

--- a/static/app.js
+++ b/static/app.js
@@ -225,6 +225,551 @@ function computeDailyTrend(matches) {
   return { days: results, tips: tips };
 }
 
+// --- Phase 2 Frontend Aggregation ---
+var COST_LABEL = {3000: '3000コスト', 2500: '2500コスト', 2000: '2000コスト', 1500: '1500コスト'};
+var COST_FATAL_DEATHS = {3000: 2, 2500: 3, 2000: 3, 1500: 4};
+
+function jsAvg(arr) { return arr.length ? arr.reduce(function (a, b) { return a + b; }, 0) / arr.length : 0; }
+function jsWinsLosses(ms) { var w = ms.filter(function (m) { return m.win; }).length; return [w, ms.length - w]; }
+function jsKdRatio(ms) { var k = 0, d = 0; ms.forEach(function (m) { k += m.kills; d += m.deaths; }); return d > 0 ? k / d : 0; }
+function jsAvgBursts(ms) {
+  var valid = ms.filter(function (m) { return m.game_end_sec > 0; });
+  if (!valid.length) return null;
+  return jsAvg(valid.map(function (m) { return m.bursts; }));
+}
+function round2(n) { return Math.round(n * 100) / 100; }
+
+function computeBasicStats(matches) {
+  var n = matches.length;
+  var wl = jsWinsLosses(matches);
+  var w = wl[0], l = wl[1];
+  var wr = n > 0 ? w / n * 100 : 0;
+  var kd = jsKdRatio(matches);
+  var eff = jsDmgEfficiency(matches);
+  var ab = jsAvgBursts(matches);
+
+  var tips = [];
+  if (eff < 1.0) {
+    tips.push('与被ダメ比 **' + round3(eff) + '** → 被ダメ超過。被弾を減らす立ち回りを意識');
+  } else if (eff >= 1.2) {
+    tips.push('与被ダメ比 **' + round3(eff) + '** → 優秀。この調子を維持');
+  }
+  if (kd < 1.0) {
+    tips.push('K/D比 **' + round2(kd) + '** → 1.0未満。撃墜↑ or 被撃墜↓を意識');
+  }
+
+  return {
+    matches: n,
+    wins: w,
+    losses: l,
+    win_rate: round1(wr),
+    avg_dmg_given: Math.round(jsAvg(matches.map(function (m) { return m.dmg_given; }))),
+    avg_dmg_taken: Math.round(jsAvg(matches.map(function (m) { return m.dmg_taken; }))),
+    dmg_efficiency: round3(eff),
+    avg_kills: round2(jsAvg(matches.map(function (m) { return m.kills; }))),
+    avg_deaths: round2(jsAvg(matches.map(function (m) { return m.deaths; }))),
+    kd_ratio: round2(kd),
+    avg_ex_dmg: Math.round(jsAvg(matches.map(function (m) { return m.ex_dmg; }))),
+    avg_bursts: ab !== null ? round2(ab) : null,
+    tips: tips,
+  };
+}
+
+function computeWinLossPattern(matches) {
+  var wins = matches.filter(function (m) { return m.win; });
+  var losses = matches.filter(function (m) { return !m.win; });
+
+  function kdOf(rows) {
+    var tk = 0, td = 0;
+    rows.forEach(function (d) { tk += d.kills; td += d.deaths; });
+    return td > 0 ? tk / td : 0;
+  }
+  function avgOf(key, rows) { return rows.length ? jsAvg(rows.map(function (d) { return d[key]; })) : 0; }
+
+  var metrics = [];
+  function addMetric(label, w, l, nd) {
+    var factor = Math.pow(10, nd);
+    metrics.push({
+      label: label,
+      win_avg: w !== null ? Math.round(w * factor) / factor : null,
+      loss_avg: l !== null ? Math.round(l * factor) / factor : null,
+      diff: (w !== null && l !== null) ? Math.round((w - l) * factor) / factor : null,
+    });
+  }
+
+  addMetric('平均与ダメージ', avgOf('dmg_given', wins), avgOf('dmg_given', losses), 1);
+  addMetric('平均被ダメージ', avgOf('dmg_taken', wins), avgOf('dmg_taken', losses), 1);
+  addMetric('与被ダメ比', wins.length ? jsDmgEfficiency(wins) : 0, losses.length ? jsDmgEfficiency(losses) : 0, 3);
+  addMetric('平均撃墜', avgOf('kills', wins), avgOf('kills', losses), 2);
+  addMetric('平均被撃墜', avgOf('deaths', wins), avgOf('deaths', losses), 2);
+  addMetric('K/D比', wins.length ? kdOf(wins) : 0, losses.length ? kdOf(losses) : 0, 2);
+  addMetric('平均EXダメージ', avgOf('ex_dmg', wins), avgOf('ex_dmg', losses), 1);
+  addMetric('平均覚醒回数', jsAvgBursts(wins), jsAvgBursts(losses), 2);
+
+  var tips = [];
+  var lDeaths = losses.length ? jsAvg(losses.map(function (d) { return d.deaths; })) : 0;
+  var lTaken = losses.length ? jsAvg(losses.map(function (d) { return d.dmg_taken; })) : 0;
+  if (lDeaths >= 1.5) {
+    tips.push('敗北時の平均被撃墜 **' + round1(lDeaths) + '回** → 耐久管理を意識');
+  }
+  if (lTaken >= 1100) {
+    tips.push('敗北時の平均被ダメ **' + Math.round(lTaken) + '** → 無駄な被弾を減らすのが改善の鍵');
+  }
+
+  // コスト帯別
+  var costGroups = {};
+  matches.forEach(function (d) {
+    var cost = d.ms_cost || 0;
+    if (COST_LABEL[cost]) {
+      if (!costGroups[cost]) costGroups[cost] = [];
+      costGroups[cost].push(d);
+    }
+  });
+
+  var costPatterns = [];
+  var costKeys = Object.keys(costGroups).map(Number).sort(function (a, b) { return b - a; });
+  costKeys.forEach(function (cost) {
+    var data = costGroups[cost];
+    if (data.length < 3) return;
+    var cWins = data.filter(function (d) { return d.win; });
+    var cLosses = data.filter(function (d) { return !d.win; });
+    if (!cWins.length || !cLosses.length) return;
+
+    var fatal = COST_FATAL_DEATHS[cost];
+    var fatalLosses = cLosses.filter(function (d) { return d.deaths >= fatal; });
+
+    var costMetrics = [];
+    [['与ダメージ', 'dmg_given'], ['被ダメージ', 'dmg_taken'], ['撃墜', 'kills'], ['被撃墜', 'deaths']].forEach(function (pair) {
+      var mLabel = pair[0], key = pair[1];
+      var wV = jsAvg(cWins.map(function (d) { return d[key]; }));
+      var lV = jsAvg(cLosses.map(function (d) { return d[key]; }));
+      costMetrics.push({ label: mLabel, win_avg: round1(wV), loss_avg: round1(lV), diff: round1(wV - lV) });
+    });
+    var cWEff = jsDmgEfficiency(cWins);
+    var cLEff = jsDmgEfficiency(cLosses);
+    costMetrics.push({ label: '与被ダメ比', win_avg: round3(cWEff), loss_avg: round3(cLEff), diff: round3(cWEff - cLEff) });
+
+    costPatterns.push({
+      cost: cost,
+      cost_label: COST_LABEL[cost],
+      matches: data.length,
+      win_rate: round1(jsWinRate(data)),
+      metrics: costMetrics,
+      fatal_deaths: fatal,
+      fatal_loss_count: fatalLosses.length,
+      fatal_loss_total: cLosses.length,
+      fatal_loss_rate: cLosses.length ? Math.round(fatalLosses.length / cLosses.length * 100) : 0,
+    });
+  });
+
+  return { metrics: metrics, tips: tips, cost_patterns: costPatterns };
+}
+
+function computeEnemyMatchup(matches, minMatches) {
+  if (minMatches === undefined) minMatches = 3;
+  var enemyStats = {};
+  matches.forEach(function (d) {
+    [d.opponent1_ms, d.opponent2_ms].forEach(function (ems) {
+      if (!ems) return;
+      if (!enemyStats[ems]) enemyStats[ems] = [];
+      enemyStats[ems].push(d);
+    });
+  });
+
+  var results = [];
+  Object.keys(enemyStats).forEach(function (ms) {
+    var ms_matches = enemyStats[ms];
+    if (ms_matches.length >= minMatches) {
+      var wr = jsWinRate(ms_matches);
+      var eff = jsDmgEfficiency(ms_matches);
+      var avgGiven = jsAvg(ms_matches.map(function (d) { return d.dmg_given; }));
+      var avgTaken = jsAvg(ms_matches.map(function (d) { return d.dmg_taken; }));
+      results.push({
+        ms: ms,
+        matches: ms_matches.length,
+        win_rate: round1(wr),
+        dmg_efficiency: round3(eff),
+        avg_dmg_given: Math.round(avgGiven),
+        avg_dmg_taken: Math.round(avgTaken),
+      });
+    }
+  });
+
+  var strong = results.filter(function (r) { return r.win_rate >= 60; }).sort(function (a, b) { return b.matches - a.matches; });
+  var weak = results.filter(function (r) { return r.win_rate <= 40; }).sort(function (a, b) { return b.matches - a.matches; });
+  var even = results.filter(function (r) { return r.win_rate > 40 && r.win_rate < 60; }).sort(function (a, b) { return b.matches - a.matches; });
+
+  var tips = [];
+  if (weak.length) {
+    var highDmgTaken = weak.filter(function (r) { return r.avg_dmg_taken >= 1200; });
+    if (highDmgTaken.length) {
+      tips.push({ text: '被ダメが多い相手 → 距離管理を見直し', details: highDmgTaken.slice(0, 3).map(function (r) { return '**' + r.ms + '** 被ダメ ' + r.avg_dmg_taken; }) });
+    }
+    var lowDmgGiven = weak.filter(function (r) { return r.avg_dmg_given <= 900; });
+    if (lowDmgGiven.length) {
+      tips.push({ text: '与ダメが低い相手 → 手数や当て方を工夫', details: lowDmgGiven.slice(0, 3).map(function (r) { return '**' + r.ms + '** 与ダメ ' + r.avg_dmg_given; }) });
+    }
+  }
+
+  return { strong: strong, weak: weak, even: even, tips: tips };
+}
+
+function computePartner(matches, minMatches) {
+  if (minMatches === undefined) minMatches = 3;
+  var partnerStats = {};
+  matches.forEach(function (d) {
+    var pms = d.partner_ms;
+    if (!pms) return;
+    if (!partnerStats[pms]) partnerStats[pms] = [];
+    partnerStats[pms].push(d);
+  });
+
+  var results = [];
+  Object.keys(partnerStats).forEach(function (ms) {
+    var ms_matches = partnerStats[ms];
+    if (ms_matches.length >= minMatches) {
+      results.push({
+        ms: ms,
+        matches: ms_matches.length,
+        win_rate: round1(jsWinRate(ms_matches)),
+        dmg_efficiency: round3(jsDmgEfficiency(ms_matches)),
+      });
+    }
+  });
+  results.sort(function (a, b) { return b.matches - a.matches; });
+  return results;
+}
+
+function computeCostPair(matches, minMatches) {
+  if (minMatches === undefined) minMatches = 3;
+  var pairs = {};
+  matches.forEach(function (d) {
+    var msName = d.ms || '(不明)';
+    var partnerCost = d.partner_cost || 0;
+    if (msName && partnerCost) {
+      var key = msName + ' + ' + partnerCost;
+      if (!pairs[key]) pairs[key] = [];
+      pairs[key].push(d);
+    }
+  });
+
+  var results = [];
+  Object.keys(pairs).forEach(function (pair) {
+    var ms_matches = pairs[pair];
+    if (ms_matches.length >= minMatches) {
+      results.push({
+        pair: pair,
+        matches: ms_matches.length,
+        win_rate: round1(jsWinRate(ms_matches)),
+        dmg_efficiency: round3(jsDmgEfficiency(ms_matches)),
+      });
+    }
+  });
+  results.sort(function (a, b) { return b.matches - a.matches; });
+  return results;
+}
+
+function computeMsPair(matches, minMatches, topN) {
+  if (minMatches === undefined) minMatches = 3;
+  if (topN === undefined) topN = 10;
+  var pairs = {};
+  matches.forEach(function (d) {
+    var key = d.ms + ' + ' + d.partner_ms;
+    if (!pairs[key]) pairs[key] = [];
+    pairs[key].push(d);
+  });
+
+  var results = [];
+  Object.keys(pairs).forEach(function (pair) {
+    var ms_matches = pairs[pair];
+    if (ms_matches.length >= minMatches) {
+      var wl = jsWinsLosses(ms_matches);
+      results.push({
+        pair: pair,
+        matches: ms_matches.length,
+        wins: wl[0],
+        losses: wl[1],
+        win_rate: round1(jsWinRate(ms_matches)),
+        dmg_efficiency: round3(jsDmgEfficiency(ms_matches)),
+      });
+    }
+  });
+
+  var byWr = results.slice().sort(function (a, b) { return a.win_rate !== b.win_rate ? b.win_rate - a.win_rate : b.matches - a.matches; }).slice(0, topN);
+  var byCount = results.slice().sort(function (a, b) { return a.matches !== b.matches ? b.matches - a.matches : b.win_rate - a.win_rate; }).slice(0, topN);
+
+  return { by_win_rate: byWr, by_matches: byCount };
+}
+
+function computeDmgContribution(matches, minMatches) {
+  if (minMatches === undefined) minMatches = 3;
+  var contribs = [];
+  var winContribs = [];
+  var loseContribs = [];
+  matches.forEach(function (d) {
+    var teamTotal = d.dmg_given + d.partner_dmg_given;
+    if (teamTotal > 0) {
+      var c = d.dmg_given / teamTotal * 100;
+      contribs.push(c);
+      if (d.win) { winContribs.push(c); } else { loseContribs.push(c); }
+    }
+  });
+  var avgContrib = contribs.length ? jsAvg(contribs) : 0;
+  var avgWin = winContribs.length ? jsAvg(winContribs) : 0;
+  var avgLose = loseContribs.length ? jsAvg(loseContribs) : 0;
+
+  // コスト帯別
+  var costGroups = {};
+  matches.forEach(function (d) {
+    var cost = d.ms_cost || 0;
+    if (COST_LABEL[cost]) {
+      if (!costGroups[cost]) costGroups[cost] = [];
+      costGroups[cost].push(d);
+    }
+  });
+
+  var costData = [];
+  var costKeys = Object.keys(costGroups).map(Number);
+  var hasMultiple = costKeys.length > 1 || costKeys.some(function (k) { return costGroups[k].length >= minMatches; });
+  if (hasMultiple) {
+    costKeys.sort(function (a, b) { return b - a; }).forEach(function (cost) {
+      var data = costGroups[cost];
+      if (data.length < minMatches) return;
+      var cAll = [], cWin = [], cLose = [];
+      data.forEach(function (d) {
+        var teamTotal = d.dmg_given + d.partner_dmg_given;
+        if (teamTotal > 0) {
+          var c = d.dmg_given / teamTotal * 100;
+          cAll.push(c);
+          if (d.win) { cWin.push(c); } else { cLose.push(c); }
+        }
+      });
+      costData.push({
+        cost: cost,
+        cost_label: COST_LABEL[cost],
+        matches: data.length,
+        avg_contribution: cAll.length ? round1(jsAvg(cAll)) : 0,
+        avg_win_contribution: cWin.length ? round1(jsAvg(cWin)) : 0,
+        avg_lose_contribution: cLose.length ? round1(jsAvg(cLose)) : 0,
+      });
+    });
+  }
+
+  return {
+    avg_contribution: round1(avgContrib),
+    avg_win_contribution: round1(avgWin),
+    avg_lose_contribution: round1(avgLose),
+    by_cost: costData,
+  };
+}
+
+function computeDeathsImpact(matches) {
+  var costGroups = {};
+  matches.forEach(function (d) {
+    var cost = d.ms_cost || 0;
+    if (COST_FATAL_DEATHS[cost]) {
+      if (!costGroups[cost]) costGroups[cost] = [];
+      costGroups[cost].push(d);
+    }
+  });
+
+  var results = [];
+  var costKeys = Object.keys(costGroups).map(Number).sort(function (a, b) { return b - a; });
+  costKeys.forEach(function (cost) {
+    var data = costGroups[cost];
+    var fatal = COST_FATAL_DEATHS[cost];
+    var maxBucket = fatal + 1;
+
+    var byDeaths = {};
+    data.forEach(function (d) {
+      var deaths = d.deaths;
+      var key = deaths >= maxBucket ? (maxBucket + '+') : String(deaths);
+      if (!byDeaths[key]) byDeaths[key] = [];
+      byDeaths[key].push(d);
+    });
+
+    var buckets = [];
+    for (var i = 0; i < fatal; i++) {
+      var key = String(i);
+      if (byDeaths[key]) {
+        var bMatches = byDeaths[key];
+        var wr = jsWinRate(bMatches);
+        var eff = jsDmgEfficiency(bMatches);
+        buckets.push({
+          deaths: i,
+          label: i + '落ち',
+          matches: bMatches.length,
+          win_rate: round1(wr),
+          dmg_efficiency: round3(eff),
+          status: i === fatal - 1 ? 'danger' : 'safe',
+        });
+      }
+    }
+
+    var fatalCount = 0;
+    for (var j = fatal; j < maxBucket; j++) {
+      fatalCount += (byDeaths[String(j)] || []).length;
+    }
+    fatalCount += (byDeaths[maxBucket + '+'] || []).length;
+
+    var safeData = [];
+    for (var k = 0; k < fatal; k++) {
+      safeData = safeData.concat(byDeaths[String(k)] || []);
+    }
+    var safeWr = safeData.length ? jsWinRate(safeData) : 0;
+
+    var tips = [];
+    if (fatalCount > 0 && data.length > 0) {
+      tips.push(fatal + '落ち以上 **' + fatalCount + '/' + data.length + '戦**（' + Math.round(fatalCount / data.length * 100) + '%）');
+    }
+    if (safeData.length) {
+      tips.push((fatal - 1) + '落ち以内の勝率 **' + round1(safeWr) + '%**');
+    }
+
+    results.push({
+      cost: cost,
+      cost_label: COST_LABEL[cost],
+      matches: data.length,
+      fatal_deaths: fatal,
+      fatal_cost: cost * fatal,
+      buckets: buckets,
+      tips: tips,
+    });
+  });
+
+  return results;
+}
+
+function computeSeason(matches) {
+  function getSeason(dateStr) {
+    var parts = dateStr.substring(0, 10).split('-');
+    var year = parseInt(parts[0], 10);
+    var m = parseInt(parts[1], 10);
+    var startMonth, sYear;
+    if (m === 12) {
+      startMonth = 12; sYear = year;
+    } else if (m % 2 === 0) {
+      startMonth = m; sYear = year;
+    } else {
+      if (m === 1) { startMonth = 12; sYear = year - 1; }
+      else { startMonth = m - 1; sYear = year; }
+    }
+    var endMonth = startMonth < 12 ? startMonth + 1 : 1;
+    var endYear = startMonth < 12 ? sYear : sYear + 1;
+    if (startMonth === 12) {
+      return sYear + '年' + startMonth + '月-' + endYear + '年' + endMonth + '月';
+    }
+    return sYear + '年' + startMonth + '-' + endMonth + '月';
+  }
+
+  function getSeasonHalf(dateStr) {
+    var m = parseInt(dateStr.substring(5, 7), 10);
+    return (m === 12 || m % 2 === 0) ? '前半' : '後半';
+  }
+
+  var seasonData = {};
+  var seasonHalf = {};
+
+  matches.forEach(function (d) {
+    var s = getSeason(d.date);
+    var h = getSeasonHalf(d.date);
+    if (!seasonData[s]) seasonData[s] = [];
+    seasonData[s].push(d);
+    if (!seasonHalf[s]) seasonHalf[s] = {};
+    if (!seasonHalf[s][h]) seasonHalf[s][h] = [];
+    seasonHalf[s][h].push(d);
+  });
+
+  var results = [];
+  Object.keys(seasonData).sort().forEach(function (seasonName) {
+    var data = seasonData[seasonName];
+    var firstHalf = (seasonHalf[seasonName] && seasonHalf[seasonName]['前半']) || [];
+    var secondHalf = (seasonHalf[seasonName] && seasonHalf[seasonName]['後半']) || [];
+
+    var tips = [];
+    if (firstHalf.length && secondHalf.length) {
+      var fWr = jsWinRate(firstHalf);
+      var sWr = jsWinRate(secondHalf);
+      var diff = sWr - fWr;
+      if (Math.abs(diff) >= 5) {
+        if (diff > 0) {
+          tips.push('後半が **+' + Math.round(diff) + '%** → シーズン後半に安定');
+        } else {
+          tips.push('前半が **+' + Math.round(-diff) + '%** → 後半は対戦環境が厳しくなった可能性');
+        }
+      }
+    }
+
+    var entry = {
+      name: seasonName,
+      matches: data.length,
+      win_rate: round1(jsWinRate(data)),
+      dmg_efficiency: round3(jsDmgEfficiency(data)),
+      tips: tips,
+    };
+    if (firstHalf.length) {
+      entry.first_half = {
+        matches: firstHalf.length,
+        win_rate: round1(jsWinRate(firstHalf)),
+        dmg_efficiency: round3(jsDmgEfficiency(firstHalf)),
+      };
+    }
+    if (secondHalf.length) {
+      entry.second_half = {
+        matches: secondHalf.length,
+        win_rate: round1(jsWinRate(secondHalf)),
+        dmg_efficiency: round3(jsDmgEfficiency(secondHalf)),
+      };
+    }
+    results.push(entry);
+  });
+
+  return results;
+}
+
+function computeBurstCount(matches) {
+  var byCount = {};
+  matches.forEach(function (d) {
+    if (d.game_end_sec === 0) return;
+    var count = d.bursts || 0;
+    if (!byCount[count]) byCount[count] = [];
+    byCount[count].push(d);
+  });
+
+  var countKeys = Object.keys(byCount).map(Number);
+  if (!countKeys.length) return null;
+
+  var results = [];
+  countKeys.sort(function (a, b) { return a - b; }).forEach(function (count) {
+    var bMatches = byCount[count];
+    var wr = jsWinRate(bMatches);
+    results.push({
+      count: count,
+      label: count > 0 ? count + '回' : '0回（未覚醒）',
+      matches: bMatches.length,
+      win_rate: round1(wr),
+    });
+  });
+
+  var tips = [];
+  if (byCount[2] && byCount[2].length >= 3) {
+    var wr2 = jsWinRate(byCount[2]);
+    var others = [];
+    Object.keys(byCount).forEach(function (c) {
+      if (Number(c) < 2) { others = others.concat(byCount[c]); }
+    });
+    if (others.length) {
+      var wrOther = jsWinRate(others);
+      var diff = wr2 - wrOther;
+      if (diff > 0) {
+        tips.push('2回覚醒できた試合の勝率が **' + Math.round(diff) + '%** 高い → ゲージ管理と耐久管理が重要');
+      }
+    }
+  }
+
+  return { by_count: results, tips: tips };
+}
+
 // --- Utility ---
 function esc(s) {
   if (s == null) return '';
@@ -1849,8 +2394,8 @@ function FixedPartnerPanel({ fp, fpItems, lens }) {
 
 // --- Tab panes ---
 
-function OverviewPane({ pd, selectedMs, lens, allPd }) {
-  var seasons = allPd.season || [];
+function OverviewPane({ pd, selectedMs, lens, allPd, frontendData }) {
+  var seasons = (frontendData && frontendData.season) || allPd.season || [];
   var msStats = allPd.ms_stats || {};
   var msEntries = Object.keys(msStats).sort(function (a, b) { return msStats[b].matches - msStats[a].matches; });
   var compareEntries = msEntries.map(function (name) {
@@ -1868,7 +2413,7 @@ function OverviewPane({ pd, selectedMs, lens, allPd }) {
       <${BasicLensSection} basic=${pd.basic_stats} pattern=${pd.win_loss_pattern} lens=${lens} />
     <//>`}
 
-    ${!selectedMs && seasons.length > 0 && html`<${Panel} title="シーズン別分析">
+    ${(!selectedMs || frontendData) && seasons.length > 0 && html`<${Panel} title="シーズン別分析">
       ${seasons.length > 1 && html`<${SeasonChart} seasons=${seasons} />`}
       ${seasons.map(function (s) {
         var rows = [['全体', s.matches, colorPct(s.win_rate), colorDE(s.dmg_efficiency, 3)]];
@@ -1937,9 +2482,13 @@ function TimePane({ pd, selectedMs, usingFrontend }) {
 
 // --- New tab panes ---
 
-function PlaystylePane({ msStats, selectedMs }) {
+function PlaystylePane({ msStats, selectedMs, frontendData }) {
   var deaths, fallOrder, dmg;
-  if (selectedMs && msStats[selectedMs]) {
+  if (frontendData) {
+    deaths = frontendData.deaths_impact;
+    dmg = frontendData.dmg_contribution;
+    fallOrder = (selectedMs && msStats[selectedMs]) ? msStats[selectedMs].fall_order : aggregateFallOrder(msStats);
+  } else if (selectedMs && msStats[selectedMs]) {
     var ms = msStats[selectedMs];
     deaths = ms.deaths_impact;
     fallOrder = ms.fall_order;
@@ -1987,9 +2536,12 @@ function PlaystylePane({ msStats, selectedMs }) {
   </div>`;
 }
 
-function BurstPane({ msStats, selectedMs }) {
+function BurstPane({ msStats, selectedMs, frontendData }) {
   var burstCount, burstHold;
-  if (selectedMs && msStats[selectedMs]) {
+  if (frontendData) {
+    burstCount = frontendData.burst_count;
+    burstHold = (selectedMs && msStats[selectedMs]) ? msStats[selectedMs].burst_hold_death : aggregateBurstHoldDeath(msStats);
+  } else if (selectedMs && msStats[selectedMs]) {
     var ms = msStats[selectedMs];
     burstCount = ms.burst_count;
     burstHold = ms.burst_hold_death;
@@ -2024,35 +2576,49 @@ function BurstPane({ msStats, selectedMs }) {
   </div>`;
 }
 
-function MatchupPane({ msStats, selectedMs }) {
-  if (selectedMs && msStats[selectedMs]) {
+function MatchupPane({ msStats, selectedMs, frontendData }) {
+  var enemyMatchup, partnerData, msPairData, costPairData;
+
+  if (frontendData) {
+    enemyMatchup = frontendData.enemy_matchup;
+    partnerData = frontendData.partner;
+    costPairData = frontendData.cost_pair;
+    msPairData = frontendData.ms_pair;
+  } else if (selectedMs && msStats[selectedMs]) {
     var ms = msStats[selectedMs];
-    var enemyStrong = (ms.enemy_matchup && ms.enemy_matchup.strong || []).slice(0, 10).map(function (e) { return { name: e.ms, winRate: e.win_rate }; });
-    var enemyWeak = (ms.enemy_matchup && ms.enemy_matchup.weak || []).slice(0, 10).map(function (e) { return { name: e.ms, winRate: e.win_rate }; });
-    var partnerEntries = (ms.partner || []).slice(0, 10).map(function (p) { return { name: p.ms, winRate: p.win_rate }; });
-    var msPairEntries = (ms.ms_pair && ms.ms_pair.by_matches || []).slice(0, 10).map(function (p) { return { name: p.pair, winRate: p.win_rate }; });
-    var costPairEntries = (ms.cost_pair || []).map(function (p) { return { name: p.pair, winRate: p.win_rate }; });
+    enemyMatchup = ms.enemy_matchup;
+    partnerData = ms.partner;
+    msPairData = ms.ms_pair;
+    costPairData = ms.cost_pair;
+  }
+
+  if (enemyMatchup || partnerData || msPairData || costPairData) {
+    var enemyStrong = (enemyMatchup && enemyMatchup.strong || []).slice(0, 10).map(function (e) { return { name: e.ms, winRate: e.win_rate }; });
+    var enemyWeak = (enemyMatchup && enemyMatchup.weak || []).slice(0, 10).map(function (e) { return { name: e.ms, winRate: e.win_rate }; });
+    var partnerEntries = (partnerData || []).slice(0, 10).map(function (p) { return { name: p.ms, winRate: p.win_rate }; });
+    var msPairEntries = (msPairData && msPairData.by_matches || []).slice(0, 10).map(function (p) { return { name: p.pair, winRate: p.win_rate }; });
+    var costPairEntries = (costPairData || []).map(function (p) { return { name: p.pair, winRate: p.win_rate }; });
 
     return html`<div class="tabpane">
-      ${ms.enemy_matchup && html`<${Panel} title="敵機体との相性">
+      ${enemyMatchup && html`<${Panel} title="敵機体との相性">
         ${enemyStrong.length > 0 && html`<h3>得意な相手</h3><${MsCompareChart} entries=${enemyStrong} />`}
         ${enemyWeak.length > 0 && html`<h3>苦手な相手</h3><${MsCompareChart} entries=${enemyWeak} />`}
-        <${EnemyMatchupSection} matchup=${ms.enemy_matchup} />
+        <${EnemyMatchupSection} matchup=${enemyMatchup} />
       <//>`}
 
-      ${ms.partner && ms.partner.length > 0 && html`<${Panel} title="相方機体との相性">
+      ${partnerData && partnerData.length > 0 && html`<${Panel} title="相方機体との相性">
         <${MsCompareChart} entries=${partnerEntries} />
-        <${PartnerSection} partners=${ms.partner} />
+        <${PartnerSection} partners=${partnerData} />
       <//>`}
 
-      ${ms.ms_pair && html`<${Panel} title="編成別勝率">
+      ${msPairData && html`<${Panel} title="編成別勝率">
         ${msPairEntries.length > 0 && html`<${MsCompareChart} entries=${msPairEntries} />`}
-        <${MsPairSubSection} msPair=${ms.ms_pair} />
+        <${MsPairSubSection} msPair=${msPairData} />
       <//>`}
 
-      ${ms.cost_pair && ms.cost_pair.length > 0 && html`<${Panel} title="コスト編成別勝率">
+      ${costPairData && costPairData.length > 0 && html`<${Panel} title="コスト編成別勝率">
         <${MsCompareChart} entries=${costPairEntries} />
-        <${CostPairSubSection} costPair=${ms.cost_pair} />
+        <${CostPairSubSection} costPair=${costPairData} />
       <//>`}
     </div>`;
   }
@@ -2312,7 +2878,7 @@ function Report({ data, userKey }) {
     return { basic_stats: ms.basic_stats, win_loss_pattern: ms.win_loss_pattern };
   }, [pd, selectedMs]);
 
-  var frontendTimeData = useMemo(function () {
+  var frontendData = useMemo(function () {
     if (!allMatches || !allMatches.length) return null;
     if (selectedPeriod === 'custom') return null;
     var filtered = allMatches;
@@ -2324,6 +2890,16 @@ function Report({ data, userKey }) {
       time_of_day: computeTimeOfDay(filtered),
       day_of_week: computeDayOfWeek(filtered),
       daily_trend: computeDailyTrend(filtered),
+      season: computeSeason(filtered),
+      basic_stats: computeBasicStats(filtered),
+      win_loss_pattern: computeWinLossPattern(filtered),
+      enemy_matchup: computeEnemyMatchup(filtered),
+      partner: computePartner(filtered),
+      cost_pair: computeCostPair(filtered),
+      ms_pair: computeMsPair(filtered),
+      dmg_contribution: computeDmgContribution(filtered),
+      deaths_impact: computeDeathsImpact(filtered),
+      burst_count: computeBurstCount(filtered),
     };
   }, [allMatches, selectedPeriod, selectedMs]);
 
@@ -2334,18 +2910,23 @@ function Report({ data, userKey }) {
     setSelectedPeriod('custom');
   }
 
+  var fePd = useMemo(function () {
+    if (!frontendData) return effectivePd;
+    return { basic_stats: frontendData.basic_stats, win_loss_pattern: frontendData.win_loss_pattern };
+  }, [frontendData, effectivePd]);
+
   var pane;
   if (activeTab === 'playstyle') {
-    pane = html`<${PlaystylePane} msStats=${msStats} selectedMs=${selectedMs} />`;
+    pane = html`<${PlaystylePane} msStats=${msStats} selectedMs=${selectedMs} frontendData=${frontendData} />`;
   } else if (activeTab === 'burst') {
-    pane = html`<${BurstPane} msStats=${msStats} selectedMs=${selectedMs} />`;
+    pane = html`<${BurstPane} msStats=${msStats} selectedMs=${selectedMs} frontendData=${frontendData} />`;
   } else if (activeTab === 'matchup') {
-    pane = html`<${MatchupPane} msStats=${msStats} selectedMs=${selectedMs} />`;
+    pane = html`<${MatchupPane} msStats=${msStats} selectedMs=${selectedMs} frontendData=${frontendData} />`;
   } else if (activeTab === 'time') {
-    var timePd = frontendTimeData ? { time_of_day: frontendTimeData.time_of_day, day_of_week: frontendTimeData.day_of_week, daily_trend: frontendTimeData.daily_trend } : pd;
-    pane = html`<${TimePane} pd=${timePd} selectedMs=${selectedMs} usingFrontend=${!!frontendTimeData} />`;
+    var timePd = frontendData ? { time_of_day: frontendData.time_of_day, day_of_week: frontendData.day_of_week, daily_trend: frontendData.daily_trend, season: frontendData.season } : pd;
+    pane = html`<${TimePane} pd=${timePd} selectedMs=${selectedMs} usingFrontend=${!!frontendData} />`;
   } else {
-    pane = html`<${OverviewPane} pd=${effectivePd} selectedMs=${selectedMs} lens=${lens} allPd=${pd} />`;
+    pane = html`<${OverviewPane} pd=${fePd} selectedMs=${selectedMs} lens=${lens} allPd=${pd} frontendData=${frontendData} />`;
   }
 
   return html`
@@ -2370,7 +2951,7 @@ function Report({ data, userKey }) {
       hasSession=${!!localStorage.getItem('catalyzer_has_session')}
       onLogout=${logout} />
 
-    <${KpiGrid} stats=${effectivePd.basic_stats} />
+    <${KpiGrid} stats=${fePd.basic_stats} />
 
     ${pane}
 


### PR DESCRIPTION
## Summary
- Python分析の10関数をJSに移行し、IndexedDBの試合データからリアルタイム集計を実現
- MS選択・期間フィルタの完全対応（全5タブ）
- Python分析データへのフォールバック機能を維持

## 移行した関数
| Python関数 | JS関数 | タブ |
|---|---|---|
| `data_basic_stats` | `computeBasicStats` | Overview |
| `data_win_loss_pattern` | `computeWinLossPattern` | Overview |
| `data_enemy_matchup` | `computeEnemyMatchup` | Matchup |
| `data_partner` | `computePartner` | Matchup |
| `data_cost_pair` | `computeCostPair` | Matchup |
| `data_ms_pair` | `computeMsPair` | Matchup |
| `data_dmg_contribution` | `computeDmgContribution` | Playstyle |
| `data_deaths_impact` | `computeDeathsImpact` | Playstyle |
| `data_season` | `computeSeason` | Time |
| `data_burst_count` | `computeBurstCount` | Burst |

## 設計
- `frontendTimeData` を `frontendData` にリネーム・拡張し、全集計結果を一括管理
- 各Paneに `frontendData` propを追加、frontendDataがある場合はそちらを優先使用
- KpiGridにも `fePd`（frontendData優先のeffectivePd）を渡してトップバーKPIも更新
- custom期間はPython分析にフォールバック

## Test plan
- [ ] MS未選択時: 各タブのデータがPythonレポートと一致
- [ ] MS選択時: 各タブがそのMSの試合に絞った集計を表示
- [ ] 期間選択時: 試合数がPythonレポートと一致
- [ ] IndexedDB削除後: Pythonデータにフォールバック
- [ ] custom期間: Pythonデータを使用

Refs #294

🤖 Generated with [Claude Code](https://claude.ai/code)