### PR TITLE
fix: ハンバーガーメニューから再分析を削除しボタンをpill型に変更

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2019,13 +2019,22 @@ function HamburgerMenu({ isOpen, onClose, shareData, hasSession, onLogout }) {
     <div class=${'menu-drawer' + (isOpen ? ' open' : '')}>
       <div class="menu-header"><img src="logo.svg" alt="catalyzer" style="height:24px;width:auto;" /></div>
       <div class="menu-body">
-        ${hasSession ? [
-          html`<button class="menu-item" style="color: var(--bad)" onClick=${function () { onClose(); onLogout(); }}>ログアウト</button>`
-        ] : null}
+        <div class="menu-section">メニュー</div>
+        <button class="menu-item active" onClick=${onClose}><span class="menu-icon">📊</span>分析レポート</button>
+        <button class="menu-item disabled"><span class="menu-icon">🔍</span>試合検索<span class="coming-soon">coming soon</span></button>
+        <button class="menu-item disabled"><span class="menu-icon">📈</span>モバイル総合戦歴<span class="coming-soon">coming soon</span></button>
+        <button class="menu-item disabled"><span class="menu-icon">🏆</span>EXランキング<span class="coming-soon">coming soon</span></button>
+        <button class="menu-item disabled"><span class="menu-icon">🤖</span>機体使用率ランキング<span class="coming-soon">coming soon</span></button>
+        <div class="menu-divider" />
+        <a class="menu-item" href="https://g-mobile.gundamgame.jp/" target="_blank" rel="noopener noreferrer"><span class="menu-icon">🌐</span>ガンダムモバイル<span class="external-icon">↗</span></a>
         <div class="menu-divider" />
         <div style="padding: 8px 16px;">
           <${ShareArea} shareData=${shareData} />
         </div>
+        ${hasSession ? html`
+          <div class="menu-divider" />
+          <button class="menu-item" style="color: var(--bad)" onClick=${function () { onClose(); onLogout(); }}>ログアウト</button>
+        ` : null}
       </div>
     </div>
   </div>`;

--- a/static/app.js
+++ b/static/app.js
@@ -2003,7 +2003,7 @@ function ShareArea({ shareData }) {
 
 // --- Hamburger menu & topbar controls ---
 
-function HamburgerMenu({ isOpen, onClose, shareData, onReAnalyze, hasSession, onLogout }) {
+function HamburgerMenu({ isOpen, onClose, shareData, hasSession, onLogout }) {
   useEffect(function () {
     if (isOpen) {
       document.body.style.overflow = 'hidden';
@@ -2019,9 +2019,7 @@ function HamburgerMenu({ isOpen, onClose, shareData, onReAnalyze, hasSession, on
     <div class=${'menu-drawer' + (isOpen ? ' open' : '')}>
       <div class="menu-header"><img src="logo.svg" alt="catalyzer" style="height:24px;width:auto;" /></div>
       <div class="menu-body">
-        <button class="menu-item" onClick=${function () { onClose(); onReAnalyze(); }}>再分析</button>
         ${hasSession ? [
-          html`<div class="menu-divider" />`,
           html`<button class="menu-item" style="color: var(--bad)" onClick=${function () { onClose(); onLogout(); }}>ログアウト</button>`
         ] : null}
         <div class="menu-divider" />
@@ -2947,7 +2945,7 @@ function Report({ data, userKey }) {
     </div>
 
     <${HamburgerMenu} isOpen=${menuOpen} onClose=${function () { setMenuOpen(false); }}
-      shareData=${shareData} onReAnalyze=${reAnalyze}
+      shareData=${shareData}
       hasSession=${!!localStorage.getItem('catalyzer_has_session')}
       onLogout=${logout} />
 
@@ -2983,7 +2981,7 @@ function Skeleton() {
       </div>
     </div>
     <${HamburgerMenu} isOpen=${menuOpen} onClose=${function () { setMenuOpen(false); }}
-      shareData=${null} onReAnalyze=${function () {}} />
+      shareData=${null} />
     <div class="kpi-grid">
       ${[0, 1, 2, 3, 4, 5].map(function () {
         return html`<div class="kpi">${bar('50%', 12, 12)}${bar('70%', 28)}</div>`;

--- a/static/index.html
+++ b/static/index.html
@@ -93,7 +93,7 @@
     }
     .topbar .brand { position: absolute; top: calc(env(safe-area-inset-top) + 18px); left: 50%; transform: translateX(-50%); font-size: 1.05em; font-weight: 800; color: var(--accent); white-space: nowrap; pointer-events: none; }
     .topbar .brand img { height: 24px; width: auto; display: block; }
-    .topbar-refresh { margin-left: auto; background: none; border: 1px solid var(--line); border-radius: 8px; color: var(--accent); font-size: 0.8em; padding: 5px 12px; cursor: pointer; width: auto; white-space: nowrap; transition: all 0.15s; }
+    .topbar-refresh { margin-left: auto; background: none; border: 1px solid var(--line); border-radius: 999px; color: var(--accent); font-size: 0.8em; padding: 5px 14px; cursor: pointer; width: auto; white-space: nowrap; transition: all 0.15s; }
     .topbar-refresh:hover { border-color: var(--accent); background: rgba(79,195,247,0.1); }
     .controls-row {
       display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-basis: 100%;

--- a/static/index.html
+++ b/static/index.html
@@ -267,8 +267,14 @@
     .menu-drawer.open { transform: translateX(0); }
     .menu-header { padding: 20px 16px 12px; border-bottom: 1px solid var(--line); font-size: 1.1em; font-weight: 800; color: var(--accent); }
     .menu-body { padding: 8px 0; flex: 1; }
-    .menu-item { display: block; width: 100%; padding: 12px 16px; border: none; background: none; color: var(--text); font-size: 0.95em; cursor: pointer; text-align: left; transition: background 0.15s; }
+    .menu-item { display: flex; align-items: center; gap: 10px; width: 100%; padding: 12px 16px; border: none; background: none; color: var(--text); font-size: 0.95em; cursor: pointer; text-align: left; transition: background 0.15s; text-decoration: none; }
     .menu-item:hover { background: var(--panel-2); }
+    .menu-item.active { color: var(--accent); font-weight: 600; }
+    .menu-item.disabled { color: var(--muted); opacity: 0.5; cursor: default; pointer-events: none; }
+    .menu-item .menu-icon { width: 20px; text-align: center; flex-shrink: 0; }
+    .menu-item .coming-soon { font-size: 0.7em; color: var(--muted); background: var(--panel-2); border-radius: 999px; padding: 1px 8px; margin-left: auto; }
+    .menu-item .external-icon { font-size: 0.75em; color: var(--muted); margin-left: 4px; }
+    .menu-section { padding: 8px 16px 4px; font-size: 0.75em; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
     .menu-divider { border-top: 1px solid var(--line); margin: 4px 0; }
     .menu-label { padding: 12px 16px 4px; font-size: 0.8em; color: var(--muted); font-weight: 600; }
 

--- a/static/index.html
+++ b/static/index.html
@@ -274,7 +274,7 @@
     .menu-item .menu-icon { width: 20px; text-align: center; flex-shrink: 0; }
     .menu-item .coming-soon { font-size: 0.7em; color: var(--muted); background: var(--panel-2); border-radius: 999px; padding: 1px 8px; margin-left: auto; }
     .menu-item .external-icon { font-size: 0.75em; color: var(--muted); margin-left: 4px; }
-    .menu-section { padding: 8px 16px 4px; font-size: 0.75em; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+    .menu-section { padding: 8px 16px 4px; font-size: 0.75em; color: var(--muted); letter-spacing: 0.05em; }
     .menu-divider { border-top: 1px solid var(--line); margin: 4px 0; }
     .menu-label { padding: 12px 16px 4px; font-size: 0.8em; color: var(--muted); font-weight: 600; }
 


### PR DESCRIPTION
## Summary
- ハンバーガーメニューから再分析ボタンを削除（トップバーに常時表示されるため不要）
- 不要になった`onReAnalyze` propを削除
- トップバーの再分析ボタンを`border-radius: 999px`のpill型に変更し、MsSelectorなど他の要素と統一
- ハンバーガーメニューにナビゲーション項目を追加:
  - 分析レポート（アクティブ）
  - 試合検索 / モバイル総合戦歴 / EXランキング / 機体使用率ランキング（coming soon）
  - ガンダムモバイル（外部リンク、↗アイコン付き）

## Test plan
- [ ] ハンバーガーメニューに再分析ボタンが表示されないことを確認
- [ ] トップバーの再分析ボタンがpill型（丸っこい）で表示される
- [ ] 再分析ボタンのクリック動作に問題がない
- [ ] メニューに「分析レポート」がアクティブ状態で表示される
- [ ] coming soon項目がグレーアウトでクリック不可
- [ ] 「ガンダムモバイル」が外部リンクとして新タブで開く
- [ ] ログアウトボタンがメニュー最下部に表示される（セッションユーザーのみ）
- [ ] 共有機能が従来通り動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6WoSemCevjW93ytejrzm