### PR TITLE
ログアウト時に実行中のスクレイピング処理を中断する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 フロントエンドがIndexedDBにmatchesを保存し、JS分析関数で統計を計算・表示
 ```
 
-**主要エンドポイント:** `POST /analyze`, `GET /status/{id}`, `GET /result/{id}`, `GET /matches`, `GET /tag-partners`, `GET /session`, `DELETE /session`, `POST /reanalyze`, `GET /health`, `GET /`（静的UI）
+**主要エンドポイント:** `POST /analyze`, `GET /status/{id}`, `GET /result/{id}`, `POST /cancel/{id}`（実行中スクレイピングの中断。ログアウト時に使用）, `GET /matches`, `GET /tag-partners`, `GET /session`, `DELETE /session`, `POST /reanalyze`, `GET /health`, `GET /`（静的UI）
 
 ## コード構成
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -74,10 +74,11 @@ type TagPartner struct {
 type JobStatus string
 
 const (
-	StatusPending  JobStatus = "pending"
-	StatusScraping JobStatus = "scraping"
-	StatusDone     JobStatus = "done"
-	StatusError    JobStatus = "error"
+	StatusPending   JobStatus = "pending"
+	StatusScraping  JobStatus = "scraping"
+	StatusDone      JobStatus = "done"
+	StatusError     JobStatus = "error"
+	StatusCancelled JobStatus = "cancelled" // ログアウト等でユーザーが処理を中断した状態
 )
 
 // JobSnapshot はジョブ状態のスナップショット

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -39,8 +39,8 @@ func TestUserKey_KnownValue(t *testing.T) {
 }
 
 func TestJobStatus_Constants(t *testing.T) {
-	statuses := []JobStatus{StatusPending, StatusScraping, StatusDone, StatusError}
-	expected := []string{"pending", "scraping", "done", "error"}
+	statuses := []JobStatus{StatusPending, StatusScraping, StatusDone, StatusError, StatusCancelled}
+	expected := []string{"pending", "scraping", "done", "error", "cancelled"}
 
 	for i, s := range statuses {
 		if string(s) != expected[i] {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -248,8 +248,11 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	usingSession := j.SavedJar != nil
 
 	datedScores, jar, err = scraper.ScrapingWithOption(username, password, since, scrapingOpt)
-	// ログアウト等でキャンセルされた場合は、途中データやセッションを一切保存せず中断する
-	if errors.Is(err, scraper.ErrCanceled) {
+	// ログアウト等でキャンセルされた場合は、途中データやセッションを一切保存せず中断する。
+	// スクレイピングが成功して返った直後や、ログイン/日別ページ収集の早期エラーが
+	// ログアウトと競合した場合でも、ctxがキャンセル済みなら error/403 と誤判定せず中断する
+	// （セッション再保存や403ブロックの誤発動を防ぐ）
+	if errors.Is(err, scraper.ErrCanceled) || (j.ctx != nil && j.ctx.Err() != nil) {
 		markCancelled(j)
 		return
 	}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -2,6 +2,7 @@
 package pipeline
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log"
@@ -50,6 +51,8 @@ type Job struct {
 	SessionToken       string          `json:"-"`
 	SavedJar           http.CookieJar  `json:"-"`
 	completedAt        time.Time
+	ctx                context.Context    // スクレイピングのキャンセル用Context（NewJobで生成）
+	cancel             context.CancelFunc // ctxのキャンセル関数。CancelJobから呼ばれる
 }
 
 // ジョブストア（インメモリ）
@@ -60,14 +63,28 @@ var (
 
 // NewJob はジョブを作成してストアに登録する
 func NewJob() *Job {
+	ctx, cancel := context.WithCancel(context.Background())
 	j := &Job{
 		ID:     uuid.New().String(),
 		Status: model.StatusPending,
+		ctx:    ctx,
+		cancel: cancel,
 	}
 	jobsMu.Lock()
 	jobs[j.ID] = j
 	jobsMu.Unlock()
 	return j
+}
+
+// CancelJob は実行中のジョブのスクレイピング処理を中断する。
+// 存在しない、または既に完了したジョブに対しては安全な no-op。
+func CancelJob(id string) {
+	jobsMu.RLock()
+	j, ok := jobs[id]
+	jobsMu.RUnlock()
+	if ok && j.cancel != nil {
+		j.cancel()
+	}
 }
 
 // GetJob はIDからジョブを取得する
@@ -103,6 +120,16 @@ type On403Func func(userHash string)
 
 // Run はスクレイピング→分析を実行し、レポートをジョブに保存する
 func Run(j *Job, username, password string, on403 ...On403Func) {
+	// ジョブ完了時にContextを解放する（CancelJobがこの後呼ばれても no-op）
+	if j.cancel != nil {
+		defer j.cancel()
+	}
+	// 開始前に既にキャンセル済み（ログアウト直後など）なら何もせず中断状態にする
+	if j.ctx != nil && j.ctx.Err() != nil {
+		markCancelled(j)
+		return
+	}
+
 	jobsMu.Lock()
 	if j.UserKey == "" {
 		j.UserKey = model.UserKey(username)
@@ -210,6 +237,7 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 			log.Printf("[INFO] Job %s: login succeeded", j.ID)
 		},
 		SavedJar: j.SavedJar,
+		Context:  j.ctx,
 	}
 	if len(backfillDates) > 0 {
 		scrapingOpt.BackfillDates = backfillDates
@@ -220,6 +248,11 @@ func Run(j *Job, username, password string, on403 ...On403Func) {
 	usingSession := j.SavedJar != nil
 
 	datedScores, jar, err = scraper.ScrapingWithOption(username, password, since, scrapingOpt)
+	// ログアウト等でキャンセルされた場合は、途中データやセッションを一切保存せず中断する
+	if errors.Is(err, scraper.ErrCanceled) {
+		markCancelled(j)
+		return
+	}
 	// 403の場合でも途中データがあれば保存・分析を続行する
 	is403WithPartialData := errors.Is(err, scraper.ErrAccessDenied) && len(datedScores) > 0
 	if err != nil && !is403WithPartialData {
@@ -371,6 +404,15 @@ func updateStatus(j *Job, s model.JobStatus) {
 	jobsMu.Lock()
 	j.Status = s
 	jobsMu.Unlock()
+}
+
+// markCancelled はジョブをキャンセル状態にする（ログアウト等でスクレイピングを中断したとき）
+func markCancelled(j *Job) {
+	jobsMu.Lock()
+	j.Status = model.StatusCancelled
+	j.completedAt = time.Now()
+	jobsMu.Unlock()
+	log.Printf("[INFO] Job %s cancelled by user", j.ID)
 }
 
 func setError(j *Job, clientMsg, detail string) {

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -89,6 +89,9 @@ var ErrNotFound = errors.New("ページが見つかりません")
 // ErrHTTPRequestFailed はHTTPリクエストが失敗した場合のエラー
 var ErrHTTPRequestFailed = errors.New("データ取得中にHTTPエラーが発生しました")
 
+// ErrCanceled は呼び出し元のContextキャンセル（ログアウト等）で処理を中断した場合のエラー
+var ErrCanceled = errors.New("処理がキャンセルされました")
+
 // dailyLink はrankpageから収集した日別ページ情報
 type dailyLink struct {
 	date     string
@@ -136,6 +139,7 @@ type ScrapingOption struct {
 	FirstBatchSize int                            // 初回OnBatchReadyを発火する試合数。0でBatchSizeと同じ。初回だけ早めに速報を出す用途
 	OnLoginSuccess func()                         // ログイン成功直後に1度だけ呼ばれる
 	SavedJar       http.CookieJar                 // 保存済みCookieJar。非nilの場合はログインをスキップ
+	Context        context.Context                // 呼び出し元のContext。キャンセルでスクレイピングを中断する。nilならBackground
 }
 
 // Scraping はスクレイピング処理を実行し、DatedScoresとログイン済みCookieJarを返す
@@ -161,6 +165,16 @@ func ScrapingWithOption(username, password string, since time.Time, opt Scraping
 		}
 	}
 
+	// 呼び出し元Context（ログアウト等のキャンセル用）。未指定ならBackground
+	parent := opt.Context
+	if parent == nil {
+		parent = context.Background()
+	}
+	// 開始前に既にキャンセル済みなら何もしない
+	if parent.Err() != nil {
+		return nil, nil, ErrCanceled
+	}
+
 	var jar http.CookieJar
 	if opt.SavedJar != nil {
 		jar = opt.SavedJar
@@ -173,6 +187,10 @@ func ScrapingWithOption(username, password string, since time.Time, opt Scraping
 	}
 	if opt.OnLoginSuccess != nil {
 		opt.OnLoginSuccess()
+	}
+	// ログイン中にキャンセルされた場合はここで中断
+	if parent.Err() != nil {
+		return nil, nil, ErrCanceled
 	}
 
 	// Phase 1: rankpageから日別ページURLを収集
@@ -193,8 +211,9 @@ func ScrapingWithOption(username, password string, since time.Time, opt Scraping
 		dailyLinks = filtered
 	}
 
-	// 403検出時に全処理を即座に打ち切るためのcontext
-	ctx, cancel := context.WithCancel(context.Background())
+	// 403検出時に全処理を即座に打ち切るためのcontext。呼び出し元Contextを親にすることで、
+	// ログアウト等の外部キャンセルでもスクレイピングが即座に停止する
+	ctx, cancel := context.WithCancel(parent)
 	defer cancel()
 
 	// Phase 2+3: 日別ページ収集→詳細ページ取得をパイプラインで並行実行
@@ -208,6 +227,13 @@ func ScrapingWithOption(username, password string, since time.Time, opt Scraping
 	}()
 
 	scores, detailErr := fetchDetailPagesStreaming(ctx, cancel, jar, entryCh, notify, opt.OnBatchReady, opt.BatchSize, opt.FirstBatchSize)
+
+	// 呼び出し元Contextのキャンセル（ログアウト等）を最優先で判定する。
+	// 内部の403キャンセル（子ctx）とは異なり親ctxが完了しているため区別できる。
+	// この場合は途中データを保存せず、403ブロックも発動させない
+	if parent.Err() != nil {
+		return nil, nil, ErrCanceled
+	}
 
 	// 403の場合は途中データがあればエラーと一緒に返す（呼び出し元で途中保存できるようにする）
 	if streamErr != nil || detailErr != nil {

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -15,11 +15,26 @@
 package scraper
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/PuerkitoBio/goquery"
 )
+
+// TestScrapingWithOption_CanceledContext は、開始前にキャンセル済みのContextを渡すと
+// ネットワークアクセスせずに ErrCanceled を返すことを確認する（ログアウト即中断の要）。
+func TestScrapingWithOption_CanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 開始前にキャンセル
+
+	_, _, err := ScrapingWithOption("user@example.com", "pw", time.Time{}, ScrapingOption{Context: ctx})
+	if !errors.Is(err, ErrCanceled) {
+		t.Fatalf("キャンセル済みContextで ErrCanceled を期待したが got: %v", err)
+	}
+}
 
 func TestParseNumber(t *testing.T) {
 	tests := []struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -192,6 +192,21 @@ func StartServer() {
 		sendJSON(w, http.StatusOK, resp)
 	})
 
+	// POST /cancel/{id} → 実行中のジョブ（スクレイピング）を中断する（ログアウト時などに使用）
+	http.HandleFunc("/cancel/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		id := r.URL.Path[len("/cancel/"):]
+		if id == "" {
+			sendJSON(w, http.StatusBadRequest, map[string]string{"error": "Job id is required"})
+			return
+		}
+		pipeline.CancelJob(id)
+		sendJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+	})
+
 	// GET /result/{id} → 分析結果(JSON)を返す
 	http.HandleFunc("/result/", func(w http.ResponseWriter, r *http.Request) {
 		handleResult(w, r, r.URL.Path[len("/result/"):])

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -268,6 +268,12 @@ func handleResult(w http.ResponseWriter, r *http.Request, id string) {
 
 	snap := j.Snapshot()
 
+	// キャンセル済み（ログアウト等で中断）は結果がない終端状態。ポーラーが確定応答を得られるようにする
+	if snap.Status == model.StatusCancelled {
+		sendJSON(w, http.StatusOK, map[string]string{"status": string(model.StatusCancelled)})
+		return
+	}
+
 	if snap.Status != model.StatusDone && snap.Status != model.StatusError {
 		if snap.PreliminaryReport != "" {
 			sendMatchesResponse(w, http.StatusOK, snap.PreliminaryReport, string(snap.Status), snap.UserKey, true)

--- a/static/app.js
+++ b/static/app.js
@@ -1017,6 +1017,8 @@ async function reanalyzeWithSession() {
       if (statusData.logged_in && statusData.has_preliminary_report && statusData.preliminary_version > lastPreliminaryVersion) {
         var prelimRes = await fetch('/result/' + jobId);
         var prelimData = await prelimRes.json();
+        // fetch中にログアウトした場合、古いレポート描画やIndexedDB再作成を防ぐ
+        if (activeJobId !== jobId) return;
         if (prelimData.matches && prelimData.preliminary) {
           if (prelimData.user_key) {
             saveMatchesToDB(prelimData.user_key, prelimData.matches);
@@ -1042,6 +1044,8 @@ async function reanalyzeWithSession() {
       if (statusData.status === 'done') {
         var resultRes = await fetch('/result/' + jobId);
         var resultData = await resultRes.json();
+        // fetch中にログアウトした場合、古いレポート描画やIndexedDB再作成を防ぐ
+        if (activeJobId !== jobId) return;
         if (resultData.error) throw new Error(resultData.error);
         if (resultData.user_key && resultData.matches) {
           await saveMatchesToDB(resultData.user_key, resultData.matches);
@@ -1063,8 +1067,9 @@ async function logout() {
   // 実行中の分析ジョブがあればスクレイピングを中断し、ポーリングを停止する
   var jid = activeJobId;
   activeJobId = null;
+  // キャンセルは撃ちっぱなし（await しない）。/cancel が詰まってもセッション削除・UIリセットを止めない
   if (jid) {
-    try { await fetch('/cancel/' + jid, { method: 'POST' }); } catch (e) {}
+    try { fetch('/cancel/' + jid, { method: 'POST' }).catch(function () {}); } catch (e) {}
   }
   try {
     await fetch('/session', { method: 'DELETE' });
@@ -1416,6 +1421,8 @@ async function analyze() {
       if (statusData.logged_in && statusData.has_preliminary_report && statusData.preliminary_version > lastPreliminaryVersion) {
         var prelimRes = await fetch('/result/' + jobId);
         var prelimData = await prelimRes.json();
+        // fetch中にログアウトした場合、古いレポート描画やIndexedDB再作成を防ぐ
+        if (activeJobId !== jobId) return;
         if (prelimData.matches && prelimData.preliminary) {
           if (prelimData.user_key) {
             saveMatchesToDB(prelimData.user_key, prelimData.matches);
@@ -1436,6 +1443,8 @@ async function analyze() {
       if (statusData.status === 'done') {
         var resultRes = await fetch('/result/' + jobId);
         var resultData = await resultRes.json();
+        // fetch中にログアウトした場合、古いレポート描画やIndexedDB再作成を防ぐ
+        if (activeJobId !== jobId) return;
 
         if (resultData.error) {
           throw new Error(resultData.error);

--- a/static/app.js
+++ b/static/app.js
@@ -40,6 +40,9 @@ var STATUS_MESSAGES = {
   error: 'エラーが発生しました',
 };
 
+// 実行中の分析ジョブID。ログアウト時にこのジョブのスクレイピングを中断し、ポーリングを停止するために使う
+var activeJobId = null;
+
 var PERIOD_KEYS = ['all', '90d', '60d', '30d', '14d', '7d', '3d', '1d'];
 
 // --- Calendar component ---
@@ -976,9 +979,12 @@ async function reanalyzeWithSession() {
     }
 
     var jobId = data.id;
+    activeJobId = jobId;
 
     while (true) {
       await new Promise(function (r) { setTimeout(r, 3000); });
+      // ログアウト等でジョブが中断/切り替わった場合はポーリングを停止する
+      if (activeJobId !== jobId) return;
 
       var statusRes = await fetch('/status/' + jobId);
       var statusData = await statusRes.json();
@@ -1021,6 +1027,8 @@ async function reanalyzeWithSession() {
         }
       }
 
+      if (statusData.status === 'cancelled') return;
+
       if (statusData.status === 'error') {
         if (statusData.error && statusData.error.indexOf('セッション') >= 0) {
           localStorage.removeItem('catalyzer_user_key');
@@ -1046,11 +1054,18 @@ async function reanalyzeWithSession() {
     error.style.display = 'block';
     error.textContent = e.message;
   } finally {
+    if (activeJobId === jobId) activeJobId = null;
     status.style.display = 'none';
   }
 }
 
 async function logout() {
+  // 実行中の分析ジョブがあればスクレイピングを中断し、ポーリングを停止する
+  var jid = activeJobId;
+  activeJobId = null;
+  if (jid) {
+    try { await fetch('/cancel/' + jid, { method: 'POST' }); } catch (e) {}
+  }
   try {
     await fetch('/session', { method: 'DELETE' });
   } catch (e) {}
@@ -1362,9 +1377,12 @@ async function analyze() {
     }
 
     var jobId = data.id;
+    activeJobId = jobId;
 
     while (true) {
       await new Promise(function (r) { setTimeout(r, 3000); });
+      // ログアウト等でジョブが中断/切り替わった場合はポーリングを停止する
+      if (activeJobId !== jobId) return;
 
       var statusRes = await fetch('/status/' + jobId);
       var statusData = await statusRes.json();
@@ -1409,6 +1427,8 @@ async function analyze() {
         }
       }
 
+      if (statusData.status === 'cancelled') return;
+
       if (statusData.status === 'error') {
         throw new Error(statusData.error || '分析に失敗しました');
       }
@@ -1450,6 +1470,7 @@ async function analyze() {
     }
     document.getElementById('loginForm').style.display = 'block';
   } finally {
+    if (activeJobId === jobId) activeJobId = null;
     btn.disabled = false;
     status.style.display = 'none';
   }


### PR DESCRIPTION
分析開始直後にログアウトしても、バックエンドのスクレイピングが最後まで
走り続けていた。ログアウトで即座にスクレイピングを止められるようにする。

- scraper: ScrapingOption に Context を追加し、内部の403キャンセル用contextを
  呼び出し元Contextの子にする。外部キャンセル（ログアウト）は親ctxの完了で
  検出し ErrCanceled を返す（内部403キャンセルとは区別され、途中データ保存や
  403ブロックを発動させない）
- model: StatusCancelled を追加
- pipeline: Job に per-job context/cancel を持たせ（NewJobで生成）、CancelJob を
  追加。Run はキャンセル時に何も保存せず cancelled 状態にする
- server: POST /cancel/{id} を追加（ログアウト時に呼ぶ）
- frontend: 実行中ジョブIDを保持し、logout() で /cancel を叩いてポーリングも停止

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WSrv3rJusjU4xKY2Uj7XEW