### PR TITLE
feat: タブに応じてKPIグリッド上部6指標を切り替え (#326)

### DIFF
--- a/static/__tests__/stats.test.js
+++ b/static/__tests__/stats.test.js
@@ -20,6 +20,9 @@ import {
   computeBurstTiming,
   computeBurstType,
   computeFixedPartners,
+  burstKpi,
+  bestWorstHour,
+  partnerKpi,
 } from '../analysis/stats.js';
 
 function makeMatch(overrides) {
@@ -718,5 +721,115 @@ describe('computeFixedPartners', function () {
     var matches = makeMatches(5, { partner_name: '別の人' });
     var result = computeFixedPartners(matches, tagPartners);
     assert.deepEqual(result.partners, []);
+  });
+});
+
+// --- burstKpi (タブ別KPI: 覚醒) ---
+
+describe('burstKpi', function () {
+  it('returns nulls for null / empty input', function () {
+    var empty = { rate2: null, winRate2: null, rate0: null, winRate0: null };
+    assert.deepEqual(burstKpi(null), empty);
+    assert.deepEqual(burstKpi({ by_count: [] }), empty);
+    assert.deepEqual(burstKpi({}), empty);
+  });
+
+  it('computes 2覚醒以上/未覚醒 の割合と加重勝率', function () {
+    // count>=2: 2回(4試合,勝率50) + 3回(1試合,勝率100) → 5/10=50%, 加重勝率=(2+1)/5=60%
+    // count==0: 2試合,勝率0 → 2/10=20%, 勝率0
+    var burstCount = {
+      by_count: [
+        { count: 0, matches: 2, win_rate: 0 },
+        { count: 1, matches: 3, win_rate: 100 },
+        { count: 2, matches: 4, win_rate: 50 },
+        { count: 3, matches: 1, win_rate: 100 },
+      ],
+    };
+    var r = burstKpi(burstCount);
+    assert.equal(r.rate2, 50);
+    assert.equal(r.winRate2, 60);
+    assert.equal(r.rate0, 20);
+    assert.equal(r.winRate0, 0);
+  });
+
+  it('winRate は該当試合が無ければ null（割合は 0）', function () {
+    var r = burstKpi({ by_count: [{ count: 1, matches: 5, win_rate: 40 }] });
+    assert.equal(r.rate2, 0);
+    assert.equal(r.winRate2, null);
+    assert.equal(r.rate0, 0);
+    assert.equal(r.winRate0, null);
+  });
+
+  it('computeBurstCount の実出力を受け取れる', function () {
+    var matches = makeMatches(3, { bursts: 2, win: true, actions: [{ event: 'x' }] });
+    var r = burstKpi(computeBurstCount(matches));
+    assert.equal(r.rate2, 100);
+    assert.equal(r.winRate2, 100);
+  });
+});
+
+// --- bestWorstHour (タブ別KPI: 時間帯) ---
+
+describe('bestWorstHour', function () {
+  it('returns nulls for null / empty', function () {
+    assert.deepEqual(bestWorstHour(null), { best: null, worst: null });
+    assert.deepEqual(bestWorstHour({ hours: [] }), { best: null, worst: null });
+  });
+
+  it('picks max/min win_rate among hours meeting minMatches', function () {
+    var tod = { hours: [
+      { hour: 10, matches: 5, win_rate: 70 },
+      { hour: 14, matches: 5, win_rate: 30 },
+      { hour: 20, matches: 1, win_rate: 100 }, // 閾値未満で除外
+    ] };
+    var r = bestWorstHour(tod, 3);
+    assert.equal(r.best.hour, 10);
+    assert.equal(r.worst.hour, 14);
+  });
+
+  it('falls back to all hours when none meet minMatches', function () {
+    var tod = { hours: [
+      { hour: 9, matches: 1, win_rate: 40 },
+      { hour: 21, matches: 2, win_rate: 80 },
+    ] };
+    var r = bestWorstHour(tod, 5);
+    assert.equal(r.best.hour, 21);
+    assert.equal(r.worst.hour, 9);
+  });
+
+  it('computeTimeOfDay の実出力を受け取れる', function () {
+    var matches = makeMatches(5, function (i) { return { date: '2025-06-15 14:0' + i }; });
+    var r = bestWorstHour(computeTimeOfDay(matches));
+    assert.equal(r.best.hour, 14);
+    assert.equal(r.worst.hour, 14);
+  });
+});
+
+// --- partnerKpi (タブ別KPI: 機体相性) ---
+
+describe('partnerKpi', function () {
+  it('returns zero/nulls for null / empty', function () {
+    assert.deepEqual(partnerKpi(null), { count: 0, top: null, bestWinRate: null });
+    assert.deepEqual(partnerKpi([]), { count: 0, top: null, bestWinRate: null });
+  });
+
+  it('top は先頭（試合数降順前提）、bestWinRate は最高勝率', function () {
+    var partner = [
+      { ms: 'A', matches: 10, win_rate: 40 },
+      { ms: 'B', matches: 5, win_rate: 90 },
+      { ms: 'C', matches: 3, win_rate: 60 },
+    ];
+    var r = partnerKpi(partner);
+    assert.equal(r.count, 3);
+    assert.equal(r.top.ms, 'A');
+    assert.equal(r.bestWinRate.ms, 'B');
+  });
+
+  it('computePartner の実出力を受け取れる', function () {
+    var matches = makeMatches(4, { partner_ms: 'ザク', win: true });
+    var r = partnerKpi(computePartner(matches));
+    assert.equal(r.count, 1);
+    assert.equal(r.top.ms, 'ザク');
+    assert.equal(r.bestWinRate.ms, 'ザク');
   });
 });

--- a/static/analysis/stats.js
+++ b/static/analysis/stats.js
@@ -654,6 +654,63 @@ export function computeBurstCount(matches) {
   return { by_count: results, tips: tips };
 }
 
+// タブ別KPI用の派生指標。computeBurstCount の結果から
+// 「2回以上覚醒」「未覚醒(0回)」の割合と加重勝率を算出する。
+// データ無し（null や空）のときは各値 null を返す。
+export function burstKpi(burstCount) {
+  var empty = { rate2: null, winRate2: null, rate0: null, winRate0: null };
+  if (!burstCount || !burstCount.by_count || !burstCount.by_count.length) return empty;
+  var byCount = burstCount.by_count;
+  var total = 0;
+  byCount.forEach(function (b) { total += b.matches; });
+  if (total === 0) return empty;
+
+  // 加重勝率: win_rate は各グループの割合なので試合数で重み付けして合算する
+  function group(predicate) {
+    var m = 0, wins = 0;
+    byCount.forEach(function (b) {
+      if (!predicate(b.count)) return;
+      m += b.matches;
+      wins += b.win_rate / 100 * b.matches;
+    });
+    return {
+      rate: round1(m / total * 100),
+      winRate: m ? round1(wins / m * 100) : null,
+    };
+  }
+
+  var two = group(function (c) { return c >= 2; });
+  var zero = group(function (c) { return c === 0; });
+  return { rate2: two.rate, winRate2: two.winRate, rate0: zero.rate, winRate0: zero.winRate };
+}
+
+// タブ別KPI用。computeTimeOfDay の結果から勝率が最高/最低の時間帯を返す。
+// minMatches 以上の時間帯を対象にし、該当が無ければ全時間帯にフォールバックする。
+export function bestWorstHour(timeOfDay, minMatches) {
+  if (minMatches === undefined) minMatches = 3;
+  if (!timeOfDay || !timeOfDay.hours || !timeOfDay.hours.length) return { best: null, worst: null };
+  var hours = timeOfDay.hours.filter(function (h) { return h.matches >= minMatches; });
+  if (!hours.length) hours = timeOfDay.hours;
+  var best = hours[0], worst = hours[0];
+  hours.forEach(function (h) {
+    if (h.win_rate > best.win_rate) best = h;
+    if (h.win_rate < worst.win_rate) worst = h;
+  });
+  return { best: best, worst: worst };
+}
+
+// タブ別KPI用。computePartner の結果（試合数降順）から
+// ユニーク相方数・最多相方・最高勝率相方を返す。
+export function partnerKpi(partner) {
+  if (!partner || !partner.length) return { count: 0, top: null, bestWinRate: null };
+  var top = partner[0]; // computePartner は試合数降順ソート済み
+  var best = partner[0];
+  partner.forEach(function (p) {
+    if (p.win_rate > best.win_rate) best = p;
+  });
+  return { count: partner.length, top: top, bestWinRate: best };
+}
+
 export function computeFallOrder(matches) {
   var noFall = [], firstFall = [], secondFall = [], sameTime = [];
   matches.forEach(function (d) {

--- a/static/app.js
+++ b/static/app.js
@@ -8,6 +8,7 @@ import {
   computeBurstCount, computeFallOrder, computeBurstTiming, computeBurstType,
   computeFixedPartners,
   computeShareData, computeMsSummary,
+  burstKpi, bestWorstHour, partnerKpi,
 } from './analysis/stats.js';
 import {
   loadMatchesFromDB, saveMatchesToDB,
@@ -418,16 +419,90 @@ function Panel({ title, children }) {
   </div>`;
 }
 
-function KpiGrid({ stats }) {
-  if (!stats) return null;
-  var cards = [
-    { label: '対戦数', value: stats.matches, cls: '', sub: stats.wins + '勝 ' + stats.losses + '敗' },
-    { label: '勝率', value: pct(stats.win_rate), cls: kpiClass(stats.win_rate, 60, 50, 40, true), sub: '' },
-    { label: '平均与ダメージ', value: num(stats.avg_dmg_given), cls: kpiClass(stats.avg_dmg_given, 1100, 900, 700, true), sub: '' },
-    { label: '平均被ダメージ', value: num(stats.avg_dmg_taken), cls: kpiClass(stats.avg_dmg_taken, 700, 800, 900, false), sub: '' },
-    { label: '平均EXダメージ', value: num(stats.avg_ex_dmg), cls: kpiClass(stats.avg_ex_dmg, 200, 160, 100, true), sub: '' },
-    { label: '与被ダメ比', value: num(stats.dmg_efficiency, 2), cls: kpiClass(stats.dmg_efficiency, 1.2, 1.0, 0.8, true), sub: '' },
+function kpiCard(label, value, cls, sub) {
+  return { label: label, value: value, cls: cls || '', sub: sub || '' };
+}
+
+var WR_KPI = [60, 50, 40, true]; // 勝率カード共通のしきい値（great/good/terrible/higher）
+function wrClass(wr) { return kpiClass(wr, WR_KPI[0], WR_KPI[1], WR_KPI[2], WR_KPI[3]); }
+
+// activeTab に応じた6枚のKPIカードを構築する。基本統計が無ければ null。
+// 各タブの派生指標は frontendData 内のデータで完結し、欠損時は '-' 表示にする。
+function buildKpiCards(activeTab, fd) {
+  var basic = fd && fd.basic_stats;
+  if (!basic) return null;
+  var matchesCard = kpiCard('対戦数', basic.matches, '', basic.wins + '勝 ' + basic.losses + '敗');
+
+  if (activeTab === 'playstyle') {
+    var fo = fd.fall_order;
+    var dc = fd.dmg_contribution;
+    // buildStats は該当0件でも win_rate:0 を返すため、count で「データ不在」と「実績0%」を区別する
+    var ff = fo && fo.first_fall.count ? fo.first_fall : null;
+    var nf = fo && fo.no_fall.count ? fo.no_fall : null;
+    return [
+      kpiCard('先落ち率', fo ? pct(fo.first_fall.rate) : '-'),
+      kpiCard('先落ち勝率', ff ? pct(ff.win_rate) : '-', ff ? wrClass(ff.win_rate) : ''),
+      kpiCard('0落ち勝率', nf ? pct(nf.win_rate) : '-', nf ? wrClass(nf.win_rate) : ''),
+      kpiCard('ダメ貢献率', dc ? pct(dc.avg_contribution) : '-'),
+      kpiCard('勝ち時貢献率', dc ? pct(dc.avg_win_contribution) : '-'),
+      kpiCard('K/D比', num(basic.kd_ratio, 2), kpiClass(basic.kd_ratio, 1.2, 1.0, 0.8, true)),
+    ];
+  }
+
+  if (activeTab === 'burst') {
+    var bk = burstKpi(fd.burst_count);
+    return [
+      kpiCard('平均覚醒回数', basic.avg_bursts != null ? num(basic.avg_bursts, 2) : '-'),
+      kpiCard('2覚醒率', pct(bk.rate2)),
+      kpiCard('2覚醒時勝率', pct(bk.winRate2), wrClass(bk.winRate2)),
+      kpiCard('未覚醒率', pct(bk.rate0)),
+      kpiCard('未覚醒時勝率', pct(bk.winRate0), wrClass(bk.winRate0)),
+      matchesCard,
+    ];
+  }
+
+  if (activeTab === 'matchup') {
+    var em = fd.enemy_matchup;
+    var pk = partnerKpi(fd.partner);
+    return [
+      kpiCard('得意機体数', em ? em.strong.length : '-', '', '勝率60%以上'),
+      kpiCard('苦手機体数', em ? em.weak.length : '-', '', '勝率40%以下'),
+      kpiCard('相方数', pk.count, '', '3戦以上'),
+      kpiCard('最多相方', pk.top ? pk.top.matches : '-', '', pk.top ? pk.top.ms : ''),
+      kpiCard('相方最高勝率', pk.bestWinRate ? pct(pk.bestWinRate.win_rate) : '-', pk.bestWinRate ? wrClass(pk.bestWinRate.win_rate) : '', pk.bestWinRate ? pk.bestWinRate.ms : ''),
+      matchesCard,
+    ];
+  }
+
+  if (activeTab === 'time') {
+    var bw = bestWorstHour(fd.time_of_day);
+    var dow = fd.day_of_week;
+    var wd = dow && dow.weekday, we = dow && dow.weekend;
+    var days = fd.daily_trend && fd.daily_trend.days ? fd.daily_trend.days.length : null;
+    return [
+      kpiCard('最高勝率時間帯', bw.best ? bw.best.hour + '時' : '-', bw.best ? wrClass(bw.best.win_rate) : '', bw.best ? pct(bw.best.win_rate) : ''),
+      kpiCard('最低勝率時間帯', bw.worst ? bw.worst.hour + '時' : '-', bw.worst ? wrClass(bw.worst.win_rate) : '', bw.worst ? pct(bw.worst.win_rate) : ''),
+      kpiCard('平日勝率', wd && wd.matches ? pct(wd.win_rate) : '-', wd && wd.matches ? wrClass(wd.win_rate) : ''),
+      kpiCard('土日勝率', we && we.matches ? pct(we.win_rate) : '-', we && we.matches ? wrClass(we.win_rate) : ''),
+      kpiCard('プレイ日数', days != null ? days : '-', '', '日'),
+      matchesCard,
+    ];
+  }
+
+  // overview（総合）: 現状維持
+  return [
+    matchesCard,
+    kpiCard('勝率', pct(basic.win_rate), wrClass(basic.win_rate)),
+    kpiCard('平均与ダメージ', num(basic.avg_dmg_given), kpiClass(basic.avg_dmg_given, 1100, 900, 700, true)),
+    kpiCard('平均被ダメージ', num(basic.avg_dmg_taken), kpiClass(basic.avg_dmg_taken, 700, 800, 900, false)),
+    kpiCard('平均EXダメージ', num(basic.avg_ex_dmg), kpiClass(basic.avg_ex_dmg, 200, 160, 100, true)),
+    kpiCard('与被ダメ比', num(basic.dmg_efficiency, 2), kpiClass(basic.dmg_efficiency, 1.2, 1.0, 0.8, true)),
   ];
+}
+
+function KpiGrid({ activeTab, frontendData }) {
+  var cards = buildKpiCards(activeTab, frontendData);
+  if (!cards) return null;
   return html`<div class="kpi-grid">${cards.map(function (c) {
     return html`<div class="kpi">
       <div class="kpi-label">${c.label}</div>
@@ -1255,7 +1330,7 @@ function Report({ data, userKey }) {
       shareData=${shareData}
       onLogout=${logout} />
 
-    <${KpiGrid} stats=${fePd.basic_stats} />
+    <${KpiGrid} activeTab=${activeTab} frontendData=${frontendData} />
 
     ${pane}
 


### PR DESCRIPTION
## 概要
Closes #326

分析ページ上部のKPIグリッド（6枚のカード）が全タブ共通の基本データ（対戦数/勝率/平均与ダメ/被ダメ/EXダメ/与被ダメ比）だったのを、**選択中タブの文脈に合った6指標**に切り替える。全て `frontendData` 内のデータで完結し、追加API呼び出しは無い。

## タブ別KPI
| タブ | 表示指標 |
|---|---|
| 総合 | 対戦数 / 勝率 / 平均与ダメ / 平均被ダメ / 平均EXダメ / 与被ダメ比（現状維持） |
| 立ち回り | 先落ち率 / 先落ち勝率 / 0落ち勝率 / ダメ貢献率 / 勝ち時貢献率 / K/D比 |
| 覚醒 | 平均覚醒回数 / 2覚醒率 / 2覚醒時勝率 / 未覚醒率 / 未覚醒時勝率 / 対戦数 |
| 機体相性 | 得意機体数 / 苦手機体数 / 相方数 / 最多相方 / 相方最高勝率 / 対戦数 |
| 時間帯 | 最高勝率時間帯 / 最低勝率時間帯 / 平日勝率 / 土日勝率 / プレイ日数 / 対戦数 |

## 実装
- `static/app.js`: `KpiGrid({activeTab, frontendData})` に変更。`buildKpiCards(activeTab, fd)` でタブ別に6カードを構築
- `static/analysis/stats.js`: 派生指標の純粋関数 `burstKpi` / `bestWorstHour` / `partnerKpi` を追加（export・テスト済み）
- データ欠損（`fall_order`/`burst_count` の null、0件グループ、`avg_bursts` null 等）は `-` 表示にフォールバック

## 検証
- `node --test 'static/__tests__/*.test.js'` → **87 pass / 0 fail**（新規11件: burstKpi 4 / bestWorstHour 4 / partnerKpi 3）
- `node --check static/app.js static/analysis/stats.js` OK
- overview タブはラベル・値・色しきい値まで旧実装と1:1一致（非破壊を確認）

## 補足
issueの候補にあった `burst_hold_death`（抱え落ち）は未実装フィールドのため、既存の `burst_count` から算出できる「2覚醒率/未覚醒率」等に置き換えた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)