### PR TITLE
feat: 勝利/敗北レンズをレポート全体に適用

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1167,6 +1167,9 @@ function Report({ data, userKey }) {
     var shareItems = computeShareData(periodFiltered);
     var filtered = periodFiltered;
     if (selectedMs) filtered = filtered.filter(function (m) { return m.ms === selectedMs; });
+    // 勝敗レンズ: 選択時はレポート全体を勝ち/負け試合のみに絞る（MS一覧・共有データは母集団のまま）
+    if (lens === 'win') filtered = filtered.filter(function (m) { return m.win; });
+    else if (lens === 'loss') filtered = filtered.filter(function (m) { return !m.win; });
     if (!filtered.length) return { ms_summary: msSummary, share_data: shareItems };
     return {
       ms_summary: msSummary,
@@ -1189,7 +1192,7 @@ function Report({ data, userKey }) {
       burst_type: computeBurstType(filtered),
       fixed_partners: computeFixedPartners(filtered, tagPartners),
     };
-  }, [allMatches, selectedPeriod, selectedMs, tagPartners, customRange]);
+  }, [allMatches, selectedPeriod, selectedMs, lens, tagPartners, customRange]);
 
   var msStats = (frontendData && frontendData.ms_summary) || {};
   var msEntries = useMemo(function () {


### PR DESCRIPTION
## 概要
トップバーの勝敗レンズ（全体/勝利/敗北）が現状 OverviewPane の一部（基本データ・固定相方）にしか効かず、他タブや大半の分析は全データのままだった。**レンズ選択時にレポート全体を勝ち/負け試合のみに絞り込む**ようにする。

## 実装
`static/app.js` の `frontendData` useMemo で、期間・MSフィルタと同じ流儀で lens による絞り込みを1箇所追加（依存配列にも `lens` を追加）。

```js
if (lens === 'win') filtered = filtered.filter(m => m.win);
else if (lens === 'loss') filtered = filtered.filter(m => !m.win);
```

- MS一覧（セレクタ）・共有データは母集団のまま（`selectedMs` と同じ扱い）
- 勝率系指標は絞ると 100%/0% になるが、意図通り（ユーザー確認済み）

## 検証
- `node --check static/app.js` OK
- 全18 compute関数を勝ち/負けのみの部分集合で実行 → クラッシュ無し・`win_rate` は 100%/0% と期待通り
- 既存の `selectedMs` フィルタと同型の部分集合生成であり、下流のcompute関数群は既存パスで任意部分集合に対する実績あり
- 注: Preact描画のE2E（ブラウザでレンズ切替）は本プロジェクトにブラウザ自動化基盤が無いため未実施

## 補足
`skip-ci` ラベル付与（Go/Docker非関与のフロントエンドJSのみの変更のため）。