### PR TITLE
fix: 時刻指定selectの選択肢が青背景で読めない問題を修正 (#309)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -249,7 +249,8 @@
     .cal-day.selected { background: var(--accent); color: #062536; font-weight: bold; border-color: var(--accent); }
     .cal-day.in-range { background: rgba(79,195,247,0.15); color: var(--text); border-color: transparent; }
     .time-sel { display: flex; align-items: center; gap: 4px; }
-    .time-select { padding: 4px 6px; border: 1px solid var(--line); border-radius: 4px; background: var(--bg); color: var(--text); font-size: 0.85em; cursor: pointer; }
+    /* color-scheme: dark でネイティブの選択肢ポップアップを暗色描画にする（未指定だと白背景+青ハイライトで文字が読めない） */
+    .time-select { padding: 4px 6px; border: 1px solid var(--line); border-radius: 4px; background: var(--bg); color: var(--text); font-size: 0.85em; cursor: pointer; color-scheme: dark; }
     .time-select:focus { outline: none; border-color: var(--accent); }
     .time-colon { color: #666; }
     .period-backdrop { display: none; }


### PR DESCRIPTION
## 概要
日付指定で「時刻を指定」をクリックすると現れる時刻セレクト(`.time-select`)のドロップダウンが、青背景+白文字で読みづらい問題を修正。

## 原因
アプリはダークテーマ(`--bg: #0d1620` 等)だが、`color-scheme` が未宣言のため、ネイティブ `<select>` の選択肢ポップアップがブラウザのライトモード(白背景+システム標準の青ハイライト)で描画されていた。`.time-select` には `color: var(--text)`(明色)が指定されているため、白背景に明色文字＋青ハイライトで文字が読めなくなっていた。

## 変更
- `static/index.html`: `.time-select` に `color-scheme: dark` を追加。ネイティブの選択肢ポップアップとハイライトが暗色テーマで描画され、コントラストが確保される。

時/分の2つのselectは同一クラス(`.time-select`)のため両方に適用される。

## 検証
- `node --test 'static/__tests__/*.test.js'`: 71 pass / 0 fail(CSSのみの変更でJSロジックは不変。ベースライン緑を確認）
- ネイティブポップアップの実描画確認はログイン後の日付指定フローが必要なため、機構(color-scheme:dark はこの「暗色ページ×ライト描画selectポップアップ」問題の定石)とCSS適用箇所で担保。

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)