### PR TITLE
OverviewPane/TimePane の到達不能な条件式の整理

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -728,7 +728,7 @@ function OverviewPane({ pd, selectedMs, lens, frontendData }) {
       <${BasicLensSection} basic=${pd.basic_stats} pattern=${pd.win_loss_pattern} lens=${lens} />
     <//>`}
 
-    ${(!selectedMs || frontendData) && seasons.length > 0 && html`<${Panel} title="シーズン別分析">
+    ${seasons.length > 0 && html`<${Panel} title="シーズン別分析">
       ${seasons.length > 1 && html`<${SeasonChart} seasons=${seasons} />`}
       ${seasons.map(function (s) {
         var rows = [['全体', s.matches, colorPct(s.win_rate), colorDE(s.dmg_efficiency, 3)]];
@@ -753,7 +753,7 @@ function OverviewPane({ pd, selectedMs, lens, frontendData }) {
   </div>`;
 }
 
-function TimePane({ pd, selectedMs, usingFrontend }) {
+function TimePane({ pd }) {
   var time = pd.time_of_day, dow = pd.day_of_week, daily = pd.daily_trend;
   var timeRows = time && time.hours ? time.hours.map(function (h) {
     return [{ sortValue: h.hour, display: h.hour + '時' }, h.matches, colorPct(h.win_rate), colorDE(h.dmg_efficiency, 3)];
@@ -769,7 +769,6 @@ function TimePane({ pd, selectedMs, usingFrontend }) {
   });
 
   return html`<div class="tabpane">
-    ${selectedMs && !usingFrontend && html`<div class="info-note">※ 時間帯データは全機体の集計です（機体別の時間帯分析は今後対応予定）</div>`}
     ${time && time.hours && time.hours.length > 0 && html`<${Panel} title="時間帯別の勝率">
       <${TimeOfDayChart} hours=${time.hours} />
       <${Tips} tips=${time.tips} />
@@ -1212,7 +1211,7 @@ function Report({ data, userKey }) {
     pane = html`<${MatchupPane} frontendData=${frontendData} />`;
   } else if (activeTab === 'time') {
     var timePd = { time_of_day: frontendData.time_of_day, day_of_week: frontendData.day_of_week, daily_trend: frontendData.daily_trend, season: frontendData.season };
-    pane = html`<${TimePane} pd=${timePd} selectedMs=${selectedMs} usingFrontend=${true} />`;
+    pane = html`<${TimePane} pd=${timePd} />`;
   } else {
     pane = html`<${OverviewPane} pd=${fePd} selectedMs=${selectedMs} lens=${lens} frontendData=${frontendData} />`;
   }

--- a/static/app.js
+++ b/static/app.js
@@ -1210,7 +1210,7 @@ function Report({ data, userKey }) {
   } else if (activeTab === 'matchup') {
     pane = html`<${MatchupPane} frontendData=${frontendData} />`;
   } else if (activeTab === 'time') {
-    var timePd = { time_of_day: frontendData.time_of_day, day_of_week: frontendData.day_of_week, daily_trend: frontendData.daily_trend, season: frontendData.season };
+    var timePd = { time_of_day: frontendData.time_of_day, day_of_week: frontendData.day_of_week, daily_trend: frontendData.daily_trend };
     pane = html`<${TimePane} pd=${timePd} />`;
   } else {
     pane = html`<${OverviewPane} pd=${fePd} selectedMs=${selectedMs} lens=${lens} frontendData=${frontendData} />`;


### PR DESCRIPTION
## 概要
Closes #343

`frontendData` が常に truthy / `usingFrontend` が固定 true という前提から生じていた到達不能な条件式を整理する。issue #340（PR #342）で aggregate 側の到達不能分岐を整理した際に発見した同種の技術的負債。

## 変更内容
- **OverviewPane**（`static/app.js:731`）: `(!selectedMs || frontendData) && seasons.length > 0` の `(!selectedMs || frontendData)` は `frontendData` が常に truthy のため常に true。dead 項を削除し `seasons.length > 0` に単純化。※ `selectedMs` prop は `744行`「機体別勝率比較」の分岐で生存中のため**維持**
- **TimePane**（`static/app.js:772`）: `selectedMs && !usingFrontend` の info-note は `usingFrontend` が固定 true のため一度も描画されない dead code。frontend モードでは時間データも `selectedMs` で絞り込み済みで「全機体の集計です」という注記自体が obsolete のため行ごと削除。未使用になる `selectedMs` / `usingFrontend` props を signature と呼び出し元から除去

## 検証
- `node --test 'static/__tests__/*.test.js'` → **71 pass / 0 fail**
- `node --check static/app.js` → 構文OK
- `grep -n usingFrontend static/app.js` → 残存参照ゼロ
- `selectedMs` が OverviewPane:744 で生存中であることを確認（signature 維持）
- ドキュメント（CLAUDE.md/README.md）は構成コンポーネント一覧に変化なしのため更新不要

## 依存関係（重要）
本PRは **PR #342 にスタック**している（`static/app.js` の呼び出し元編集が近接しコンフリクトを避けるため、#342 のブランチを親に作成）。**#342 を先にマージすること**。#342 マージ後、本PRの差分は本コミット1件（`OverviewPane/TimePane の到達不能な条件式を整理`）のみになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
