### PR TITLE
perf: /matches の差分取得をFirestoreクエリレベルで絞り込む

### DIFF
--- a/internal/firestore/scores.go
+++ b/internal/firestore/scores.go
@@ -127,6 +127,36 @@ func LoadScores(userKey string) (model.DatedScores, error) {
 		return nil, fmt.Errorf("query matches: %w", err)
 	}
 
+	return docsToScores(docs), nil
+}
+
+// LoadScoresAfter はFirestoreからユーザーのafterより後（>）のmatchesのみ読み取り、
+// datetime昇順のDatedScoresで返す。差分取得用に全量読み取りを避けるためのクエリレベルフィルタ。
+// 境界はBuildMatchDataのメモリフィルタ（Datetime.After(after)）と揃えて厳密な `>` とする。
+func LoadScoresAfter(userKey string, after time.Time) (model.DatedScores, error) {
+	c := getClient()
+	if c == nil {
+		return nil, fmt.Errorf("firestore client not initialized")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), loadScoresTimeout)
+	defer cancel()
+
+	userRef := c.Collection("users").Doc(userKey)
+	docs, err := userRef.Collection("matches").
+		Where("datetime", ">", after).
+		OrderBy("datetime", firestore.Asc).
+		Documents(ctx).GetAll()
+	if err != nil {
+		return nil, fmt.Errorf("query matches after %s: %w", after.Format(time.RFC3339), err)
+	}
+
+	return docsToScores(docs), nil
+}
+
+// docsToScores はmatchesドキュメント群をDatedScoresに変換する。
+// 各試合のMatchTimelineはPlayerNo==1のDatedScoreにセットされる。
+func docsToScores(docs []*firestore.DocumentSnapshot) model.DatedScores {
 	scores := make(model.DatedScores, 0, len(docs)*4)
 	for _, doc := range docs {
 		var md matchDoc
@@ -171,7 +201,7 @@ func LoadScores(userKey string) (model.DatedScores, error) {
 		}
 	}
 
-	return scores, nil
+	return scores
 }
 
 // GetLatestDatetime はFirestoreからユーザーの最新試合日時を取得する。

--- a/internal/pipeline/matchdata.go
+++ b/internal/pipeline/matchdata.go
@@ -168,8 +168,16 @@ func BuildMatchData(ds model.DatedScores, costsMap map[string]int, after time.Ti
 }
 
 // GetMatchData はFirestoreからscoresを読み取り、フロントエンド向けの試合データを返す。
+// afterが非ゼロの場合はFirestoreクエリレベルで差分（datetime > after）のみ読み取り、
+// 全量読み取りによるレイテンシと読み取りコストを避ける。
 func GetMatchData(userKey string, after time.Time) ([]MatchData, error) {
-	scores, err := fs.LoadScores(userKey)
+	var scores model.DatedScores
+	var err error
+	if after.IsZero() {
+		scores, err = fs.LoadScores(userKey)
+	} else {
+		scores, err = fs.LoadScoresAfter(userKey, after)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("load scores: %w", err)
 	}

--- a/internal/pipeline/matchdata.go
+++ b/internal/pipeline/matchdata.go
@@ -94,6 +94,10 @@ func buildActions(timeline *model.MatchTimeline, group string) []ActionJSON {
 func BuildMatchData(ds model.DatedScores, costsMap map[string]int, after time.Time) []MatchData {
 	groups := make(map[string][]model.DatedScore)
 	for _, d := range ds {
+		// afterフィルタ。GetMatchData経由ではLoadScoresAfterがFirestore側で
+		// datetime > after に絞るためここは冗長だが、全量LoadScores経路や
+		// 他呼び出し元からの安全網として残す。境界はLoadScoresAfterの `>` と
+		// 揃えて厳密なAfter（>）とする——ここを >= に緩めると両者が食い違う。
 		if !after.IsZero() && !d.Datetime.After(after) {
 			continue
 		}

--- a/internal/pipeline/matchdata_test.go
+++ b/internal/pipeline/matchdata_test.go
@@ -1,0 +1,78 @@
+package pipeline
+
+import (
+	"testing"
+	"time"
+
+	"github.com/yuki9431/catalyzer/internal/model"
+)
+
+// match は4人分のDatedScoreを同一datetimeで生成するテストヘルパー。
+// PlayerNo 1..4 に p1Win を自分(PlayerNo 1)の勝敗として割り当てる。
+func match(dt time.Time, p1Win bool) model.DatedScores {
+	ds := make(model.DatedScores, 4)
+	for i := 0; i < 4; i++ {
+		ds[i] = model.DatedScore{
+			PlayerNo: i + 1,
+			Datetime: dt,
+			PlayerScore: model.PlayerScore{
+				Name: string(rune('a' + i)),
+				Win:  (i < 2) == p1Win, // team1(PlayerNo 1,2)はp1Winと同じ勝敗
+			},
+		}
+	}
+	return ds
+}
+
+func TestBuildMatchData_AfterBoundaryIsStrict(t *testing.T) {
+	base := time.Date(2026, 7, 4, 21, 30, 0, 0, time.UTC)
+
+	var scores model.DatedScores
+	// after と完全一致（境界そのもの）— 厳密な > なので除外されるべき
+	scores = append(scores, match(base, true)...)
+	// after より1分後 — 含まれるべき
+	scores = append(scores, match(base.Add(time.Minute), false)...)
+	// after より前 — 除外されるべき
+	scores = append(scores, match(base.Add(-time.Minute), true)...)
+
+	got := BuildMatchData(scores, nil, base)
+
+	if len(got) != 1 {
+		t.Fatalf("境界(=after)と過去は除外し、after超のみ返すはず: want 1 match, got %d", len(got))
+	}
+	wantDate := base.Add(time.Minute).Format("2006-01-02 15:04")
+	if got[0].Date != wantDate {
+		t.Errorf("返された試合の日時が不正: want %q, got %q", wantDate, got[0].Date)
+	}
+}
+
+func TestBuildMatchData_ZeroAfterReturnsAll(t *testing.T) {
+	base := time.Date(2026, 7, 4, 21, 30, 0, 0, time.UTC)
+
+	var scores model.DatedScores
+	scores = append(scores, match(base, true)...)
+	scores = append(scores, match(base.Add(time.Hour), false)...)
+
+	got := BuildMatchData(scores, nil, time.Time{})
+
+	if len(got) != 2 {
+		t.Fatalf("afterゼロ値なら全試合を返すはず: want 2 matches, got %d", len(got))
+	}
+	// datetime昇順で返ること
+	if got[0].Date >= got[1].Date {
+		t.Errorf("試合はdatetime昇順で返るはず: got[0]=%q got[1]=%q", got[0].Date, got[1].Date)
+	}
+}
+
+func TestBuildMatchData_IncompleteMatchDropped(t *testing.T) {
+	base := time.Date(2026, 7, 4, 21, 30, 0, 0, time.UTC)
+
+	// 3人しかいない試合はスキップされる（4人揃わないと集計できない）
+	scores := match(base, true)[:3]
+
+	got := BuildMatchData(scores, nil, time.Time{})
+
+	if len(got) != 0 {
+		t.Fatalf("4人揃わない試合はスキップされるはず: want 0, got %d", len(got))
+	}
+}


### PR DESCRIPTION
## 概要

`GET /matches?user_key=&after=` が `after` 指定時でも `LoadScores` で全scoresをFirestoreから読み取り、メモリ上でフィルタしていた無駄を解消する。

## 変更内容

- `internal/firestore/scores.go`
  - `LoadScoresAfter(userKey, after)` を追加。`Where("datetime", ">", after)` でFirestoreクエリレベルに差分フィルタを適用。
  - `LoadScores` と共通のドキュメント変換ロジックを `docsToScores` ヘルパーに切り出して重複を排除。
- `internal/pipeline/matchdata.go`
  - `GetMatchData` で `after` 非ゼロ時に `LoadScoresAfter` を使うよう分岐。ゼロ時は従来通り全量読み取り。

## 設計メモ

- 境界は既存の `BuildMatchData` のメモリフィルタ（`Datetime.After(after)`）と揃えて厳密な `>`。`After()` は絶対時刻比較なので、同一の `after` 値をFirestoreクエリに渡すことで結果集合は不変。
- `Where("datetime", ">")` と `OrderBy("datetime", Asc)` は不等式フィールドと先頭OrderByが同一のため合成インデックス不要（単一フィールドインデックスで動作）。
- `BuildMatchData` のメモリフィルタはクエリ絞り込み後は冗長になるが、安全網として残置。

## 検証

- `go build ./cmd/server` ✅
- `go test -race ./internal/...` ✅
- `go vet ./internal/...` ✅
- `gofmt -l` 差分ゼロ ✅
- golangci-lint はCIで実行

## 残課題・制限

- firestoreパッケージは従来より単体テスト無し（emulator前提）。本変更もその方針を踏襲し、クエリ挙動はstgデプロイで確認する。

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)