### PR TITLE
chore: ES modules分割のクリーンアップとドキュメント更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 - `internal/server/` — HTTPハンドラ（`server.go`）+ IPベースレート制限（`ratelimit.go`）+ Basic認証（`basicauth.go`）+ 403一時ブロック（`block403.go`）+ セッション管理エンドポイント
 - `scripts/analyze.py` — Python分析: 勝率、与被ダメ比、固定相方検出（K/D・EXダメ・覚醒回数・勝敗パターン付き）、JSON構造化レポート生成
 - `static/index.html` — SPA フロントエンド（ダークテーマ、レスポンシブ対応、カスタムドロップダウン）
-- `static/app.js` — フロントエンドJS本体（CSP対応で外部化。htm/Preactでレンダリング）。主要コンポーネント: Calendar/TimeSelector/PeriodSelector（期間指定）、ShareArea（SNS共有）、HamburgerMenu（左ドロワー）、MsSelector/LensToggle（トップバーフィルタ）、Dashboard（Panel/KpiGrid/CompareRadar/BasicLensSection/FixedPartnerPanel/各Pane）、App（状態管理・ルーティング）
+- `static/app.js` — フロントエンドJS本体（CSP対応で外部化。htm/Preactでレンダリング）。主要コンポーネント: Calendar/TimeSelector/PeriodSelector（期間指定）、ShareArea（SNS共有）、HamburgerMenu（左ドロワー）、MsSelector/LensToggle（トップバーフィルタ）、Panel/KpiGrid/CompareRadar/BasicLensSection/FixedPartnerPanel、5タブ構成（OverviewPane/PlaystylePane/BurstPane/MatchupPane/TimePane）、Report（状態管理・タブ切替・フロントエンド集計）。IndexedDBキャッシュからフロントエンド集計、未キャッシュ時はサーバー分析結果にフォールバック
 - `static/analysis/stats.js` — 統計分析関数。時間帯/曜日/日別/シーズン/基本データ/勝敗パターン/敵相性/相方/コスト編成/MS編成/ダメージ貢献/被撃墜影響/覚醒回数/先落ち後落ち/覚醒抱え落ち/固定相方
 - `static/analysis/aggregate.js` — 集計関数。被撃墜影響/先落ち/ダメージ貢献/覚醒回数/覚醒抱え落ち/敵相性/相方の全MS横断集計
 - `static/components/ui.js` — 汎用UIコンポーネント（Tips/SortableTable/Table/SubSection）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,13 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 - `internal/server/` — HTTPハンドラ（`server.go`）+ IPベースレート制限（`ratelimit.go`）+ Basic認証（`basicauth.go`）+ 403一時ブロック（`block403.go`）+ セッション管理エンドポイント
 - `scripts/analyze.py` — Python分析: 勝率、与被ダメ比、固定相方検出（K/D・EXダメ・覚醒回数・勝敗パターン付き）、JSON構造化レポート生成
 - `static/index.html` — SPA フロントエンド（ダークテーマ、レスポンシブ対応、カスタムドロップダウン）
-- `static/app.js` — フロントエンドJS（CSP対応で外部化。htm/Preactでレンダリング）。主要コンポーネント: Report（状態管理）、HamburgerMenu（左ドロワー）、MsSelector/LensToggle（トップバーフィルタ）、5タブ構成（OverviewPane/PlaystylePane/BurstPane/MatchupPane/TimePane）、FixedPartnerPanel（レンズ対応6軸レーダー）、各種Chart/集計関数。フロントエンド集計（Phase 1: 時間帯/曜日/日別、Phase 2: 基本データ/勝敗パターン/敵相性/相方/コスト編成/MS編成/ダメージ貢献/被撃墜影響/シーズン/覚醒回数、Phase 3: 先落ち後落ち/覚醒抱え落ち/固定相方）でIndexedDBの試合データからリアルタイム集計、Python分析へのフォールバック付き
+- `static/app.js` — フロントエンドJS本体（CSP対応で外部化。htm/Preactでレンダリング）。主要コンポーネント: Calendar/TimeSelector/PeriodSelector（期間指定）、ShareArea（SNS共有）、HamburgerMenu（左ドロワー）、MsSelector/LensToggle（トップバーフィルタ）、Dashboard（Panel/KpiGrid/CompareRadar/BasicLensSection/FixedPartnerPanel/各Pane）、App（状態管理・ルーティング）
+- `static/analysis/stats.js` — 統計分析関数。時間帯/曜日/日別/シーズン/基本データ/勝敗パターン/敵相性/相方/コスト編成/MS編成/ダメージ貢献/被撃墜影響/覚醒回数/先落ち後落ち/覚醒抱え落ち/固定相方
+- `static/analysis/aggregate.js` — 集計関数。被撃墜影響/先落ち/ダメージ貢献/覚醒回数/覚醒抱え落ち/敵相性/相方の全MS横断集計
+- `static/components/ui.js` — 汎用UIコンポーネント（Tips/SortableTable/Table/SubSection）
+- `static/components/charts.js` — Chart.jsグラフ＋レポートセクション（EnemyMatchupSection/PartnerSection/時間帯・曜日・日別・シーズンChart等）
+- `static/lib/db.js` — IndexedDBキャッシュ（試合データの保存・読み込み・差分取得）
+- `static/lib/format.js` — 書式ヘルパー（数値フォーマット・色分け・SVGアイコン・共有テキスト生成）
 - `static/htm-preact-standalone.js` — htm + Preact ライブラリ（スタンドアロン版）
 - `static/chart.umd.min.js` — Chart.js ライブラリ（グラフ描画用）
 - `static/preview.html` — フロントエンド開発用プレビュー（gitignore対象）

--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@
 ├── static/
 │   ├── index.html                 # フロントエンド
 │   ├── app.js                     # フロントエンドJS（CSP対応で外部化）
+│   ├── analysis/
+│   │   ├── stats.js               # 統計分析関数（時間帯/曜日/敵相性等）
+│   │   └── aggregate.js           # 集計関数（被撃墜影響/先落ち等）
+│   ├── components/
+│   │   ├── ui.js                  # 汎用UIコンポーネント（Tips/Table等）
+│   │   └── charts.js              # Chart.jsグラフ・レポートセクション
+│   ├── lib/
+│   │   ├── db.js                  # IndexedDBキャッシュ
+│   │   └── format.js              # 書式・色分け・共有テキスト生成
 │   ├── logo.svg                   # ロゴ
 │   ├── favicon.svg                # ファビコン（SVG）
 │   ├── htm-preact-standalone.js   # htm + Preactライブラリ
@@ -124,6 +133,9 @@
 | `internal/server/` | HTTPハンドラ・レート制限・Basic認証・403ブロック・セッション管理 |
 | `scripts/` | Go以外のスクリプト（Python分析等） |
 | `static/` | フロントエンドHTML/JS/CSS |
+| `static/analysis/` | 統計分析・集計関数（ESモジュール） |
+| `static/components/` | UIコンポーネント・Chart.jsグラフ |
+| `static/lib/` | IndexedDBキャッシュ・書式ヘルパー |
 | `data/` | 静的データファイル（MSリスト等） |
 | `infra/` | Pulumi IaC（GCPリソース管理） |
 

--- a/static/lib/db.js
+++ b/static/lib/db.js
@@ -2,7 +2,7 @@ var MATCH_DB_NAME = 'catalyzer';
 var MATCH_DB_VERSION = 1;
 var MATCH_STORE = 'matches';
 
-export function openMatchDB() {
+function openMatchDB() {
   return new Promise(function (resolve, reject) {
     var req = indexedDB.open(MATCH_DB_NAME, MATCH_DB_VERSION);
     req.onupgradeneeded = function (e) {
@@ -51,7 +51,7 @@ export function loadMatchesFromDB(userKey) {
   });
 }
 
-export function getLatestMatchDate(userKey) {
+function getLatestMatchDate(userKey) {
   return openMatchDB().then(function (db) {
     return new Promise(function (resolve, reject) {
       var tx = db.transaction(MATCH_STORE, 'readonly');

--- a/static/lib/format.js
+++ b/static/lib/format.js
@@ -17,7 +17,7 @@ export function boldText(s) {
 export function pct(n) { return n != null ? n.toFixed(1) + '%' : '-'; }
 export function num(n, d) { return n != null ? n.toFixed(d != null ? d : 0) : '-'; }
 
-export function valClass4(n, great, good, bad, terrible, higherIsBetter) {
+function valClass4(n, great, good, bad, terrible, higherIsBetter) {
   if (n == null) return '';
   if (higherIsBetter) {
     if (n >= great) return 'val-great';
@@ -32,7 +32,7 @@ export function valClass4(n, great, good, bad, terrible, higherIsBetter) {
   }
 }
 
-export function colorVal(n, great, good, bad, terrible, higherIsBetter, decimals) {
+function colorVal(n, great, good, bad, terrible, higherIsBetter, decimals) {
   if (n == null) return '-';
   var cls = valClass4(n, great, good, bad, terrible, higherIsBetter);
   var text = n.toFixed(decimals != null ? decimals : 0);


### PR DESCRIPTION
## Summary
- `format.js`の内部専用関数（`valClass4`, `colorVal`）から`export`を削除
- `db.js`の内部専用関数（`openMatchDB`, `getLatestMatchDate`）から`export`を削除
- `README.md`のプロジェクト構成にES modules分割後のサブディレクトリ（`analysis/`, `components/`, `lib/`）を追加
- `CLAUDE.md`のコード構成セクションをモジュール分割後の構成に更新

## Test plan
- [ ] モジュール内部で`valClass4`/`colorVal`/`openMatchDB`/`getLatestMatchDate`が正常に呼ばれることを確認
- [ ] 外部ファイルからこれらの関数をimportしていないことを`grep`で確認済み
- [ ] ブラウザでアプリが正常に動作することを確認

> **Note:** #328 (`refactor/split-app-js`) のマージ後にマージしてください

🤖 Generated with [Claude Code](https://claude.ai/code)