### PR TITLE
fix(ui): 日付指定ドロップダウンでカレンダーが見えない問題を修正 (#309)

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -182,6 +182,14 @@ function PeriodSelector({ periods, selected, onSelect, userKey, onCustomReport }
 
   var containerRef = useRef(null);
   var triggerRef = useRef(null);
+  var customElRef = useRef(null);
+
+  // 日付指定を開いたらカレンダーが見えるようドロップダウン内でスクロールする
+  useEffect(function () {
+    if (showCustom && customElRef.current) {
+      customElRef.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }, [showCustom]);
 
   useEffect(function () {
     function handleClick(e) {
@@ -247,7 +255,7 @@ function PeriodSelector({ periods, selected, onSelect, userKey, onCustomReport }
         ${userKey && html`<button class=${'period-dropdown-item period-dropdown-custom' + (showCustom ? ' active' : '')}
           onClick=${function () { setShowCustom(!showCustom); }}>日付指定</button>`}
       </div>
-      ${showCustom && html`<div class="period-custom">
+      ${showCustom && html`<div class="period-custom" ref=${customElRef}>
         <div class="period-custom-range">
           <div class="period-custom-col">
             <span class="period-custom-title">開始: ${startDate || '未選択'}${showTime ? ' ' + String(startHour).padStart(2, '0') + ':' + String(startMin).padStart(2, '0') : ''}</span>

--- a/static/index.html
+++ b/static/index.html
@@ -219,13 +219,13 @@
     .period-trigger { display: flex; align-items: center; gap: 8px; padding: 9px 16px; border: 1px solid var(--line); border-radius: 999px; background: var(--panel); color: var(--text); font-size: 0.85em; cursor: pointer; transition: all 0.2s; width: auto; }
     .period-trigger:hover { border-color: var(--accent); }
     .period-arrow { font-size: 0.7em; color: var(--muted); }
-    .period-dropdown { position: absolute; top: 100%; right: 0; margin-top: 4px; background: var(--panel); border: 1px solid var(--line); border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.4); z-index: 100; min-width: 240px; overflow: hidden; }
+    .period-dropdown { position: absolute; top: 100%; right: 0; margin-top: 4px; background: var(--panel); border: 1px solid var(--line); border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.4); z-index: 100; min-width: 240px; max-height: calc(100vh - 96px); overflow: hidden auto; }
     .period-dropdown-list { display: flex; flex-direction: column; }
     .period-dropdown-item { padding: 10px 16px; border: none; background: none; color: var(--text); font-size: 0.9em; cursor: pointer; text-align: left; transition: all 0.15s; width: 100%; }
     .period-dropdown-item:hover { background: var(--panel-2); }
     .period-dropdown-item.active { color: var(--accent); background: var(--bg); font-weight: bold; }
     .period-dropdown-custom { border-top: 1px solid var(--line); }
-    .period-custom { padding: 12px 16px; border-top: 1px solid var(--line); display: flex; flex-direction: column; gap: 10px; }
+    .period-custom { padding: 12px 16px; border-top: 1px solid var(--line); display: flex; flex-direction: column; gap: 10px; min-width: 300px; }
     .period-custom-range { display: flex; gap: 12px; }
     .period-custom-col { display: flex; flex-direction: column; gap: 6px; flex: 1; }
     .period-custom-title { color: var(--accent); font-size: 0.85em; font-weight: bold; }
@@ -363,6 +363,7 @@
       .ms-topbar-item { padding: 14px 16px; font-size: 1em; }
       .panel-select-item { padding: 14px 16px; font-size: 1em; }
       .period-custom-range { flex-direction: column; }
+      .period-custom { min-width: 0; }
     }
   </style>
 </head>


### PR DESCRIPTION
「日付指定」を開いてもカレンダーがプリセット一覧の下に隠れており、ユーザーが
その存在に気づきにくい（発見性）の問題を修正する。スクロール自体はモバイルでは
既に可能だったため、本PRの主眼は「カレンダーに気づいてもらう・見やすくする」こと。

- カスタム日付セクションに min-width を設定してカレンダーを広く見やすく表示
  （狭い画面では min-width をリセットして横はみ出しを防止）
- 日付指定を開いた際にカレンダーを scrollIntoView し、下にカレンダーが
  あることをユーザーが気づけるようにする
- あわせてデスクトップのドロップダウンにも max-height + overflow-y:auto を付与し、
  プリセット一覧が長く縦にはみ出した場合でも内部スクロールで到達できるようにする
  （堅牢性向上。モバイルは既存の max-height:70vh を維持）

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BPXo4LDCcdbvEtJR3yBDWX