### PR TITLE
fix: セッション保存機能が動作しない問題を修正

### DIFF
--- a/infra/app/Pulumi.prod.yaml
+++ b/infra/app/Pulumi.prod.yaml
@@ -12,3 +12,5 @@ config:
   exvs-app:sharedStack: organization/exvs-shared/shared
   gcp:project: exvs2ib-analyzer
   gcp:region: asia-northeast1
+  exvs-app:sessionEncryptionKey:
+    secure: v1:ay3DXBLUnNZxg2tO:rv3t+K6ITd6nu3MXxCOo0Y5f4tlBSRVAlSJEe2Tj2PxDN0Cm7D6CgI0IvGAcFqQPPz1MpoM/K8JAKmoeMdK75/waKpfrTQiWtFGKgBNnnZ0=

--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -12,3 +12,5 @@ config:
   exvs-app:sharedStack: organization/exvs-shared/shared
   gcp:project: exvs2ib-analyzer
   gcp:region: asia-northeast1
+  exvs-app:sessionEncryptionKey:
+    secure: v1:vVvFyaTGB6LXa+TX:E27DnnLeNESxIaq6IFlX4gi796mnG+zlD4OexyrgqOsIo35FLA09sGjwV1DNUwiczGdx3IbF5Qidmm2P8kPJYrudDDJ3rOMj4fmJ5dOjgY4=

--- a/infra/app/index.ts
+++ b/infra/app/index.ts
@@ -9,6 +9,7 @@ const maxInstances = config.requireNumber("maxInstances");
 const image = config.requireSecret("image");
 const domain = config.require("domain");
 const firestoreDatabase = config.require("firestoreDatabase");
+const sessionEncryptionKey = config.getSecret("sessionEncryptionKey");
 
 // shared スタックからDNSゾーン名を取得
 const sharedStackName = config.require("sharedStack");
@@ -36,6 +37,14 @@ export const service = new gcp.cloudrunv2.Service(
               name: "FIRESTORE_DATABASE",
               value: firestoreDatabase,
             },
+            ...(sessionEncryptionKey !== undefined
+              ? [
+                  {
+                    name: "SESSION_ENCRYPTION_KEY",
+                    value: sessionEncryptionKey,
+                  },
+                ]
+              : []),
           ],
           resources: {
             cpuIdle: true,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -278,19 +278,15 @@ func handleResult(w http.ResponseWriter, r *http.Request, id string) {
 		setSessionCookie(w, j.SessionToken)
 	}
 
-	type doneResponse struct {
-		Report       json.RawMessage `json:"report"`
-		UserKey      string          `json:"user_key,omitempty"`
-		Partial      bool            `json:"partial,omitempty"`
-		SessionSaved bool            `json:"session_saved,omitempty"`
-	}
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(doneResponse{
+	resp := reportResponse{
 		Report:       json.RawMessage(snap.Report),
 		UserKey:      snap.UserKey,
 		Partial:      snap.PartialData,
 		SessionSaved: sessionSaved,
-	})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(resp)
 }
 
 func handleCustomPeriod(w http.ResponseWriter, r *http.Request, id string) {
@@ -447,14 +443,16 @@ func sendJSON(w http.ResponseWriter, code int, data interface{}) {
 
 // sendRawReport はJSON形式のレポートをレスポンスとして返す。
 // reportJSONはanalyze.pyが生成したJSON文字列。json.RawMessageで二重エンコードを防ぐ。
+type reportResponse struct {
+	Report       json.RawMessage `json:"report"`
+	Status       string          `json:"status,omitempty"`
+	Preliminary  bool            `json:"preliminary,omitempty"`
+	Partial      bool            `json:"partial,omitempty"`
+	UserKey      string          `json:"user_key,omitempty"`
+	SessionSaved bool            `json:"session_saved,omitempty"`
+}
+
 func sendRawReport(w http.ResponseWriter, code int, reportJSON, status, userKey string, preliminary bool, partial ...bool) {
-	type reportResponse struct {
-		Report      json.RawMessage `json:"report"`
-		Status      string          `json:"status,omitempty"`
-		Preliminary bool            `json:"preliminary,omitempty"`
-		Partial     bool            `json:"partial,omitempty"`
-		UserKey     string          `json:"user_key,omitempty"`
-	}
 	isPartial := len(partial) > 0 && partial[0]
 	resp := reportResponse{
 		Report:      json.RawMessage(reportJSON),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -273,11 +273,24 @@ func handleResult(w http.ResponseWriter, r *http.Request, id string) {
 	}
 
 	// remember=true でジョブ完了時、セッションCookieを発行
-	if j.Remember && j.SessionToken != "" {
+	sessionSaved := j.Remember && j.SessionToken != ""
+	if sessionSaved {
 		setSessionCookie(w, j.SessionToken)
 	}
 
-	sendRawReport(w, http.StatusOK, snap.Report, "", snap.UserKey, false, snap.PartialData)
+	type doneResponse struct {
+		Report       json.RawMessage `json:"report"`
+		UserKey      string          `json:"user_key,omitempty"`
+		Partial      bool            `json:"partial,omitempty"`
+		SessionSaved bool            `json:"session_saved,omitempty"`
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(doneResponse{
+		Report:       json.RawMessage(snap.Report),
+		UserKey:      snap.UserKey,
+		Partial:      snap.PartialData,
+		SessionSaved: sessionSaved,
+	})
 }
 
 func handleCustomPeriod(w http.ResponseWriter, r *http.Request, id string) {

--- a/static/app.js
+++ b/static/app.js
@@ -3425,8 +3425,8 @@ async function analyze() {
 
         renderReport(resultData.report, resultData.user_key);
         renderedReal = true;
-        // remember=trueで分析成功 → セッションフラグをセット
-        if (remember) {
+        // サーバーがセッションを保存した場合のみフラグをセット
+        if (resultData.session_saved) {
           try { localStorage.setItem('catalyzer_has_session', '1'); } catch (e) {}
         }
         if (resultData.user_key) {


### PR DESCRIPTION
## Summary

- **根本原因**: `SESSION_ENCRYPTION_KEY` 環境変数がCloud Runに未設定のため `session.Enabled()` が常に `false` を返し、セッションcookieが発行されない。しかしフロントエンドは `remember` チェックボックスの状態だけで `localStorage.catalyzer_has_session` フラグを設定していたため、次回アクセス時に「セッションが見つかりません」エラーが発生
- **サーバー修正**: `/result/{id}` の完了レスポンスに `session_saved` フラグを追加。セッションcookieを実際に発行した場合のみ `true` を返す
- **フロントエンド修正**: `remember` 変数ではなく `resultData.session_saved` を確認してからlocalStorageフラグを設定
- **インフラ修正**: Pulumi設定に `sessionEncryptionKey` をオプショナルなシークレットとして追加。stg/prod両環境に暗号化済み鍵を設定済み

## Test plan

- [ ] `go vet` / `go build` / `go test` パス確認済み
- [ ] SESSION_ENCRYPTION_KEY未設定で remember=true → localStorage フラグが設定されないこと
- [ ] SESSION_ENCRYPTION_KEY設定後 remember=true → セッション保存・復元が正常動作すること
- [ ] セッション保持中に「再分析」ボタン → パスワード不要で再分析できること

🤖 Generated with [Claude Code](https://claude.ai/code)