### PR TITLE
fix: 再分析ボタンをセッション有無に関わらず常に表示

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2352,7 +2352,7 @@ function Report({ data, userKey }) {
     <div class="topbar" ref=${topbarRef}>
       <button class="hamburger" onClick=${function () { setMenuOpen(true); }}>☰</button>
       <span class="brand"><img src="logo.svg" alt="catalyzer" /></span>
-      ${localStorage.getItem('catalyzer_has_session') && html`<button class="topbar-refresh" onClick=${reAnalyze}>再分析</button>`}
+      <button class="topbar-refresh" onClick=${reAnalyze}>再分析</button>
       <div class="controls-row">
         <${PeriodSelector} periods=${allPeriods} selected=${selectedPeriod} onSelect=${setSelectedPeriod}
           userKey=${userKey} onCustomReport=${handleCustomReport} />


### PR DESCRIPTION
## Summary
- レポート表示中は再分析ボタンを常にトップバーに表示するよう変更
- セッション保持ユーザー限定の条件を削除（`reAnalyze()`が内部でフロー振り分け済み）

## Test plan
- [ ] セッションなし+キャッシュあり: リロード時にレポートと再分析ボタンが表示される
- [ ] セッションあり: 従来通り再分析ボタンが表示される
- [ ] 再分析ボタンクリック: セッションありならパスワード不要、なしならログインフォーム表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6WoSemCevjW93ytejrzm