### PR TITLE
試合検索機能を実装 (#295)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,13 +98,15 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 - `internal/pipeline/` — 分析パイプライン（`Job`型、ジョブストア、`Run`関数、JSON生成、試合データ配信（`ActionJSON`型でタイムラインイベント展開）、セッション永続化）
 - `internal/server/` — HTTPハンドラ（`server.go`）+ IPベースレート制限（`ratelimit.go`）+ Basic認証（`basicauth.go`）+ 403一時ブロック（`block403.go`）+ セッション管理エンドポイント
 - `static/index.html` — SPA フロントエンド（ダークテーマ、レスポンシブ対応、カスタムドロップダウン）
-- `static/app.js` — フロントエンドJS本体（CSP対応で外部化。htm/Preactでレンダリング）。主要コンポーネント: Calendar/TimeSelector/PeriodSelector（期間指定）、ShareArea（SNS共有）、HamburgerMenu（左ドロワー）、MsSelector/LensToggle（トップバーフィルタ）、Panel/KpiGrid/CompareRadar/BasicLensSection/FixedPartnerPanel、5タブ構成（OverviewPane/PlaystylePane/BurstPane/MatchupPane/TimePane）、Report（状態管理・タブ切替・フロントエンド集計）。IndexedDBキャッシュからフロントエンドで全統計を計算
+- `static/app.js` — フロントエンドJS本体（CSP対応で外部化。htm/Preactでレンダリング）。主要コンポーネント: Calendar/TimeSelector/PeriodSelector（期間指定）、ShareArea（SNS共有）、HamburgerMenu（左ドロワー・レポート/試合検索の画面切替）、MsSelector/LensToggle（トップバーフィルタ）、Panel/KpiGrid/CompareRadar/BasicLensSection/FixedPartnerPanel、5タブ構成（OverviewPane/PlaystylePane/BurstPane/MatchupPane/TimePane）、Report（状態管理・タブ切替・レポート/検索ビュー切替・フロントエンド集計）。IndexedDBキャッシュからフロントエンドで全統計を計算
 - `static/analysis/stats.js` — 統計分析関数。時間帯/曜日/日別/シーズン/基本データ/勝敗パターン/敵相性/相方/コスト編成/MS編成/ダメージ貢献/被撃墜と勝率（自分×相方の2軸・回数ベース）/覚醒回数/先落ち後落ち/覚醒タイミング（発動時の被撃墜数で1機目/2機目/3機目に分類）/覚醒タイプ別傾向（F/S/E）/固定相方/SNS共有データ/MS別サマリー
+- `static/analysis/search.js` — 試合検索の純粋関数（機体名一覧の集計・条件絞り込み・並べ替え）。IndexedDBの全試合をフロントエンドでフィルタ
 - `static/components/ui.js` — 汎用UIコンポーネント（Tips/SortableTable/Table/SubSection）
+- `static/components/search.js` — 試合検索ビュー（SearchView）。フィルタフォーム＋結果一覧（ソート・ページネーション）＋試合詳細モーダル（自分/相方のスコア比較・タイムライン）
 - `static/components/charts.js` — Chart.jsグラフ＋レポートセクション（EnemyMatchupSection/PartnerSection/時間帯・曜日・日別・シーズンChart等）
 - `static/lib/db.js` — IndexedDBキャッシュ（試合データの保存・読み込み・差分取得）
 - `static/lib/format.js` — 書式ヘルパー（数値フォーマット・色分け・SVGアイコン・共有テキスト生成）
-- `static/__tests__/` — フロントエンドJSテスト（Node.js組み込みテストランナー、依存ゼロ。stats/formatの純粋関数テスト）
+- `static/__tests__/` — フロントエンドJSテスト（Node.js組み込みテストランナー、依存ゼロ。stats/format/searchの純粋関数テスト）
 - `static/htm-preact-standalone.js` — htm + Preact ライブラリ（スタンドアロン版）
 - `static/chart.umd.min.js` — Chart.js ライブラリ（グラフ描画用）
 - `static/preview.html` — フロントエンド開発用プレビュー（gitignore対象）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 - `static/analysis/stats.js` — 統計分析関数。時間帯/曜日/日別/シーズン/基本データ/勝敗パターン/敵相性/相方/コスト編成/MS編成/ダメージ貢献/被撃墜と勝率（自分×相方の2軸・回数ベース）/覚醒回数/先落ち後落ち/覚醒タイミング（発動時の被撃墜数で1機目/2機目/3機目に分類）/覚醒タイプ別傾向（F/S/E）/固定相方/SNS共有データ/MS別サマリー
 - `static/analysis/search.js` — 試合検索の純粋関数（機体名一覧の集計・条件絞り込み・並べ替え）。IndexedDBの全試合をフロントエンドでフィルタ
 - `static/components/ui.js` — 汎用UIコンポーネント（Tips/SortableTable/Table/SubSection）
-- `static/components/search.js` — 試合検索ビュー（SearchView）。フィルタフォーム＋結果一覧（ソート・ページネーション）＋試合詳細モーダル（自分/相方のスコア比較・タイムライン）
+- `static/components/search.js` — 試合検索ビュー（SearchView）。フィルタフォーム＋結果一覧（ソート・ページネーション）＋試合詳細モーダル（4人分のスコア一覧・試合経過）
 - `static/components/charts.js` — Chart.jsグラフ＋レポートセクション（EnemyMatchupSection/PartnerSection/時間帯・曜日・日別・シーズンChart等）
 - `static/lib/db.js` — IndexedDBキャッシュ（試合データの保存・読み込み・差分取得）
 - `static/lib/format.js` — 書式ヘルパー（数値フォーマット・色分け・SVGアイコン・共有テキスト生成）

--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -5,7 +5,7 @@ config:
   exvs-app:domain: stg.exvs-analyzer.com
   exvs-app:firestoreDatabase: exvs-analyzer
   exvs-app:image:
-    secure: v1:bqDf3phrJamvR9Tq:1J0o1EF8Kku/GRWA3Z9DMTHgOI0yDKyQJPnMq/DHPFGCUxrs+id29tYGdtxmVNCRDRK1IPm7A2kbn/HlG95Lw9vjdw7hoc0XueJbTcapcFvT2Ufs0/oWRt2jhBO/eN0BfAPY6f4or7Ze240t1ziH70/LpKIV8g==
+    secure: v1:MkxUoiQI21zx1nFa:QVv14Mkg5aMZh3ODzcQhzbxH+bVTyvnHSn6Phsa0kYcSUzre2+bujvxowv3dm93b83MyTSfn3RA+QFGPI9laP9wGbTAyH7d9jLuZYV0+tXPR3fISNzYSCo6exLHrLFznigVvMF+sDDH6Qc415nKjs2IyC2TdHg==
   exvs-app:maxInstances: "1"
   exvs-app:memory: 512Mi
   exvs-app:serviceName: stg-exvs-analyzer

--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -5,7 +5,7 @@ config:
   exvs-app:domain: stg.exvs-analyzer.com
   exvs-app:firestoreDatabase: exvs-analyzer
   exvs-app:image:
-    secure: v1:SYeTlfaaWjjR0+oa:RRgljGz1kBHuVc7QyPV0MowRGSLKX6DhFYxKX8uG7zhuOdlqhm8Dq4ejFXoeGmxaA5azrs88qkHDSSkss9XYQhvVbnpc8vgE0jhiw4DIY7kgbfuOZV4oyxlAALg/wc1+1pF51DEdEoqpvj3PNMd+UL8nQhVNqg==
+    secure: v1:1EwQaMiD58UfKXPr:cm6iW3mNpH1VFuSN0x0Z27ZRBmMIJsbIeyD4Km2HsdMMNG3Njb/ZFEbHbKc89KUQj/aW+6DB7dh3ScNmey047QsNlq9o2Qiareri5KujRHkWV1CstzEkH17471gJFcC66KEVE7/D0GfCFxvgr+8eBiSkgzhWtw==
   exvs-app:maxInstances: "1"
   exvs-app:memory: 512Mi
   exvs-app:serviceName: stg-exvs-analyzer

--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -5,7 +5,7 @@ config:
   exvs-app:domain: stg.exvs-analyzer.com
   exvs-app:firestoreDatabase: exvs-analyzer
   exvs-app:image:
-    secure: v1:MkxUoiQI21zx1nFa:QVv14Mkg5aMZh3ODzcQhzbxH+bVTyvnHSn6Phsa0kYcSUzre2+bujvxowv3dm93b83MyTSfn3RA+QFGPI9laP9wGbTAyH7d9jLuZYV0+tXPR3fISNzYSCo6exLHrLFznigVvMF+sDDH6Qc415nKjs2IyC2TdHg==
+    secure: v1:lNJrTh0HdJMvWPVM:DehzlQQOlkwQujuXgCZXohaK18G3l2gkkIbLCGQ30smajlabE/jBkihVF/ttTJ5L64OMmBZN8K7Yqv69dru2+4ITbGelWBjJbQkpeIgavNzXaJO5JWcTS9ddX+Xm7J9Eblvn9r5sdwkvAEsb+gETftb/SmmaYQ==
   exvs-app:maxInstances: "1"
   exvs-app:memory: 512Mi
   exvs-app:serviceName: stg-exvs-analyzer

--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -5,7 +5,7 @@ config:
   exvs-app:domain: stg.exvs-analyzer.com
   exvs-app:firestoreDatabase: exvs-analyzer
   exvs-app:image:
-    secure: v1:OzoNlbc5gny5JrUw:0nlngsnJoCecKHo9xVqiISEc+eiDU43zBUchVggEzY42A6fkZ0+7dZcCMbCObl3KZK9UNTqDq84h8sPK7JcBeVDVduWntt89bwj3D/IWroyR1HPPrgjLZsNyYS0mhKx9RgPBkeEkFy7964dfWyDS3Mk4EjuU+g==
+    secure: v1:SYeTlfaaWjjR0+oa:RRgljGz1kBHuVc7QyPV0MowRGSLKX6DhFYxKX8uG7zhuOdlqhm8Dq4ejFXoeGmxaA5azrs88qkHDSSkss9XYQhvVbnpc8vgE0jhiw4DIY7kgbfuOZV4oyxlAALg/wc1+1pF51DEdEoqpvj3PNMd+UL8nQhVNqg==
   exvs-app:maxInstances: "1"
   exvs-app:memory: 512Mi
   exvs-app:serviceName: stg-exvs-analyzer

--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -5,7 +5,7 @@ config:
   exvs-app:domain: stg.exvs-analyzer.com
   exvs-app:firestoreDatabase: exvs-analyzer
   exvs-app:image:
-    secure: v1:lNJrTh0HdJMvWPVM:DehzlQQOlkwQujuXgCZXohaK18G3l2gkkIbLCGQ30smajlabE/jBkihVF/ttTJ5L64OMmBZN8K7Yqv69dru2+4ITbGelWBjJbQkpeIgavNzXaJO5JWcTS9ddX+Xm7J9Eblvn9r5sdwkvAEsb+gETftb/SmmaYQ==
+    secure: v1:OzoNlbc5gny5JrUw:0nlngsnJoCecKHo9xVqiISEc+eiDU43zBUchVggEzY42A6fkZ0+7dZcCMbCObl3KZK9UNTqDq84h8sPK7JcBeVDVduWntt89bwj3D/IWroyR1HPPrgjLZsNyYS0mhKx9RgPBkeEkFy7964dfWyDS3Mk4EjuU+g==
   exvs-app:maxInstances: "1"
   exvs-app:memory: 512Mi
   exvs-app:serviceName: stg-exvs-analyzer

--- a/internal/pipeline/matchdata.go
+++ b/internal/pipeline/matchdata.go
@@ -26,8 +26,10 @@ type MatchData struct {
 	PartnerCost     int          `json:"partner_cost,omitempty"`
 	Opponent1MS     string       `json:"opponent1_ms"`
 	Opponent1Cost   int          `json:"opponent1_cost,omitempty"`
+	Opponent1Name   string       `json:"opponent1_name"`
 	Opponent2MS     string       `json:"opponent2_ms"`
 	Opponent2Cost   int          `json:"opponent2_cost,omitempty"`
+	Opponent2Name   string       `json:"opponent2_name"`
 	Win             bool         `json:"win"`
 	Score           int          `json:"score"`
 	Kills           int          `json:"kills"`
@@ -144,8 +146,10 @@ func BuildMatchData(ds model.DatedScores, costsMap map[string]int, after time.Ti
 			PartnerCost:     costsMap[mslist.StripQuery(partner.MsImageURL)],
 			Opponent1MS:     opp1.MsName,
 			Opponent1Cost:   costsMap[mslist.StripQuery(opp1.MsImageURL)],
+			Opponent1Name:   opp1.Name,
 			Opponent2MS:     opp2.MsName,
 			Opponent2Cost:   costsMap[mslist.StripQuery(opp2.MsImageURL)],
+			Opponent2Name:   opp2.Name,
 			Win:             me.Win,
 			Score:           me.Score,
 			Kills:           me.Kills,

--- a/internal/pipeline/matchdata.go
+++ b/internal/pipeline/matchdata.go
@@ -19,36 +19,49 @@ type ActionJSON struct {
 
 // MatchData はフロントエンド向けの試合データ（プレイヤー視点）
 type MatchData struct {
-	Date            string       `json:"date"`
-	MS              string       `json:"ms"`
-	MSCost          int          `json:"ms_cost,omitempty"`
-	PartnerMS       string       `json:"partner_ms"`
-	PartnerCost     int          `json:"partner_cost,omitempty"`
-	Opponent1MS     string       `json:"opponent1_ms"`
-	Opponent1Cost   int          `json:"opponent1_cost,omitempty"`
-	Opponent1Name   string       `json:"opponent1_name"`
-	Opponent2MS     string       `json:"opponent2_ms"`
-	Opponent2Cost   int          `json:"opponent2_cost,omitempty"`
-	Opponent2Name   string       `json:"opponent2_name"`
-	Win             bool         `json:"win"`
-	Score           int          `json:"score"`
-	Kills           int          `json:"kills"`
-	Deaths          int          `json:"deaths"`
-	DmgGiven        int          `json:"dmg_given"`
-	DmgTaken        int          `json:"dmg_taken"`
-	ExDmg           int          `json:"ex_dmg"`
-	PartnerName     string       `json:"partner_name"`
-	PartnerScore    int          `json:"partner_score"`
-	PartnerKills    int          `json:"partner_kills"`
-	PartnerDeaths   int          `json:"partner_deaths"`
-	PartnerDmgGiven int          `json:"partner_dmg_given"`
-	PartnerDmgTaken int          `json:"partner_dmg_taken"`
-	PartnerExDmg    int          `json:"partner_ex_dmg"`
-	Bursts          int          `json:"bursts"`
-	PartnerBursts   int          `json:"partner_bursts"`
-	Actions         []ActionJSON `json:"actions"`
-	PartnerActions  []ActionJSON `json:"partner_actions"`
-	GameEndSec      float64      `json:"game_end_sec,omitempty"`
+	Date            string `json:"date"`
+	MS              string `json:"ms"`
+	MSCost          int    `json:"ms_cost,omitempty"`
+	PartnerMS       string `json:"partner_ms"`
+	PartnerCost     int    `json:"partner_cost,omitempty"`
+	Opponent1MS     string `json:"opponent1_ms"`
+	Opponent1Cost   int    `json:"opponent1_cost,omitempty"`
+	Opponent1Name   string `json:"opponent1_name"`
+	Opponent2MS     string `json:"opponent2_ms"`
+	Opponent2Cost   int    `json:"opponent2_cost,omitempty"`
+	Opponent2Name   string `json:"opponent2_name"`
+	Win             bool   `json:"win"`
+	Score           int    `json:"score"`
+	Kills           int    `json:"kills"`
+	Deaths          int    `json:"deaths"`
+	DmgGiven        int    `json:"dmg_given"`
+	DmgTaken        int    `json:"dmg_taken"`
+	ExDmg           int    `json:"ex_dmg"`
+	PartnerName     string `json:"partner_name"`
+	PartnerScore    int    `json:"partner_score"`
+	PartnerKills    int    `json:"partner_kills"`
+	PartnerDeaths   int    `json:"partner_deaths"`
+	PartnerDmgGiven int    `json:"partner_dmg_given"`
+	PartnerDmgTaken int    `json:"partner_dmg_taken"`
+	PartnerExDmg    int    `json:"partner_ex_dmg"`
+	Bursts          int    `json:"bursts"`
+	PartnerBursts   int    `json:"partner_bursts"`
+	// 敵2機のスコア（公式「スコア」画面と同じ項目。覚醒回数はタイムライン側で扱う）
+	Opponent1Score    int          `json:"opponent1_score"`
+	Opponent1Kills    int          `json:"opponent1_kills"`
+	Opponent1Deaths   int          `json:"opponent1_deaths"`
+	Opponent1DmgGiven int          `json:"opponent1_dmg_given"`
+	Opponent1DmgTaken int          `json:"opponent1_dmg_taken"`
+	Opponent1ExDmg    int          `json:"opponent1_ex_dmg"`
+	Opponent2Score    int          `json:"opponent2_score"`
+	Opponent2Kills    int          `json:"opponent2_kills"`
+	Opponent2Deaths   int          `json:"opponent2_deaths"`
+	Opponent2DmgGiven int          `json:"opponent2_dmg_given"`
+	Opponent2DmgTaken int          `json:"opponent2_dmg_taken"`
+	Opponent2ExDmg    int          `json:"opponent2_ex_dmg"`
+	Actions           []ActionJSON `json:"actions"`
+	PartnerActions    []ActionJSON `json:"partner_actions"`
+	GameEndSec        float64      `json:"game_end_sec,omitempty"`
 }
 
 // countBursts はタイムラインから指定グループの覚醒回数を数える。
@@ -139,36 +152,48 @@ func BuildMatchData(ds model.DatedScores, costsMap map[string]int, after time.Ti
 		}
 
 		matches = append(matches, MatchData{
-			Date:            entries[0].Datetime.Format("2006-01-02 15:04"),
-			MS:              me.MsName,
-			MSCost:          costsMap[mslist.StripQuery(me.MsImageURL)],
-			PartnerMS:       partner.MsName,
-			PartnerCost:     costsMap[mslist.StripQuery(partner.MsImageURL)],
-			Opponent1MS:     opp1.MsName,
-			Opponent1Cost:   costsMap[mslist.StripQuery(opp1.MsImageURL)],
-			Opponent1Name:   opp1.Name,
-			Opponent2MS:     opp2.MsName,
-			Opponent2Cost:   costsMap[mslist.StripQuery(opp2.MsImageURL)],
-			Opponent2Name:   opp2.Name,
-			Win:             me.Win,
-			Score:           me.Score,
-			Kills:           me.Kills,
-			Deaths:          me.Deaths,
-			DmgGiven:        me.GiveDamage,
-			DmgTaken:        me.ReceiveDamage,
-			ExDmg:           me.ExDamage,
-			PartnerName:     partner.Name,
-			PartnerScore:    partner.Score,
-			PartnerKills:    partner.Kills,
-			PartnerDeaths:   partner.Deaths,
-			PartnerDmgGiven: partner.GiveDamage,
-			PartnerDmgTaken: partner.ReceiveDamage,
-			PartnerExDmg:    partner.ExDamage,
-			Bursts:          countBursts(timeline, "team1-1"),
-			PartnerBursts:   countBursts(timeline, "team1-2"),
-			Actions:         buildActions(timeline, "team1-1"),
-			PartnerActions:  buildActions(timeline, "team1-2"),
-			GameEndSec:      gameEndSec,
+			Date:              entries[0].Datetime.Format("2006-01-02 15:04"),
+			MS:                me.MsName,
+			MSCost:            costsMap[mslist.StripQuery(me.MsImageURL)],
+			PartnerMS:         partner.MsName,
+			PartnerCost:       costsMap[mslist.StripQuery(partner.MsImageURL)],
+			Opponent1MS:       opp1.MsName,
+			Opponent1Cost:     costsMap[mslist.StripQuery(opp1.MsImageURL)],
+			Opponent1Name:     opp1.Name,
+			Opponent2MS:       opp2.MsName,
+			Opponent2Cost:     costsMap[mslist.StripQuery(opp2.MsImageURL)],
+			Opponent2Name:     opp2.Name,
+			Opponent1Score:    opp1.Score,
+			Opponent1Kills:    opp1.Kills,
+			Opponent1Deaths:   opp1.Deaths,
+			Opponent1DmgGiven: opp1.GiveDamage,
+			Opponent1DmgTaken: opp1.ReceiveDamage,
+			Opponent1ExDmg:    opp1.ExDamage,
+			Opponent2Score:    opp2.Score,
+			Opponent2Kills:    opp2.Kills,
+			Opponent2Deaths:   opp2.Deaths,
+			Opponent2DmgGiven: opp2.GiveDamage,
+			Opponent2DmgTaken: opp2.ReceiveDamage,
+			Opponent2ExDmg:    opp2.ExDamage,
+			Win:               me.Win,
+			Score:             me.Score,
+			Kills:             me.Kills,
+			Deaths:            me.Deaths,
+			DmgGiven:          me.GiveDamage,
+			DmgTaken:          me.ReceiveDamage,
+			ExDmg:             me.ExDamage,
+			PartnerName:       partner.Name,
+			PartnerScore:      partner.Score,
+			PartnerKills:      partner.Kills,
+			PartnerDeaths:     partner.Deaths,
+			PartnerDmgGiven:   partner.GiveDamage,
+			PartnerDmgTaken:   partner.ReceiveDamage,
+			PartnerExDmg:      partner.ExDamage,
+			Bursts:            countBursts(timeline, "team1-1"),
+			PartnerBursts:     countBursts(timeline, "team1-2"),
+			Actions:           buildActions(timeline, "team1-1"),
+			PartnerActions:    buildActions(timeline, "team1-2"),
+			GameEndSec:        gameEndSec,
 		})
 	}
 

--- a/internal/pipeline/matchdata.go
+++ b/internal/pipeline/matchdata.go
@@ -19,33 +19,36 @@ type ActionJSON struct {
 
 // MatchData はフロントエンド向けの試合データ（プレイヤー視点）
 type MatchData struct {
-	Date            string `json:"date"`
-	MS              string `json:"ms"`
-	MSCost          int    `json:"ms_cost,omitempty"`
-	PartnerMS       string `json:"partner_ms"`
-	PartnerCost     int    `json:"partner_cost,omitempty"`
-	Opponent1MS     string `json:"opponent1_ms"`
-	Opponent1Cost   int    `json:"opponent1_cost,omitempty"`
-	Opponent1Name   string `json:"opponent1_name"`
-	Opponent2MS     string `json:"opponent2_ms"`
-	Opponent2Cost   int    `json:"opponent2_cost,omitempty"`
-	Opponent2Name   string `json:"opponent2_name"`
-	Win             bool   `json:"win"`
-	Score           int    `json:"score"`
-	Kills           int    `json:"kills"`
-	Deaths          int    `json:"deaths"`
-	DmgGiven        int    `json:"dmg_given"`
-	DmgTaken        int    `json:"dmg_taken"`
-	ExDmg           int    `json:"ex_dmg"`
-	PartnerName     string `json:"partner_name"`
-	PartnerScore    int    `json:"partner_score"`
-	PartnerKills    int    `json:"partner_kills"`
-	PartnerDeaths   int    `json:"partner_deaths"`
-	PartnerDmgGiven int    `json:"partner_dmg_given"`
-	PartnerDmgTaken int    `json:"partner_dmg_taken"`
-	PartnerExDmg    int    `json:"partner_ex_dmg"`
-	Bursts          int    `json:"bursts"`
-	PartnerBursts   int    `json:"partner_bursts"`
+	Date             string `json:"date"`
+	Name             string `json:"name"`
+	TeamName         string `json:"team_name"`          // 自陣のタッグ名（固定タッグ時。シャッフルは空）
+	OpponentTeamName string `json:"opponent_team_name"` // 敵陣のタッグ名
+	MS               string `json:"ms"`
+	MSCost           int    `json:"ms_cost,omitempty"`
+	PartnerMS        string `json:"partner_ms"`
+	PartnerCost      int    `json:"partner_cost,omitempty"`
+	Opponent1MS      string `json:"opponent1_ms"`
+	Opponent1Cost    int    `json:"opponent1_cost,omitempty"`
+	Opponent1Name    string `json:"opponent1_name"`
+	Opponent2MS      string `json:"opponent2_ms"`
+	Opponent2Cost    int    `json:"opponent2_cost,omitempty"`
+	Opponent2Name    string `json:"opponent2_name"`
+	Win              bool   `json:"win"`
+	Score            int    `json:"score"`
+	Kills            int    `json:"kills"`
+	Deaths           int    `json:"deaths"`
+	DmgGiven         int    `json:"dmg_given"`
+	DmgTaken         int    `json:"dmg_taken"`
+	ExDmg            int    `json:"ex_dmg"`
+	PartnerName      string `json:"partner_name"`
+	PartnerScore     int    `json:"partner_score"`
+	PartnerKills     int    `json:"partner_kills"`
+	PartnerDeaths    int    `json:"partner_deaths"`
+	PartnerDmgGiven  int    `json:"partner_dmg_given"`
+	PartnerDmgTaken  int    `json:"partner_dmg_taken"`
+	PartnerExDmg     int    `json:"partner_ex_dmg"`
+	Bursts           int    `json:"bursts"`
+	PartnerBursts    int    `json:"partner_bursts"`
 	// 敵2機のスコア（公式「スコア」画面と同じ項目。覚醒回数はタイムライン側で扱う）
 	Opponent1Score    int          `json:"opponent1_score"`
 	Opponent1Kills    int          `json:"opponent1_kills"`
@@ -61,6 +64,8 @@ type MatchData struct {
 	Opponent2ExDmg    int          `json:"opponent2_ex_dmg"`
 	Actions           []ActionJSON `json:"actions"`
 	PartnerActions    []ActionJSON `json:"partner_actions"`
+	Opponent1Actions  []ActionJSON `json:"opponent1_actions"`
+	Opponent2Actions  []ActionJSON `json:"opponent2_actions"`
 	GameEndSec        float64      `json:"game_end_sec,omitempty"`
 }
 
@@ -153,6 +158,9 @@ func BuildMatchData(ds model.DatedScores, costsMap map[string]int, after time.Ti
 
 		matches = append(matches, MatchData{
 			Date:              entries[0].Datetime.Format("2006-01-02 15:04"),
+			Name:              me.Name,
+			TeamName:          me.TeamName,
+			OpponentTeamName:  opp1.TeamName,
 			MS:                me.MsName,
 			MSCost:            costsMap[mslist.StripQuery(me.MsImageURL)],
 			PartnerMS:         partner.MsName,
@@ -193,6 +201,8 @@ func BuildMatchData(ds model.DatedScores, costsMap map[string]int, after time.Ti
 			PartnerBursts:     countBursts(timeline, "team1-2"),
 			Actions:           buildActions(timeline, "team1-1"),
 			PartnerActions:    buildActions(timeline, "team1-2"),
+			Opponent1Actions:  buildActions(timeline, "team2-1"),
+			Opponent2Actions:  buildActions(timeline, "team2-2"),
 			GameEndSec:        gameEndSec,
 		})
 	}

--- a/internal/pipeline/matchdata.go
+++ b/internal/pipeline/matchdata.go
@@ -49,24 +49,36 @@ type MatchData struct {
 	PartnerExDmg     int    `json:"partner_ex_dmg"`
 	Bursts           int    `json:"bursts"`
 	PartnerBursts    int    `json:"partner_bursts"`
+	Opponent1Bursts  int    `json:"opponent1_bursts"`
+	Opponent2Bursts  int    `json:"opponent2_bursts"`
 	// 敵2機のスコア（公式「スコア」画面と同じ項目。覚醒回数はタイムライン側で扱う）
-	Opponent1Score    int          `json:"opponent1_score"`
-	Opponent1Kills    int          `json:"opponent1_kills"`
-	Opponent1Deaths   int          `json:"opponent1_deaths"`
-	Opponent1DmgGiven int          `json:"opponent1_dmg_given"`
-	Opponent1DmgTaken int          `json:"opponent1_dmg_taken"`
-	Opponent1ExDmg    int          `json:"opponent1_ex_dmg"`
-	Opponent2Score    int          `json:"opponent2_score"`
-	Opponent2Kills    int          `json:"opponent2_kills"`
-	Opponent2Deaths   int          `json:"opponent2_deaths"`
-	Opponent2DmgGiven int          `json:"opponent2_dmg_given"`
-	Opponent2DmgTaken int          `json:"opponent2_dmg_taken"`
-	Opponent2ExDmg    int          `json:"opponent2_ex_dmg"`
-	Actions           []ActionJSON `json:"actions"`
-	PartnerActions    []ActionJSON `json:"partner_actions"`
-	Opponent1Actions  []ActionJSON `json:"opponent1_actions"`
-	Opponent2Actions  []ActionJSON `json:"opponent2_actions"`
-	GameEndSec        float64      `json:"game_end_sec,omitempty"`
+	Opponent1Score    int `json:"opponent1_score"`
+	Opponent1Kills    int `json:"opponent1_kills"`
+	Opponent1Deaths   int `json:"opponent1_deaths"`
+	Opponent1DmgGiven int `json:"opponent1_dmg_given"`
+	Opponent1DmgTaken int `json:"opponent1_dmg_taken"`
+	Opponent1ExDmg    int `json:"opponent1_ex_dmg"`
+	Opponent2Score    int `json:"opponent2_score"`
+	Opponent2Kills    int `json:"opponent2_kills"`
+	Opponent2Deaths   int `json:"opponent2_deaths"`
+	Opponent2DmgGiven int `json:"opponent2_dmg_given"`
+	Opponent2DmgTaken int `json:"opponent2_dmg_taken"`
+	Opponent2ExDmg    int `json:"opponent2_ex_dmg"`
+	// 各プレイヤーの追加情報（機体熟練度・試合内スコア順位）。店舗は自分の分のみ取得可能。
+	Proficiency          string       `json:"proficiency"`
+	PartnerProficiency   string       `json:"partner_proficiency"`
+	Opponent1Proficiency string       `json:"opponent1_proficiency"`
+	Opponent2Proficiency string       `json:"opponent2_proficiency"`
+	ScoreRanking         int          `json:"score_ranking"`
+	PartnerScoreRanking  int          `json:"partner_score_ranking"`
+	Opp1ScoreRanking     int          `json:"opponent1_score_ranking"`
+	Opp2ScoreRanking     int          `json:"opponent2_score_ranking"`
+	Arcade               string       `json:"arcade"` // 自分のプレイ店舗のみ
+	Actions              []ActionJSON `json:"actions"`
+	PartnerActions       []ActionJSON `json:"partner_actions"`
+	Opponent1Actions     []ActionJSON `json:"opponent1_actions"`
+	Opponent2Actions     []ActionJSON `json:"opponent2_actions"`
+	GameEndSec           float64      `json:"game_end_sec,omitempty"`
 }
 
 // countBursts はタイムラインから指定グループの覚醒回数を数える。
@@ -199,11 +211,23 @@ func BuildMatchData(ds model.DatedScores, costsMap map[string]int, after time.Ti
 			PartnerExDmg:      partner.ExDamage,
 			Bursts:            countBursts(timeline, "team1-1"),
 			PartnerBursts:     countBursts(timeline, "team1-2"),
+			Opponent1Bursts:   countBursts(timeline, "team2-1"),
+			Opponent2Bursts:   countBursts(timeline, "team2-2"),
 			Actions:           buildActions(timeline, "team1-1"),
 			PartnerActions:    buildActions(timeline, "team1-2"),
 			Opponent1Actions:  buildActions(timeline, "team2-1"),
 			Opponent2Actions:  buildActions(timeline, "team2-2"),
-			GameEndSec:        gameEndSec,
+			// 追加情報（機体熟練度・試合内順位・階級・プレイ店舗）
+			Proficiency:          me.MsProficiency,
+			PartnerProficiency:   partner.MsProficiency,
+			Opponent1Proficiency: opp1.MsProficiency,
+			Opponent2Proficiency: opp2.MsProficiency,
+			ScoreRanking:         me.ScoreRanking,
+			PartnerScoreRanking:  partner.ScoreRanking,
+			Opp1ScoreRanking:     opp1.ScoreRanking,
+			Opp2ScoreRanking:     opp2.ScoreRanking,
+			Arcade:               me.ArcadeName,
+			GameEndSec:           gameEndSec,
 		})
 	}
 

--- a/internal/pipeline/matchdata_test.go
+++ b/internal/pipeline/matchdata_test.go
@@ -46,6 +46,26 @@ func TestBuildMatchData_AfterBoundaryIsStrict(t *testing.T) {
 	}
 }
 
+func TestBuildMatchData_PopulatesPlayerNames(t *testing.T) {
+	base := time.Date(2026, 7, 4, 21, 30, 0, 0, time.UTC)
+
+	got := BuildMatchData(match(base, true), nil, time.Time{})
+	if len(got) != 1 {
+		t.Fatalf("want 1 match, got %d", len(got))
+	}
+	// match ヘルパーは PlayerNo 1..4 に 'a'..'d' を割り当てる。
+	// 相方=PlayerNo2='b'、敵1=PlayerNo3='c'、敵2=PlayerNo4='d'。
+	if got[0].PartnerName != "b" {
+		t.Errorf("PartnerName: want %q, got %q", "b", got[0].PartnerName)
+	}
+	if got[0].Opponent1Name != "c" {
+		t.Errorf("Opponent1Name: want %q, got %q", "c", got[0].Opponent1Name)
+	}
+	if got[0].Opponent2Name != "d" {
+		t.Errorf("Opponent2Name: want %q, got %q", "d", got[0].Opponent2Name)
+	}
+}
+
 func TestBuildMatchData_ZeroAfterReturnsAll(t *testing.T) {
 	base := time.Date(2026, 7, 4, 21, 30, 0, 0, time.UTC)
 

--- a/internal/pipeline/matchdata_test.go
+++ b/internal/pipeline/matchdata_test.go
@@ -12,12 +12,17 @@ import (
 func match(dt time.Time, p1Win bool) model.DatedScores {
 	ds := make(model.DatedScores, 4)
 	for i := 0; i < 4; i++ {
+		teamName := "myteam" // PlayerNo 1,2 は自陣
+		if i >= 2 {
+			teamName = "enemyteam" // PlayerNo 3,4 は敵陣
+		}
 		ds[i] = model.DatedScore{
 			PlayerNo: i + 1,
 			Datetime: dt,
 			PlayerScore: model.PlayerScore{
-				Name: string(rune('a' + i)),
-				Win:  (i < 2) == p1Win, // team1(PlayerNo 1,2)はp1Winと同じ勝敗
+				Name:     string(rune('a' + i)),
+				TeamName: teamName,
+				Win:      (i < 2) == p1Win, // team1(PlayerNo 1,2)はp1Winと同じ勝敗
 			},
 		}
 	}
@@ -46,6 +51,22 @@ func TestBuildMatchData_AfterBoundaryIsStrict(t *testing.T) {
 	}
 }
 
+func TestBuildMatchData_PopulatesTeamNames(t *testing.T) {
+	base := time.Date(2026, 7, 4, 21, 30, 0, 0, time.UTC)
+
+	got := BuildMatchData(match(base, true), nil, time.Time{})
+	if len(got) != 1 {
+		t.Fatalf("want 1 match, got %d", len(got))
+	}
+	// 自陣=PlayerNo1のTeamName、敵陣=PlayerNo3のTeamName。
+	if got[0].TeamName != "myteam" {
+		t.Errorf("TeamName: want %q, got %q", "myteam", got[0].TeamName)
+	}
+	if got[0].OpponentTeamName != "enemyteam" {
+		t.Errorf("OpponentTeamName: want %q, got %q", "enemyteam", got[0].OpponentTeamName)
+	}
+}
+
 func TestBuildMatchData_PopulatesPlayerNames(t *testing.T) {
 	base := time.Date(2026, 7, 4, 21, 30, 0, 0, time.UTC)
 
@@ -54,7 +75,10 @@ func TestBuildMatchData_PopulatesPlayerNames(t *testing.T) {
 		t.Fatalf("want 1 match, got %d", len(got))
 	}
 	// match ヘルパーは PlayerNo 1..4 に 'a'..'d' を割り当てる。
-	// 相方=PlayerNo2='b'、敵1=PlayerNo3='c'、敵2=PlayerNo4='d'。
+	// 自分=PlayerNo1='a'、相方=PlayerNo2='b'、敵1=PlayerNo3='c'、敵2=PlayerNo4='d'。
+	if got[0].Name != "a" {
+		t.Errorf("Name: want %q, got %q", "a", got[0].Name)
+	}
 	if got[0].PartnerName != "b" {
 		t.Errorf("PartnerName: want %q, got %q", "b", got[0].PartnerName)
 	}

--- a/internal/pipeline/matchdata_test.go
+++ b/internal/pipeline/matchdata_test.go
@@ -66,6 +66,35 @@ func TestBuildMatchData_PopulatesPlayerNames(t *testing.T) {
 	}
 }
 
+func TestBuildMatchData_PopulatesOpponentScores(t *testing.T) {
+	dt := time.Date(2026, 7, 4, 21, 30, 0, 0, time.UTC)
+	// PlayerNo 3,4 が敵。区別できるようスコアを変えて設定する。
+	ds := model.DatedScores{
+		{PlayerNo: 1, Datetime: dt, PlayerScore: model.PlayerScore{Win: true}},
+		{PlayerNo: 2, Datetime: dt, PlayerScore: model.PlayerScore{Win: true}},
+		{PlayerNo: 3, Datetime: dt, PlayerScore: model.PlayerScore{
+			Score: 22372, Kills: 2, Deaths: 2, GiveDamage: 849, ReceiveDamage: 1360, ExDamage: 283,
+		}},
+		{PlayerNo: 4, Datetime: dt, PlayerScore: model.PlayerScore{
+			Score: 10328, Kills: 0, Deaths: 1, GiveDamage: 471, ReceiveDamage: 720, ExDamage: 0,
+		}},
+	}
+
+	got := BuildMatchData(ds, nil, time.Time{})
+	if len(got) != 1 {
+		t.Fatalf("want 1 match, got %d", len(got))
+	}
+	m := got[0]
+	if m.Opponent1Score != 22372 || m.Opponent1Kills != 2 || m.Opponent1Deaths != 2 ||
+		m.Opponent1DmgGiven != 849 || m.Opponent1DmgTaken != 1360 || m.Opponent1ExDmg != 283 {
+		t.Errorf("Opponent1 scores mismatch: %+v", m)
+	}
+	if m.Opponent2Score != 10328 || m.Opponent2Kills != 0 || m.Opponent2Deaths != 1 ||
+		m.Opponent2DmgGiven != 471 || m.Opponent2DmgTaken != 720 || m.Opponent2ExDmg != 0 {
+		t.Errorf("Opponent2 scores mismatch: %+v", m)
+	}
+}
+
 func TestBuildMatchData_ZeroAfterReturnsAll(t *testing.T) {
 	base := time.Date(2026, 7, 4, 21, 30, 0, 0, time.UTC)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/yuki9431/catalyzer/internal/firestore"
 	"github.com/yuki9431/catalyzer/internal/model"
+	"github.com/yuki9431/catalyzer/internal/mslist"
 	"github.com/yuki9431/catalyzer/internal/pipeline"
 	"github.com/yuki9431/catalyzer/internal/session"
 	"golang.org/x/time/rate"
@@ -222,6 +223,23 @@ func StartServer() {
 		handleMatches(w, r)
 	})
 
+	// GET /ms-list → MSリスト（機体名→画像URL）を配信。
+	// フロントの試合検索一覧が機体名から公式CDNのサムネイル画像を解決するために使う。
+	// 起動時に一度だけ読み込む（静的データ。失敗時は空を返し、フロントは機体名テキストにフォールバック）。
+	msList, mserr := mslist.LoadMSList(pipeline.DefaultMSListPath)
+	if mserr != nil {
+		log.Printf("[WARN] Failed to load MS list for /ms-list: %v", mserr)
+		msList = []model.MSInfo{}
+	}
+	http.HandleFunc("/ms-list", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		sendJSON(w, http.StatusOK, msList)
+	})
+
 	// GET /session → セッションの有効性チェック（キャッシュレポート付き）
 	http.HandleFunc("/session", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
@@ -368,7 +386,8 @@ func securityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
-		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'")
+		// img-src に公式リソースCDNを許可（試合検索一覧で機体サムネイル画像を表示するため。画像のみ）
+		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://resource.exvs2ib.vsmobile.jp")
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000")
 		next.ServeHTTP(w, r)
 	})

--- a/static/__tests__/search.test.js
+++ b/static/__tests__/search.test.js
@@ -108,23 +108,33 @@ describe('filterMatches', function () {
     var f = emptyFilters(); f.enemyMs = 'Y';
     assert.equal(filterMatches(matches, f).length, 2);
   });
-  it('filters by partner player name (partial, case-insensitive)', function () {
+  it('filters by player name (partner or enemy, partial, case-insensitive)', function () {
     var ms = [
-      makeMatch({ partner_name: 'ガンダムマスター' }),
-      makeMatch({ partner_name: 'Red Comet' }),
-      makeMatch({ partner_name: 'しゃあ専用' }),
+      makeMatch({ partner_name: 'ガンダムマスター', opponent1_name: '敵A', opponent2_name: '敵B' }),
+      makeMatch({ partner_name: 'Red Comet', opponent1_name: 'シャア', opponent2_name: 'ララァ' }),
+      makeMatch({ partner_name: 'しゃあ専用', opponent1_name: 'アムロ', opponent2_name: 'ブライト' }),
     ];
+    // 相方名にヒット
     var partial = emptyFilters(); partial.playerName = 'マスター';
     assert.equal(filterMatches(ms, partial).length, 1);
+    // 大小文字無視（相方名）
     var ci = emptyFilters(); ci.playerName = 'red';
     assert.equal(filterMatches(ms, ci).length, 1);
+    // 前後空白は無視
     var trimmed = emptyFilters(); trimmed.playerName = '  Comet  ';
     assert.equal(filterMatches(ms, trimmed).length, 1);
+    // 敵1の名前にヒット
+    var enemy1 = emptyFilters(); enemy1.playerName = 'シャア';
+    assert.equal(filterMatches(ms, enemy1).length, 1);
+    // 敵2の名前にヒット
+    var enemy2 = emptyFilters(); enemy2.playerName = 'ブライト';
+    assert.equal(filterMatches(ms, enemy2).length, 1);
+    // どこにも無ければ0件
     var none = emptyFilters(); none.playerName = '存在しない';
     assert.equal(filterMatches(ms, none).length, 0);
   });
-  it('player name filter treats missing partner_name safely', function () {
-    var ms = [makeMatch({ partner_name: undefined })];
+  it('player name filter treats missing names safely', function () {
+    var ms = [makeMatch({ partner_name: undefined, opponent1_name: undefined, opponent2_name: undefined })];
     var f = emptyFilters(); f.playerName = 'a';
     assert.equal(filterMatches(ms, f).length, 0);
   });

--- a/static/__tests__/search.test.js
+++ b/static/__tests__/search.test.js
@@ -108,6 +108,26 @@ describe('filterMatches', function () {
     var f = emptyFilters(); f.enemyMs = 'Y';
     assert.equal(filterMatches(matches, f).length, 2);
   });
+  it('filters by partner player name (partial, case-insensitive)', function () {
+    var ms = [
+      makeMatch({ partner_name: 'ガンダムマスター' }),
+      makeMatch({ partner_name: 'Red Comet' }),
+      makeMatch({ partner_name: 'しゃあ専用' }),
+    ];
+    var partial = emptyFilters(); partial.playerName = 'マスター';
+    assert.equal(filterMatches(ms, partial).length, 1);
+    var ci = emptyFilters(); ci.playerName = 'red';
+    assert.equal(filterMatches(ms, ci).length, 1);
+    var trimmed = emptyFilters(); trimmed.playerName = '  Comet  ';
+    assert.equal(filterMatches(ms, trimmed).length, 1);
+    var none = emptyFilters(); none.playerName = '存在しない';
+    assert.equal(filterMatches(ms, none).length, 0);
+  });
+  it('player name filter treats missing partner_name safely', function () {
+    var ms = [makeMatch({ partner_name: undefined })];
+    var f = emptyFilters(); f.playerName = 'a';
+    assert.equal(filterMatches(ms, f).length, 0);
+  });
   it('filters by result', function () {
     var win = emptyFilters(); win.result = 'win';
     assert.equal(filterMatches(matches, win).length, 2);

--- a/static/__tests__/search.test.js
+++ b/static/__tests__/search.test.js
@@ -64,6 +64,16 @@ describe('collectMsOptions', function () {
     var names = opts.enemies.map(function (e) { return e.name; });
     assert.equal(names.indexOf(''), -1);
   });
+  it('counts a mirror matchup (same ms on both opponents) once per match', function () {
+    var matches = [
+      makeMatch({ opponent1_ms: 'ザクII', opponent2_ms: 'ザクII' }),
+      makeMatch({ opponent1_ms: 'ザクII', opponent2_ms: 'グフ' }),
+    ];
+    var opts = collectMsOptions(matches);
+    var zaku = opts.enemies.find(function (e) { return e.name === 'ザクII'; });
+    // 1試合目で2回出現するが、試合数としては2（各試合1回）
+    assert.equal(zaku.matches, 2);
+  });
   it('handles empty input', function () {
     var opts = collectMsOptions([]);
     assert.deepEqual(opts, { mine: [], partners: [], enemies: [] });

--- a/static/__tests__/search.test.js
+++ b/static/__tests__/search.test.js
@@ -76,7 +76,7 @@ describe('collectMsOptions', function () {
   });
   it('handles empty input', function () {
     var opts = collectMsOptions([]);
-    assert.deepEqual(opts, { mine: [], partners: [], enemies: [], myTags: [], enemyCostPairs: [] });
+    assert.deepEqual(opts, { mine: [], partners: [], enemies: [], myTags: [], enemyCostPairs: [], playerNames: [], enemyTags: [] });
   });
   it('orders enemyCostPairs by cost descending (not by match count)', function () {
     var matches = [

--- a/static/__tests__/search.test.js
+++ b/static/__tests__/search.test.js
@@ -146,6 +146,23 @@ describe('filterMatches', function () {
     // 両方そろっている試合のみ（順不同OK）＝2件
     assert.equal(filterMatches(ms, f).length, 2);
   });
+  it('filters by player name scope (ally / enemy / both)', function () {
+    var ms = [
+      makeMatch({ partner_name: 'シャア', opponent1_name: '敵A', opponent2_name: '敵B' }),
+      makeMatch({ partner_name: '相方X', opponent1_name: 'シャア', opponent2_name: '敵C' }),
+    ];
+    // both: 相方でも相手でもヒット → 2件
+    var both = emptyFilters(); both.playerName = 'シャア';
+    assert.equal(filterMatches(ms, both).length, 2);
+    // ally: 相方名のみ → 1件目
+    var ally = emptyFilters(); ally.playerName = 'シャア'; ally.playerNameScope = 'ally';
+    assert.equal(filterMatches(ms, ally).length, 1);
+    assert.equal(filterMatches(ms, ally)[0].partner_name, 'シャア');
+    // enemy: 相手名のみ → 2件目
+    var enemy = emptyFilters(); enemy.playerName = 'シャア'; enemy.playerNameScope = 'enemy';
+    assert.equal(filterMatches(ms, enemy).length, 1);
+    assert.equal(filterMatches(ms, enemy)[0].opponent1_name, 'シャア');
+  });
   it('filters by player name (partner or enemy, partial, case-insensitive)', function () {
     var ms = [
       makeMatch({ partner_name: 'ガンダムマスター', opponent1_name: '敵A', opponent2_name: '敵B' }),

--- a/static/__tests__/search.test.js
+++ b/static/__tests__/search.test.js
@@ -1,0 +1,173 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  emptyFilters, hasActiveFilters, collectMsOptions,
+  filterMatches, sortMatches, SORT_OPTIONS,
+} from '../analysis/search.js';
+
+function makeMatch(overrides) {
+  return Object.assign({
+    date: '2025-06-15 14:30',
+    win: true,
+    ms: 'ガンダム',
+    ms_cost: 3000,
+    dmg_given: 1000,
+    dmg_taken: 800,
+    kills: 2,
+    deaths: 1,
+    ex_dmg: 150,
+    score: 500,
+    bursts: 2,
+    actions: [],
+    partner_actions: [],
+    partner_ms: 'ザク',
+    partner_cost: 2000,
+    partner_name: 'パートナー',
+    opponent1_ms: 'シャアザク',
+    opponent2_ms: 'ゲルググ',
+  }, overrides);
+}
+
+describe('emptyFilters / hasActiveFilters', function () {
+  it('empty filters are not active', function () {
+    assert.equal(hasActiveFilters(emptyFilters()), false);
+  });
+  it('detects a set result filter', function () {
+    var f = emptyFilters();
+    f.result = 'win';
+    assert.equal(hasActiveFilters(f), true);
+  });
+  it('detects a set text/number filter', function () {
+    var f = emptyFilters();
+    f.myMs = 'ガンダム';
+    assert.equal(hasActiveFilters(f), true);
+    var g = emptyFilters();
+    g.dmgGivenMin = 500;
+    assert.equal(hasActiveFilters(g), true);
+  });
+});
+
+describe('collectMsOptions', function () {
+  it('tallies mine/partners/enemies by frequency', function () {
+    var matches = [
+      makeMatch({ ms: 'A', partner_ms: 'P1', opponent1_ms: 'E1', opponent2_ms: 'E2' }),
+      makeMatch({ ms: 'A', partner_ms: 'P2', opponent1_ms: 'E1', opponent2_ms: 'E3' }),
+      makeMatch({ ms: 'B', partner_ms: 'P1', opponent1_ms: 'E1', opponent2_ms: '' }),
+    ];
+    var opts = collectMsOptions(matches);
+    assert.equal(opts.mine[0].name, 'A');
+    assert.equal(opts.mine[0].matches, 2);
+    // E1 appears in all 3 matches → most frequent enemy
+    assert.equal(opts.enemies[0].name, 'E1');
+    assert.equal(opts.enemies[0].matches, 3);
+    // empty opponent2 in third match is ignored
+    var names = opts.enemies.map(function (e) { return e.name; });
+    assert.equal(names.indexOf(''), -1);
+  });
+  it('handles empty input', function () {
+    var opts = collectMsOptions([]);
+    assert.deepEqual(opts, { mine: [], partners: [], enemies: [] });
+  });
+});
+
+describe('filterMatches', function () {
+  var matches = [
+    makeMatch({ date: '2025-06-10 10:00', ms: 'ガンダム', win: true, dmg_given: 1200, dmg_taken: 600, kills: 3, deaths: 0, partner_ms: 'ザク', opponent1_ms: 'X', opponent2_ms: 'Y' }),
+    makeMatch({ date: '2025-06-15 12:00', ms: 'ズゴック', win: false, dmg_given: 700, dmg_taken: 1100, kills: 1, deaths: 2, partner_ms: 'グフ', opponent1_ms: 'Y', opponent2_ms: 'Z' }),
+    makeMatch({ date: '2025-06-20 20:00', ms: 'ガンダム', win: true, dmg_given: 900, dmg_taken: 900, kills: 2, deaths: 1, partner_ms: 'ザク', opponent1_ms: 'Z', opponent2_ms: 'X' }),
+  ];
+
+  it('returns all with empty filters', function () {
+    assert.equal(filterMatches(matches, emptyFilters()).length, 3);
+  });
+  it('filters by date range (inclusive, date-only)', function () {
+    var f = emptyFilters(); f.dateFrom = '2025-06-15'; f.dateTo = '2025-06-20';
+    var r = filterMatches(matches, f);
+    assert.equal(r.length, 2);
+    assert.equal(r[0].date, '2025-06-15 12:00');
+  });
+  it('filters by my ms', function () {
+    var f = emptyFilters(); f.myMs = 'ガンダム';
+    assert.equal(filterMatches(matches, f).length, 2);
+  });
+  it('filters by partner ms', function () {
+    var f = emptyFilters(); f.partnerMs = 'グフ';
+    assert.equal(filterMatches(matches, f).length, 1);
+  });
+  it('filters by enemy ms matching either opponent', function () {
+    var f = emptyFilters(); f.enemyMs = 'Y';
+    assert.equal(filterMatches(matches, f).length, 2);
+  });
+  it('filters by result', function () {
+    var win = emptyFilters(); win.result = 'win';
+    assert.equal(filterMatches(matches, win).length, 2);
+    var loss = emptyFilters(); loss.result = 'loss';
+    assert.equal(filterMatches(matches, loss).length, 1);
+  });
+  it('filters by damage range', function () {
+    var f = emptyFilters(); f.dmgGivenMin = 800; f.dmgGivenMax = 1000;
+    var r = filterMatches(matches, f);
+    assert.equal(r.length, 1);
+    assert.equal(r[0].dmg_given, 900);
+  });
+  it('filters by kills/deaths range', function () {
+    var f = emptyFilters(); f.deathsMax = 0;
+    var r = filterMatches(matches, f);
+    assert.equal(r.length, 1);
+    assert.equal(r[0].deaths, 0);
+  });
+  it('combines multiple conditions (AND)', function () {
+    var f = emptyFilters();
+    f.myMs = 'ガンダム'; f.result = 'win'; f.dmgGivenMin = 1000;
+    var r = filterMatches(matches, f);
+    assert.equal(r.length, 1);
+    assert.equal(r[0].dmg_given, 1200);
+  });
+  it('does not mutate the input array', function () {
+    var copy = matches.slice();
+    filterMatches(matches, { myMs: 'ガンダム' });
+    assert.deepEqual(matches, copy);
+  });
+});
+
+describe('sortMatches', function () {
+  var matches = [
+    makeMatch({ date: '2025-06-10 10:00', dmg_given: 1200, kills: 3 }),
+    makeMatch({ date: '2025-06-20 20:00', dmg_given: 700, kills: 1 }),
+    makeMatch({ date: '2025-06-15 12:00', dmg_given: 900, kills: 3 }),
+  ];
+
+  it('sorts by date descending', function () {
+    var r = sortMatches(matches, 'date', true);
+    assert.deepEqual(r.map(function (m) { return m.date; }),
+      ['2025-06-20 20:00', '2025-06-15 12:00', '2025-06-10 10:00']);
+  });
+  it('sorts by date ascending', function () {
+    var r = sortMatches(matches, 'date', false);
+    assert.equal(r[0].date, '2025-06-10 10:00');
+  });
+  it('sorts by numeric field descending', function () {
+    var r = sortMatches(matches, 'dmg_given', true);
+    assert.deepEqual(r.map(function (m) { return m.dmg_given; }), [1200, 900, 700]);
+  });
+  it('breaks ties by most recent date', function () {
+    var r = sortMatches(matches, 'kills', true);
+    // two matches have kills=3; the newer (06-15) comes before the older (06-10)
+    assert.equal(r[0].kills, 3);
+    assert.equal(r[0].date, '2025-06-15 12:00');
+    assert.equal(r[1].date, '2025-06-10 10:00');
+  });
+  it('does not mutate the input array', function () {
+    var copy = matches.slice();
+    sortMatches(matches, 'dmg_given', true);
+    assert.deepEqual(matches, copy);
+  });
+});
+
+describe('SORT_OPTIONS', function () {
+  it('every option has key and label', function () {
+    SORT_OPTIONS.forEach(function (o) {
+      assert.ok(o.key && o.label);
+    });
+  });
+});

--- a/static/__tests__/search.test.js
+++ b/static/__tests__/search.test.js
@@ -39,7 +39,7 @@ describe('emptyFilters / hasActiveFilters', function () {
   });
   it('detects a set text/number filter', function () {
     var f = emptyFilters();
-    f.myMs = 'ガンダム';
+    f.myMsList = ['ガンダム'];
     assert.equal(hasActiveFilters(f), true);
     var g = emptyFilters();
     g.dmgGivenMin = 500;
@@ -76,7 +76,32 @@ describe('collectMsOptions', function () {
   });
   it('handles empty input', function () {
     var opts = collectMsOptions([]);
-    assert.deepEqual(opts, { mine: [], partners: [], enemies: [] });
+    assert.deepEqual(opts, { mine: [], partners: [], enemies: [], myTags: [], enemyCostPairs: [] });
+  });
+  it('orders enemyCostPairs by cost descending (not by match count)', function () {
+    var matches = [
+      makeMatch({ opponent1_cost: 2000, opponent2_cost: 2000 }),
+      makeMatch({ opponent1_cost: 2000, opponent2_cost: 2000 }),
+      makeMatch({ opponent1_cost: 3000, opponent2_cost: 2500 }),
+    ];
+    var opts = collectMsOptions(matches);
+    // 対戦数は 2000+2000 の方が多いが、コスト降順で 3000+2500 が先
+    assert.equal(opts.enemyCostPairs[0].name, '3000 + 2500');
+    assert.equal(opts.enemyCostPairs[1].name, '2000 + 2000');
+  });
+  it('tallies own team (myTags) from team_name only', function () {
+    var matches = [
+      makeMatch({ team_name: 'アルファ', opponent_team_name: 'ブラボー' }),
+      makeMatch({ team_name: 'アルファ', opponent_team_name: 'チャーリー' }),
+      makeMatch({ team_name: '', opponent_team_name: '' }),
+    ];
+    var opts = collectMsOptions(matches);
+    // 自陣アルファが2試合で最頻。敵陣タッグ(ブラボー等)は myTags に含まない
+    assert.equal(opts.myTags[0].name, 'アルファ');
+    assert.equal(opts.myTags[0].matches, 2);
+    var names = opts.myTags.map(function (t) { return t.name; });
+    assert.equal(names.indexOf('ブラボー'), -1);
+    assert.equal(names.indexOf(''), -1);
   });
 });
 
@@ -97,16 +122,29 @@ describe('filterMatches', function () {
     assert.equal(r[0].date, '2025-06-15 12:00');
   });
   it('filters by my ms', function () {
-    var f = emptyFilters(); f.myMs = 'ガンダム';
+    var f = emptyFilters(); f.myMsList = ['ガンダム'];
     assert.equal(filterMatches(matches, f).length, 2);
   });
   it('filters by partner ms', function () {
-    var f = emptyFilters(); f.partnerMs = 'グフ';
+    var f = emptyFilters(); f.partnerMsList = ['グフ'];
     assert.equal(filterMatches(matches, f).length, 1);
   });
-  it('filters by enemy ms matching either opponent', function () {
-    var f = emptyFilters(); f.enemyMs = 'Y';
+  it('filters by enemy ms multi-select (OR: any selected among opponents)', function () {
+    var f = emptyFilters(); f.enemyMsList = ['Y']; f.enemyMsMode = 'or';
     assert.equal(filterMatches(matches, f).length, 2);
+    // Y または Z のどちらかが相手にいる試合（全3件）
+    var f2 = emptyFilters(); f2.enemyMsList = ['Y', 'Z']; f2.enemyMsMode = 'or';
+    assert.equal(filterMatches(matches, f2).length, 3);
+  });
+  it('filters by enemy ms multi-select (AND: enemy composition, all present)', function () {
+    var ms = [
+      makeMatch({ opponent1_ms: 'ターンX', opponent2_ms: 'アリュゼウス' }),
+      makeMatch({ opponent1_ms: 'アリュゼウス', opponent2_ms: 'ターンX' }), // 順不同で同編成
+      makeMatch({ opponent1_ms: 'ターンX', opponent2_ms: 'ザク' }),
+    ];
+    var f = emptyFilters(); f.enemyMsList = ['ターンX', 'アリュゼウス']; f.enemyMsMode = 'and';
+    // 両方そろっている試合のみ（順不同OK）＝2件
+    assert.equal(filterMatches(ms, f).length, 2);
   });
   it('filters by player name (partner or enemy, partial, case-insensitive)', function () {
     var ms = [
@@ -138,6 +176,81 @@ describe('filterMatches', function () {
     var f = emptyFilters(); f.playerName = 'a';
     assert.equal(filterMatches(ms, f).length, 0);
   });
+  it('filters by own tag (myTagName, exact match on team_name)', function () {
+    var ms = [
+      makeMatch({ team_name: 'アルファ', opponent_team_name: 'ブラボー' }),
+      makeMatch({ team_name: 'アルファ', opponent_team_name: 'チャーリー' }),
+      makeMatch({ team_name: 'デルタ', opponent_team_name: 'アルファ' }),
+    ];
+    // 自陣team_nameのみ完全一致（敵陣にアルファがある3件目はヒットしない）
+    var own = emptyFilters(); own.myTagList = ['アルファ'];
+    assert.equal(filterMatches(ms, own).length, 2);
+    // 完全一致（部分文字列では一致しない）
+    var partial = emptyFilters(); partial.myTagList = ['アル'];
+    assert.equal(filterMatches(ms, partial).length, 0);
+  });
+  it('filters by enemy tag (enemyTagName, partial match on opponent_team_name)', function () {
+    var ms = [
+      makeMatch({ team_name: 'アルファ', opponent_team_name: 'ブラボー団' }),
+      makeMatch({ team_name: 'チャーリー', opponent_team_name: 'デルタ' }),
+    ];
+    // 敵陣タッグの部分一致
+    var partial = emptyFilters(); partial.enemyTagName = 'ブラボー';
+    assert.equal(filterMatches(ms, partial).length, 1);
+    // 大小文字無視 + 前後空白無視
+    var ci = emptyFilters(); ci.enemyTagName = '  デルタ ';
+    assert.equal(filterMatches(ms, ci).length, 1);
+    // 自陣team_nameは敵タッグ検索の対象外
+    var ownOnly = emptyFilters(); ownOnly.enemyTagName = 'アルファ';
+    assert.equal(filterMatches(ms, ownOnly).length, 0);
+    // 空タッグ名(シャッフル)は安全にスキップ
+    var missing = [makeMatch({ opponent_team_name: '' })];
+    var f = emptyFilters(); f.enemyTagName = 'ブラボー';
+    assert.equal(filterMatches(missing, f).length, 0);
+  });
+  it('filters by my cost (exact, numeric)', function () {
+    var ms = [
+      makeMatch({ ms_cost: 3000 }), makeMatch({ ms_cost: 2500 }), makeMatch({ ms_cost: 3000 }),
+    ];
+    var f = emptyFilters(); f.myCostList = ['3000'];
+    assert.equal(filterMatches(ms, f).length, 2);
+    var f2 = emptyFilters(); f2.myCostList = ['1500'];
+    assert.equal(filterMatches(ms, f2).length, 0);
+  });
+  it('filters by partner cost (exact, numeric)', function () {
+    var ms = [
+      makeMatch({ partner_cost: 2000 }), makeMatch({ partner_cost: 1500 }),
+    ];
+    var f = emptyFilters(); f.partnerCostList = ['2000'];
+    assert.equal(filterMatches(ms, f).length, 1);
+  });
+  it('filters by enemy cost pair (order-independent, normalized)', function () {
+    var ms = [
+      makeMatch({ opponent1_cost: 3000, opponent2_cost: 2500 }),
+      makeMatch({ opponent1_cost: 2500, opponent2_cost: 3000 }), // 同編成(順不同)
+      makeMatch({ opponent1_cost: 2000, opponent2_cost: 2000 }),
+    ];
+    var f = emptyFilters(); f.enemyCostPairList = ['3000 + 2500'];
+    assert.equal(filterMatches(ms, f).length, 2);
+    var f2 = emptyFilters(); f2.enemyCostPairList = ['2000 + 2000'];
+    assert.equal(filterMatches(ms, f2).length, 1);
+    // 未取得(0)コストは対象外
+    var miss = [makeMatch({ opponent1_cost: 0, opponent2_cost: 3000 })];
+    var f3 = emptyFilters(); f3.enemyCostPairList = ['3000 + 2500'];
+    assert.equal(filterMatches(miss, f3).length, 0);
+  });
+  it('filters by score / ex_dmg / bursts ranges', function () {
+    var ms = [
+      makeMatch({ score: 300, ex_dmg: 100, bursts: 1 }),
+      makeMatch({ score: 600, ex_dmg: 250, bursts: 3 }),
+    ];
+    var sc = emptyFilters(); sc.scoreMin = 500;
+    assert.equal(filterMatches(ms, sc).length, 1);
+    var ex = emptyFilters(); ex.exDmgMax = 150;
+    assert.equal(filterMatches(ms, ex).length, 1);
+    var bu = emptyFilters(); bu.burstsMin = 2; bu.burstsMax = 4;
+    assert.equal(filterMatches(ms, bu).length, 1);
+  });
   it('filters by result', function () {
     var win = emptyFilters(); win.result = 'win';
     assert.equal(filterMatches(matches, win).length, 2);
@@ -158,7 +271,7 @@ describe('filterMatches', function () {
   });
   it('combines multiple conditions (AND)', function () {
     var f = emptyFilters();
-    f.myMs = 'ガンダム'; f.result = 'win'; f.dmgGivenMin = 1000;
+    f.myMsList = ['ガンダム']; f.result = 'win'; f.dmgGivenMin = 1000;
     var r = filterMatches(matches, f);
     assert.equal(r.length, 1);
     assert.equal(r[0].dmg_given, 1200);

--- a/static/analysis/search.js
+++ b/static/analysis/search.js
@@ -23,6 +23,7 @@ export function emptyFilters() {
     enemyMsList: [],         // 敵機（複数選択）
     enemyMsMode: 'or',       // 'and'=相手編成に全部いる / 'or'=どれかいる
     playerName: '',          // 相方・敵プレイヤー名の部分一致（曖昧検索）
+    playerNameScope: 'both',  // 'both' | 'ally'(相方のみ) | 'enemy'(相手のみ)
     myTagList: [],           // 味方タッグ名（複数選択・OR）
     enemyTagName: '',        // 敵陣タッグ名の部分一致（曖昧検索）
     result: 'all',           // 'all' | 'win' | 'loss'
@@ -129,8 +130,11 @@ function inRange(value, min, max) {
 
 // 試合内のプレイヤー名（相方・敵1・敵2）のいずれかが needle を部分一致で含むか。
 // needle は呼び出し側で trim + toLowerCase 済みであること。
-function nameMatches(m, needle) {
-  var names = [m.partner_name, m.opponent1_name, m.opponent2_name];
+function nameMatches(m, needle, scope) {
+  var names;
+  if (scope === 'ally') names = [m.partner_name];
+  else if (scope === 'enemy') names = [m.opponent1_name, m.opponent2_name];
+  else names = [m.partner_name, m.opponent1_name, m.opponent2_name];
   for (var i = 0; i < names.length; i++) {
     if (String(names[i] || '').toLowerCase().indexOf(needle) >= 0) return true;
   }
@@ -149,8 +153,9 @@ export function filterMatches(matches, filters) {
   // 敵機は複数選択。and=相手2機に選んだ機体が全部いる（編成指定）、or=どれかいる。
   var enemyMsList = f.enemyMsList || [];
   var enemyMsMode = f.enemyMsMode || 'or';
-  // プレイヤー名は部分一致・大小文字無視の曖昧検索（相方・敵の名前が対象）
+  // プレイヤー名は部分一致・大小文字無視の曖昧検索。scopeで相方のみ/相手のみに絞れる。
   var playerName = (f.playerName || '').trim().toLowerCase();
+  var playerNameScope = f.playerNameScope || 'both';
   // 味方タッグは複数選択・OR。敵タッグ名は部分一致・大小文字無視（敵陣）。
   var myTagList = f.myTagList || [];
   var enemyTagName = (f.enemyTagName || '').trim().toLowerCase();
@@ -180,7 +185,7 @@ export function filterMatches(matches, filters) {
         : enemyMsList.some(function (x) { return es.indexOf(x) >= 0; });
       if (!hit) return false;
     }
-    if (playerName && !nameMatches(m, playerName)) return false;
+    if (playerName && !nameMatches(m, playerName, playerNameScope)) return false;
     if (myTagList.length && myTagList.indexOf(m.team_name) < 0) return false;
     if (enemyTagName && String(m.opponent_team_name || '').toLowerCase().indexOf(enemyTagName) < 0) return false;
     if (result === 'win' && !m.win) return false;

--- a/static/analysis/search.js
+++ b/static/analysis/search.js
@@ -107,6 +107,9 @@ export function collectMsOptions(matches) {
     enemies: tally(ms, [function (m) { return [m.opponent1_ms, m.opponent2_ms]; }]),
     myTags: tally(ms, [function (m) { return [m.team_name]; }]),
     enemyCostPairs: costPairs,
+    // 曖昧検索入力の候補用（相方・敵のプレイヤー名／相手タッグ名）。
+    playerNames: tally(ms, [function (m) { return [m.partner_name, m.opponent1_name, m.opponent2_name]; }]),
+    enemyTags: tally(ms, [function (m) { return [m.opponent_team_name]; }]),
   };
 }
 

--- a/static/analysis/search.js
+++ b/static/analysis/search.js
@@ -90,6 +90,16 @@ function inRange(value, min, max) {
   return true;
 }
 
+// 試合内のプレイヤー名（相方・敵1・敵2）のいずれかが needle を部分一致で含むか。
+// needle は呼び出し側で trim + toLowerCase 済みであること。
+function nameMatches(m, needle) {
+  var names = [m.partner_name, m.opponent1_name, m.opponent2_name];
+  for (var i = 0; i < names.length; i++) {
+    if (String(names[i] || '').toLowerCase().indexOf(needle) >= 0) return true;
+  }
+  return false;
+}
+
 // 試合配列を filters で絞り込む。元配列は変更しない。
 export function filterMatches(matches, filters) {
   var f = filters || {};
@@ -98,7 +108,7 @@ export function filterMatches(matches, filters) {
   var myMs = f.myMs || '';
   var partnerMs = f.partnerMs || '';
   var enemyMs = f.enemyMs || '';
-  // プレイヤー名は部分一致・大小文字無視の曖昧検索（相方名が対象）
+  // プレイヤー名は部分一致・大小文字無視の曖昧検索（相方・敵の名前が対象）
   var playerName = (f.playerName || '').trim().toLowerCase();
   var result = f.result || 'all';
   var dgMin = toNum(f.dmgGivenMin), dgMax = toNum(f.dmgGivenMax);
@@ -113,7 +123,7 @@ export function filterMatches(matches, filters) {
     if (myMs && m.ms !== myMs) return false;
     if (partnerMs && m.partner_ms !== partnerMs) return false;
     if (enemyMs && m.opponent1_ms !== enemyMs && m.opponent2_ms !== enemyMs) return false;
-    if (playerName && String(m.partner_name || '').toLowerCase().indexOf(playerName) < 0) return false;
+    if (playerName && !nameMatches(m, playerName)) return false;
     if (result === 'win' && !m.win) return false;
     if (result === 'loss' && m.win) return false;
     if (!inRange(m.dmg_given, dgMin, dgMax)) return false;

--- a/static/analysis/search.js
+++ b/static/analysis/search.js
@@ -2,15 +2,15 @@
 // IndexedDBキャッシュから読み込んだ試合データ配列を、条件で絞り込み・並べ替える純粋関数群。
 // UI（components/search.js）から切り離すことで単体テスト可能にしている。
 
-// 並べ替えの選択肢。key はソート対象のフィールド、num はソート方向の既定（true=降順が自然）。
+// 並べ替えの選択肢。key はソート対象のフィールド。並び順（昇順/降順）はUI側のトグルで制御する。
 export var SORT_OPTIONS = [
-  { key: 'date', label: '日付', desc: true },
-  { key: 'dmg_given', label: '与ダメージ', desc: true },
-  { key: 'dmg_taken', label: '被ダメージ', desc: true },
-  { key: 'kills', label: '撃墜数', desc: true },
-  { key: 'deaths', label: '被撃墜数', desc: true },
-  { key: 'ex_dmg', label: 'EXダメージ', desc: true },
-  { key: 'score', label: 'スコア', desc: true },
+  { key: 'date', label: '日付' },
+  { key: 'dmg_given', label: '与ダメージ' },
+  { key: 'dmg_taken', label: '被ダメージ' },
+  { key: 'kills', label: '撃墜数' },
+  { key: 'deaths', label: '被撃墜数' },
+  { key: 'ex_dmg', label: 'EXダメージ' },
+  { key: 'score', label: 'スコア' },
 ];
 
 // フィルタの初期値。UI側はこれを複製して状態の初期値に使う。
@@ -40,17 +40,20 @@ export function hasActiveFilters(filters) {
   return false;
 }
 
-// 出現頻度つきで機体名の一覧を作る内部ヘルパー。
+// 出現「試合数」つきで機体名の一覧を作る内部ヘルパー。
 // getters は各試合から機体名（複数可）を取り出す関数の配列。
+// 同一試合内で同じ機体名が複数回出ても（例: 敵2機が同一機体）1試合として数える。
 function tally(matches, getters) {
   var counts = {};
   for (var i = 0; i < matches.length; i++) {
     var m = matches[i];
+    var seen = {};
     for (var g = 0; g < getters.length; g++) {
       var names = getters[g](m);
       for (var n = 0; n < names.length; n++) {
         var name = names[n];
-        if (!name) continue;
+        if (!name || seen[name]) continue;
+        seen[name] = true;
         counts[name] = (counts[name] || 0) + 1;
       }
     }

--- a/static/analysis/search.js
+++ b/static/analysis/search.js
@@ -18,6 +18,7 @@ export function emptyFilters() {
   return {
     dateFrom: '', dateTo: '',
     myMs: '', partnerMs: '', enemyMs: '',
+    playerName: '',          // 相方プレイヤー名の部分一致（曖昧検索）
     result: 'all',           // 'all' | 'win' | 'loss'
     dmgGivenMin: '', dmgGivenMax: '',
     dmgTakenMin: '', dmgTakenMax: '',
@@ -30,7 +31,7 @@ export function emptyFilters() {
 export function hasActiveFilters(filters) {
   var f = filters || {};
   if (f.result && f.result !== 'all') return true;
-  var keys = ['dateFrom', 'dateTo', 'myMs', 'partnerMs', 'enemyMs',
+  var keys = ['dateFrom', 'dateTo', 'myMs', 'partnerMs', 'enemyMs', 'playerName',
     'dmgGivenMin', 'dmgGivenMax', 'dmgTakenMin', 'dmgTakenMax',
     'killsMin', 'killsMax', 'deathsMin', 'deathsMax'];
   for (var i = 0; i < keys.length; i++) {
@@ -97,6 +98,8 @@ export function filterMatches(matches, filters) {
   var myMs = f.myMs || '';
   var partnerMs = f.partnerMs || '';
   var enemyMs = f.enemyMs || '';
+  // プレイヤー名は部分一致・大小文字無視の曖昧検索（相方名が対象）
+  var playerName = (f.playerName || '').trim().toLowerCase();
   var result = f.result || 'all';
   var dgMin = toNum(f.dmgGivenMin), dgMax = toNum(f.dmgGivenMax);
   var dtMin = toNum(f.dmgTakenMin), dtMax = toNum(f.dmgTakenMax);
@@ -110,6 +113,7 @@ export function filterMatches(matches, filters) {
     if (myMs && m.ms !== myMs) return false;
     if (partnerMs && m.partner_ms !== partnerMs) return false;
     if (enemyMs && m.opponent1_ms !== enemyMs && m.opponent2_ms !== enemyMs) return false;
+    if (playerName && String(m.partner_name || '').toLowerCase().indexOf(playerName) < 0) return false;
     if (result === 'win' && !m.win) return false;
     if (result === 'loss' && m.win) return false;
     if (!inRange(m.dmg_given, dgMin, dgMax)) return false;

--- a/static/analysis/search.js
+++ b/static/analysis/search.js
@@ -1,0 +1,142 @@
+// --- 試合検索ロジック ---
+// IndexedDBキャッシュから読み込んだ試合データ配列を、条件で絞り込み・並べ替える純粋関数群。
+// UI（components/search.js）から切り離すことで単体テスト可能にしている。
+
+// 並べ替えの選択肢。key はソート対象のフィールド、num はソート方向の既定（true=降順が自然）。
+export var SORT_OPTIONS = [
+  { key: 'date', label: '日付', desc: true },
+  { key: 'dmg_given', label: '与ダメージ', desc: true },
+  { key: 'dmg_taken', label: '被ダメージ', desc: true },
+  { key: 'kills', label: '撃墜数', desc: true },
+  { key: 'deaths', label: '被撃墜数', desc: true },
+  { key: 'ex_dmg', label: 'EXダメージ', desc: true },
+  { key: 'score', label: 'スコア', desc: true },
+];
+
+// フィルタの初期値。UI側はこれを複製して状態の初期値に使う。
+export function emptyFilters() {
+  return {
+    dateFrom: '', dateTo: '',
+    myMs: '', partnerMs: '', enemyMs: '',
+    result: 'all',           // 'all' | 'win' | 'loss'
+    dmgGivenMin: '', dmgGivenMax: '',
+    dmgTakenMin: '', dmgTakenMax: '',
+    killsMin: '', killsMax: '',
+    deathsMin: '', deathsMax: '',
+  };
+}
+
+// 何らかの絞り込みが指定されているか（デフォルト状態でないか）を判定する。
+export function hasActiveFilters(filters) {
+  var f = filters || {};
+  if (f.result && f.result !== 'all') return true;
+  var keys = ['dateFrom', 'dateTo', 'myMs', 'partnerMs', 'enemyMs',
+    'dmgGivenMin', 'dmgGivenMax', 'dmgTakenMin', 'dmgTakenMax',
+    'killsMin', 'killsMax', 'deathsMin', 'deathsMax'];
+  for (var i = 0; i < keys.length; i++) {
+    var v = f[keys[i]];
+    if (v !== '' && v != null) return true;
+  }
+  return false;
+}
+
+// 出現頻度つきで機体名の一覧を作る内部ヘルパー。
+// getters は各試合から機体名（複数可）を取り出す関数の配列。
+function tally(matches, getters) {
+  var counts = {};
+  for (var i = 0; i < matches.length; i++) {
+    var m = matches[i];
+    for (var g = 0; g < getters.length; g++) {
+      var names = getters[g](m);
+      for (var n = 0; n < names.length; n++) {
+        var name = names[n];
+        if (!name) continue;
+        counts[name] = (counts[name] || 0) + 1;
+      }
+    }
+  }
+  return Object.keys(counts)
+    .map(function (name) { return { name: name, matches: counts[name] }; })
+    .sort(function (a, b) {
+      return a.matches !== b.matches ? b.matches - a.matches : a.name.localeCompare(b.name);
+    });
+}
+
+// 絞り込みドロップダウン用の機体名リスト（自機・相方・敵）を出現頻度順で返す。
+export function collectMsOptions(matches) {
+  var ms = matches || [];
+  return {
+    mine: tally(ms, [function (m) { return [m.ms]; }]),
+    partners: tally(ms, [function (m) { return [m.partner_ms]; }]),
+    enemies: tally(ms, [function (m) { return [m.opponent1_ms, m.opponent2_ms]; }]),
+  };
+}
+
+// 文字列・数値を数値に変換。空文字/null/変換不能は null。
+function toNum(v) {
+  if (v === '' || v == null) return null;
+  var n = typeof v === 'number' ? v : parseFloat(v);
+  return isNaN(n) ? null : n;
+}
+
+// value が [min, max]（各 null 許容）の範囲に収まるか。
+function inRange(value, min, max) {
+  if (min != null && value < min) return false;
+  if (max != null && value > max) return false;
+  return true;
+}
+
+// 試合配列を filters で絞り込む。元配列は変更しない。
+export function filterMatches(matches, filters) {
+  var f = filters || {};
+  var dateFrom = f.dateFrom || '';
+  var dateTo = f.dateTo || '';
+  var myMs = f.myMs || '';
+  var partnerMs = f.partnerMs || '';
+  var enemyMs = f.enemyMs || '';
+  var result = f.result || 'all';
+  var dgMin = toNum(f.dmgGivenMin), dgMax = toNum(f.dmgGivenMax);
+  var dtMin = toNum(f.dmgTakenMin), dtMax = toNum(f.dmgTakenMax);
+  var kMin = toNum(f.killsMin), kMax = toNum(f.killsMax);
+  var deMin = toNum(f.deathsMin), deMax = toNum(f.deathsMax);
+
+  return (matches || []).filter(function (m) {
+    var day = (m.date || '').substring(0, 10);
+    if (dateFrom && day < dateFrom) return false;
+    if (dateTo && day > dateTo) return false;
+    if (myMs && m.ms !== myMs) return false;
+    if (partnerMs && m.partner_ms !== partnerMs) return false;
+    if (enemyMs && m.opponent1_ms !== enemyMs && m.opponent2_ms !== enemyMs) return false;
+    if (result === 'win' && !m.win) return false;
+    if (result === 'loss' && m.win) return false;
+    if (!inRange(m.dmg_given, dgMin, dgMax)) return false;
+    if (!inRange(m.dmg_taken, dtMin, dtMax)) return false;
+    if (!inRange(m.kills, kMin, kMax)) return false;
+    if (!inRange(m.deaths, deMin, deMax)) return false;
+    return true;
+  });
+}
+
+// 試合配列を key で並べ替える。元配列は変更しない。
+// 日付は文字列比較（"YYYY-MM-DD HH:MM" は辞書順=時系列順）、それ以外は数値比較。
+// 同値の場合は日付の新しい順で安定させる。
+export function sortMatches(matches, key, desc) {
+  var arr = (matches || []).slice();
+  var dir = desc ? -1 : 1;
+  arr.sort(function (a, b) {
+    var va, vb;
+    if (key === 'date') {
+      va = a.date || ''; vb = b.date || '';
+      if (va < vb) return -1 * dir;
+      if (va > vb) return 1 * dir;
+      return 0;
+    }
+    va = a[key] != null ? a[key] : 0;
+    vb = b[key] != null ? b[key] : 0;
+    if (va !== vb) return (va - vb) * dir;
+    // タイブレーク: 新しい試合を先に
+    var da = a.date || '', db = b.date || '';
+    return da < db ? 1 : da > db ? -1 : 0;
+  });
+  return arr;
+}

--- a/static/analysis/search.js
+++ b/static/analysis/search.js
@@ -16,14 +16,26 @@ export var SORT_OPTIONS = [
 // フィルタの初期値。UI側はこれを複製して状態の初期値に使う。
 export function emptyFilters() {
   return {
+    playDays: '',            // 期間プリセット（''=全データ / '1d','3d'... レポートと同じ直近プレイ日数）
     dateFrom: '', dateTo: '',
-    myMs: '', partnerMs: '', enemyMs: '',
-    playerName: '',          // 相方プレイヤー名の部分一致（曖昧検索）
+    myMsList: [],            // 自機（複数選択・OR）
+    partnerMsList: [],       // 僚機（複数選択・OR）
+    enemyMsList: [],         // 敵機（複数選択）
+    enemyMsMode: 'or',       // 'and'=相手編成に全部いる / 'or'=どれかいる
+    playerName: '',          // 相方・敵プレイヤー名の部分一致（曖昧検索）
+    myTagList: [],           // 味方タッグ名（複数選択・OR）
+    enemyTagName: '',        // 敵陣タッグ名の部分一致（曖昧検索）
     result: 'all',           // 'all' | 'win' | 'loss'
+    myCostList: [],          // 自機コスト（複数選択・OR）
+    partnerCostList: [],     // 僚機コスト（複数選択・OR）
+    enemyCostPairList: [],   // 相手コスト編成（複数選択・OR）
     dmgGivenMin: '', dmgGivenMax: '',
     dmgTakenMin: '', dmgTakenMax: '',
     killsMin: '', killsMax: '',
     deathsMin: '', deathsMax: '',
+    scoreMin: '', scoreMax: '',
+    exDmgMin: '', exDmgMax: '',
+    burstsMin: '', burstsMax: '',
   };
 }
 
@@ -31,9 +43,14 @@ export function emptyFilters() {
 export function hasActiveFilters(filters) {
   var f = filters || {};
   if (f.result && f.result !== 'all') return true;
-  var keys = ['dateFrom', 'dateTo', 'myMs', 'partnerMs', 'enemyMs', 'playerName',
+  var listKeys = ['myMsList', 'partnerMsList', 'enemyMsList', 'myTagList', 'myCostList', 'partnerCostList', 'enemyCostPairList'];
+  for (var j = 0; j < listKeys.length; j++) {
+    if (f[listKeys[j]] && f[listKeys[j]].length) return true;
+  }
+  var keys = ['playDays', 'dateFrom', 'dateTo', 'playerName', 'enemyTagName',
     'dmgGivenMin', 'dmgGivenMax', 'dmgTakenMin', 'dmgTakenMax',
-    'killsMin', 'killsMax', 'deathsMin', 'deathsMax'];
+    'killsMin', 'killsMax', 'deathsMin', 'deathsMax',
+    'scoreMin', 'scoreMax', 'exDmgMin', 'exDmgMax', 'burstsMin', 'burstsMax'];
   for (var i = 0; i < keys.length; i++) {
     var v = f[keys[i]];
     if (v !== '' && v != null) return true;
@@ -66,13 +83,30 @@ function tally(matches, getters) {
     });
 }
 
-// 絞り込みドロップダウン用の機体名リスト（自機・相方・敵）を出現頻度順で返す。
+// 相手2機のコスト編成キー。高コスト+低コストで正規化（順不同で同一扱い）。
+// どちらかが未取得(0)なら '' を返して集計・絞り込み対象外にする。
+export function enemyCostPairKey(a, b) {
+  var x = Number(a) || 0, y = Number(b) || 0;
+  if (!x || !y) return '';
+  return Math.max(x, y) + ' + ' + Math.min(x, y);
+}
+
+// 絞り込みドロップダウン用のリスト（自機・相方・敵の機体名／自陣・敵陣のタッグ名／相手コスト編成）を
+// 出現頻度順で返す。
 export function collectMsOptions(matches) {
   var ms = matches || [];
+  // 相手コスト編成は出現数順ではなくコスト降順（3000+3000 → 3000+2500 → …）で並べる。
+  var costPairs = tally(ms, [function (m) { return [enemyCostPairKey(m.opponent1_cost, m.opponent2_cost)]; }]);
+  costPairs.sort(function (a, b) {
+    var pa = a.name.split(' + '), pb = b.name.split(' + ');
+    return (Number(pb[0]) - Number(pa[0])) || (Number(pb[1]) - Number(pa[1]));
+  });
   return {
     mine: tally(ms, [function (m) { return [m.ms]; }]),
     partners: tally(ms, [function (m) { return [m.partner_ms]; }]),
     enemies: tally(ms, [function (m) { return [m.opponent1_ms, m.opponent2_ms]; }]),
+    myTags: tally(ms, [function (m) { return [m.team_name]; }]),
+    enemyCostPairs: costPairs,
   };
 }
 
@@ -100,36 +134,64 @@ function nameMatches(m, needle) {
   return false;
 }
 
+
 // 試合配列を filters で絞り込む。元配列は変更しない。
 export function filterMatches(matches, filters) {
   var f = filters || {};
   var dateFrom = f.dateFrom || '';
   var dateTo = f.dateTo || '';
-  var myMs = f.myMs || '';
-  var partnerMs = f.partnerMs || '';
-  var enemyMs = f.enemyMs || '';
+  // 自機・僚機は複数選択・OR（選んだどれかに一致）。
+  var myMsList = f.myMsList || [];
+  var partnerMsList = f.partnerMsList || [];
+  // 敵機は複数選択。and=相手2機に選んだ機体が全部いる（編成指定）、or=どれかいる。
+  var enemyMsList = f.enemyMsList || [];
+  var enemyMsMode = f.enemyMsMode || 'or';
   // プレイヤー名は部分一致・大小文字無視の曖昧検索（相方・敵の名前が対象）
   var playerName = (f.playerName || '').trim().toLowerCase();
+  // 味方タッグは複数選択・OR。敵タッグ名は部分一致・大小文字無視（敵陣）。
+  var myTagList = f.myTagList || [];
+  var enemyTagName = (f.enemyTagName || '').trim().toLowerCase();
   var result = f.result || 'all';
+  // コスト系は複数選択・OR。コストは数値比較のため数値化しておく。
+  var myCostList = (f.myCostList || []).map(Number);
+  var partnerCostList = (f.partnerCostList || []).map(Number);
+  var enemyCostPairList = f.enemyCostPairList || [];
   var dgMin = toNum(f.dmgGivenMin), dgMax = toNum(f.dmgGivenMax);
   var dtMin = toNum(f.dmgTakenMin), dtMax = toNum(f.dmgTakenMax);
   var kMin = toNum(f.killsMin), kMax = toNum(f.killsMax);
   var deMin = toNum(f.deathsMin), deMax = toNum(f.deathsMax);
+  var scMin = toNum(f.scoreMin), scMax = toNum(f.scoreMax);
+  var exMin = toNum(f.exDmgMin), exMax = toNum(f.exDmgMax);
+  var buMin = toNum(f.burstsMin), buMax = toNum(f.burstsMax);
 
   return (matches || []).filter(function (m) {
     var day = (m.date || '').substring(0, 10);
     if (dateFrom && day < dateFrom) return false;
     if (dateTo && day > dateTo) return false;
-    if (myMs && m.ms !== myMs) return false;
-    if (partnerMs && m.partner_ms !== partnerMs) return false;
-    if (enemyMs && m.opponent1_ms !== enemyMs && m.opponent2_ms !== enemyMs) return false;
+    if (myMsList.length && myMsList.indexOf(m.ms) < 0) return false;
+    if (partnerMsList.length && partnerMsList.indexOf(m.partner_ms) < 0) return false;
+    if (enemyMsList.length) {
+      var es = [m.opponent1_ms, m.opponent2_ms];
+      var hit = enemyMsMode === 'and'
+        ? enemyMsList.every(function (x) { return es.indexOf(x) >= 0; })
+        : enemyMsList.some(function (x) { return es.indexOf(x) >= 0; });
+      if (!hit) return false;
+    }
     if (playerName && !nameMatches(m, playerName)) return false;
+    if (myTagList.length && myTagList.indexOf(m.team_name) < 0) return false;
+    if (enemyTagName && String(m.opponent_team_name || '').toLowerCase().indexOf(enemyTagName) < 0) return false;
     if (result === 'win' && !m.win) return false;
     if (result === 'loss' && m.win) return false;
+    if (myCostList.length && myCostList.indexOf(m.ms_cost) < 0) return false;
+    if (partnerCostList.length && partnerCostList.indexOf(m.partner_cost) < 0) return false;
+    if (enemyCostPairList.length && enemyCostPairList.indexOf(enemyCostPairKey(m.opponent1_cost, m.opponent2_cost)) < 0) return false;
     if (!inRange(m.dmg_given, dgMin, dgMax)) return false;
     if (!inRange(m.dmg_taken, dtMin, dtMax)) return false;
     if (!inRange(m.kills, kMin, kMax)) return false;
     if (!inRange(m.deaths, deMin, deMax)) return false;
+    if (!inRange(m.score, scMin, scMax)) return false;
+    if (!inRange(m.ex_dmg, exMin, exMax)) return false;
+    if (!inRange(m.bursts, buMin, buMax)) return false;
     return true;
   });
 }

--- a/static/analysis/stats.js
+++ b/static/analysis/stats.js
@@ -4,6 +4,29 @@
 
 export var PERIOD_DAYS = { '90d': 90, '60d': 60, '30d': 30, '14d': 14, '7d': 7, '3d': 3, '1d': 1 };
 
+// 基本データ各指標の基準レンジ [0%側の値, 100%側の値]。レーダー等の0-100正規化で共有する。
+// 守備系(被ダメ・被撃墜)は「小さいほど良い」ため大小を逆に置く。
+export var METRIC_RANGE = {
+  dmgGiven: [600, 1200],
+  kills: [0.5, 2.5],
+  bursts: [0, 2.5],
+  dmgTaken: [1200, 600],
+  deaths: [2.5, 0.5],
+  exDmg: [80, 250],
+};
+
+// 値を [min, max] 基準で 0-100 に写像（min>max の反転軸も同式で処理）。null は 0。
+export function clampN(v, min, max) {
+  if (v == null) return 0;
+  return Math.max(0, Math.min(100, (v - min) / (max - min) * 100));
+}
+
+// METRIC_RANGE のキーで指標を 0-100 に正規化する。基本データ・レーダーで共用。
+export function clampMetric(v, key) {
+  var r = METRIC_RANGE[key];
+  return clampN(v, r[0], r[1]);
+}
+
 var COST_LABEL = {3000: '3000コスト', 2500: '2500コスト', 2000: '2000コスト', 1500: '1500コスト'};
 var COST_FATAL_DEATHS = {3000: 2, 2500: 3, 2000: 3, 1500: 4};
 var TEAM_DEATH_MAX = 3;   // これ以上は "3+" に集約

--- a/static/app.js
+++ b/static/app.js
@@ -21,6 +21,7 @@ import {
 import {
   Tips, SortableTable, Table, SubSection,
 } from './components/ui.js';
+import { SearchView } from './components/search.js';
 import {
   useInView,
   EnemyMatchupSection, PartnerSection, MsPairSubSection, CostPairSubSection,
@@ -318,7 +319,7 @@ function ShareArea({ shareData }) {
 
 // --- Hamburger menu & topbar controls ---
 
-function HamburgerMenu({ isOpen, onClose, shareData, onLogout }) {
+function HamburgerMenu({ isOpen, onClose, shareData, onLogout, currentView, onNavigate }) {
   useEffect(function () {
     if (isOpen) {
       document.body.style.overflow = 'hidden';
@@ -329,14 +330,19 @@ function HamburgerMenu({ isOpen, onClose, shareData, onLogout }) {
   }, [isOpen]);
 
   if (!isOpen) return null;
+  var view = currentView || 'report';
+  function go(target) {
+    if (onNavigate) onNavigate(target);
+    onClose();
+  }
   return html`<div>
     <div class="menu-backdrop" onClick=${onClose} />
     <div class=${'menu-drawer' + (isOpen ? ' open' : '')}>
       <div class="menu-header"><img src="logo.svg" alt="catalyzer" style="height:24px;width:auto;" /></div>
       <div class="menu-body">
         <div class="menu-section">メニュー</div>
-        <button class="menu-item active" onClick=${onClose}><span class="menu-icon">📊</span>分析レポート</button>
-        <button class="menu-item disabled"><span class="menu-icon">🔍</span>試合検索<span class="coming-soon">coming soon</span></button>
+        <button class=${'menu-item' + (view === 'report' ? ' active' : '')} onClick=${function () { go('report'); }}><span class="menu-icon">📊</span>分析レポート</button>
+        <button class=${'menu-item' + (view === 'search' ? ' active' : '')} onClick=${function () { go('search'); }}><span class="menu-icon">🔍</span>試合検索</button>
         <button class="menu-item disabled"><span class="menu-icon">📈</span>モバイル総合戦歴<span class="coming-soon">coming soon</span></button>
         <button class="menu-item disabled"><span class="menu-icon">🏆</span>EXランキング<span class="coming-soon">coming soon</span></button>
         <button class="menu-item disabled"><span class="menu-icon">🤖</span>機体使用率ランキング<span class="coming-soon">coming soon</span></button>
@@ -1106,6 +1112,8 @@ function Report({ data, userKey }) {
   var lens = lensRef[0], setLens = lensRef[1];
   var menuRef = useState(false);
   var menuOpen = menuRef[0], setMenuOpen = menuRef[1];
+  var viewRef = useState('report');
+  var view = viewRef[0], setView = viewRef[1];
   var matchesRef = useState(data.matches || null);
   var allMatches = matchesRef[0], setAllMatches = matchesRef[1];
   var tagPartnersRef = useState(null);
@@ -1219,6 +1227,21 @@ function Report({ data, userKey }) {
     return { basic_stats: null, win_loss_pattern: null };
   }, [frontendData]);
 
+  // 試合検索ビュー: ダッシュボードのフィルタ群とは独立した専用画面。
+  // allMatches（IndexedDBキャッシュ）を共有し、フロントエンドで絞り込む。
+  if (view === 'search') {
+    return html`
+      <div class="topbar">
+        <button class="hamburger" onClick=${function () { setMenuOpen(true); }}>☰</button>
+        <span class="brand"><img src="logo.svg" alt="catalyzer" /></span>
+        <button class="topbar-refresh" onClick=${function () { setView('report'); }}>レポートへ戻る</button>
+      </div>
+      <${HamburgerMenu} isOpen=${menuOpen} onClose=${function () { setMenuOpen(false); }}
+        shareData=${shareData} onLogout=${logout} currentView=${view} onNavigate=${setView} />
+      <${SearchView} matches=${allMatches || []} />
+    `;
+  }
+
   if (!frontendData) {
     return html`<${Skeleton} />`;
   }
@@ -1256,7 +1279,7 @@ function Report({ data, userKey }) {
 
     <${HamburgerMenu} isOpen=${menuOpen} onClose=${function () { setMenuOpen(false); }}
       shareData=${shareData}
-      onLogout=${logout} />
+      onLogout=${logout} currentView=${view} onNavigate=${setView} />
 
     <${KpiGrid} stats=${fePd.basic_stats} />
 

--- a/static/app.js
+++ b/static/app.js
@@ -8,6 +8,7 @@ import {
   computeBurstCount, computeFallOrder, computeBurstTiming, computeBurstType,
   computeFixedPartners,
   computeShareData, computeMsSummary,
+  clampMetric,
 } from './analysis/stats.js';
 import {
   loadMatchesFromDB, saveMatchesToDB,
@@ -322,12 +323,6 @@ function LensToggle({ lens, onSelect }) {
 
 // --- Dashboard building blocks ---
 
-// 値を min..max の範囲で 0-100 に正規化（レーダー用）
-function clampN(v, min, max) {
-  if (v == null) return 0;
-  return Math.max(0, Math.min(100, (v - min) / (max - min) * 100));
-}
-
 // KPIカードの色クラス。higher=trueは大きいほど良い
 function kpiClass(n, great, good, terrible, higher) {
   if (n == null) return '';
@@ -376,7 +371,7 @@ function BasicLensSection({ basic, pattern, lens }) {
   // 攻めを上半分・守りを下半分に固めつつ3ペアを対極配置: 与ダメ↔被ダメ, 撃墜↔被撃墜, EXダメ↔覚醒回数
   // 軸順(idx): 0=与ダメ(上), 1=撃墜(右上), 2=覚醒回数(右下), 3=被ダメ(下), 4=被撃墜(左下), 5=EXダメ(左上)
   function vec(dgv, kv, bv, dtv, dthv, exv) {
-    return [clampN(dgv, 600, 1200), clampN(kv, 0.5, 2.5), clampN(bv, 0, 2.5), clampN(dtv, 1200, 600), clampN(dthv, 2.5, 0.5), clampN(exv, 80, 250)];
+    return [clampMetric(dgv, 'dmgGiven'), clampMetric(kv, 'kills'), clampMetric(bv, 'bursts'), clampMetric(dtv, 'dmgTaken'), clampMetric(dthv, 'deaths'), clampMetric(exv, 'exDmg')];
   }
   var seriesByLens = {
     all: { label: '全体', color: '#81d4fa', bg: 'rgba(129,212,250,.2)', data: vec(basic.avg_dmg_given, basic.avg_kills, basic.avg_bursts, basic.avg_dmg_taken, basic.avg_deaths, basic.avg_ex_dmg) },
@@ -560,12 +555,12 @@ function FixedPartnerPanel({ fp, fpItems, lens }) {
   function pVec(stats, wlMetrics) {
     function v(label, allVal) { return valFor(wlMetrics, label, allVal); }
     return [
-      clampN(v('平均与ダメージ', stats.avg_dmg_given), 600, 1200),
-      clampN(v('平均撃墜', stats.avg_kills), 0.5, 2.5),
-      clampN(v('平均覚醒回数', stats.avg_bursts), 0, 2.5),
-      clampN(v('平均被ダメージ', stats.avg_dmg_taken), 1200, 600),
-      clampN(v('平均被撃墜', stats.avg_deaths), 2.5, 0.5),
-      clampN(v('平均EXダメージ', stats.avg_ex_dmg), 80, 250),
+      clampMetric(v('平均与ダメージ', stats.avg_dmg_given), 'dmgGiven'),
+      clampMetric(v('平均撃墜', stats.avg_kills), 'kills'),
+      clampMetric(v('平均覚醒回数', stats.avg_bursts), 'bursts'),
+      clampMetric(v('平均被ダメージ', stats.avg_dmg_taken), 'dmgTaken'),
+      clampMetric(v('平均被撃墜', stats.avg_deaths), 'deaths'),
+      clampMetric(v('平均EXダメージ', stats.avg_ex_dmg), 'exDmg'),
     ];
   }
 
@@ -991,8 +986,18 @@ function Report({ data, userKey }) {
   var lens = lensRef[0], setLens = lensRef[1];
   var menuRef = useState(false);
   var menuOpen = menuRef[0], setMenuOpen = menuRef[1];
-  var viewRef = useState('report');
+  // 再分析はReportを再マウントするため、view(report/search)をlocalStorageで永続化して復元する。
+  var viewRef = useState(function () { try { return localStorage.getItem('catalyzer_view') || 'report'; } catch (e) { return 'report'; } });
   var view = viewRef[0], setView = viewRef[1];
+  function navigate(v) {
+    setView(v);
+    try { localStorage.setItem('catalyzer_view', v); } catch (e) {}
+    // 画面切替時に、メニューで残ったスクロールロックを確実に解除し先頭へ戻す
+    // （ヘッダーが下に固定されスクロール不能になる不具合の対処）。
+    document.body.style.overflow = '';
+    document.documentElement.style.overflow = '';
+    window.scrollTo(0, 0);
+  }
   var matchesRef = useState(data.matches || null);
   var allMatches = matchesRef[0], setAllMatches = matchesRef[1];
   var tagPartnersRef = useState(null);
@@ -1048,6 +1053,15 @@ function Report({ data, userKey }) {
     window.addEventListener('scroll', onScroll, { passive: true });
     return function () { window.removeEventListener('scroll', onScroll); };
   }, []);
+
+  // 画面(view)が変わるたびに、メニュー由来のスクロールロックを確実に解除し先頭へ戻す。
+  // 再分析中はReportが再描画(再マウント)されるため、navigate内だけでなくここでも保証する
+  // （切替時にヘッダーが下に固定されスクロール不能になる不具合の対処）。
+  useEffect(function () {
+    document.body.style.overflow = '';
+    document.documentElement.style.overflow = '';
+    window.scrollTo(0, 0);
+  }, [view]);
 
   var PERIOD_LABELS = { all: '全データ', '90d': '90日', '60d': '60日', '30d': '30日', '14d': '14日', '7d': '7日', '3d': '3日', '1d': '1日' };
   var periods = {};
@@ -1124,16 +1138,16 @@ function Report({ data, userKey }) {
   // 試合検索ビュー: ダッシュボードのフィルタ群とは独立した専用画面。
   // allMatches（IndexedDBキャッシュ）を共有し、フロントエンドで絞り込む。
   if (view === 'search') {
-    return html`
+    return html`<div class="view-root">
       <div class="topbar">
         <button class="hamburger" onClick=${function () { setMenuOpen(true); }}>☰</button>
         <span class="brand"><img src="logo.svg" alt="catalyzer" /></span>
-        <button class="topbar-refresh" onClick=${function () { setView('report'); }}>レポートへ戻る</button>
+        <button class="topbar-refresh" onClick=${reAnalyze}>再分析</button>
       </div>
       <${HamburgerMenu} isOpen=${menuOpen} onClose=${function () { setMenuOpen(false); }}
-        shareData=${shareData} onLogout=${logout} currentView=${view} onNavigate=${setView} />
+        shareData=${shareData} onLogout=${logout} currentView=${view} onNavigate=${navigate} />
       <${SearchView} matches=${allMatches || []} msImages=${msImages || {}} />
-    `;
+    </div>`;
   }
 
   if (!frontendData) {
@@ -1154,7 +1168,7 @@ function Report({ data, userKey }) {
     pane = html`<${OverviewPane} pd=${fePd} selectedMs=${selectedMs} lens=${lens} frontendData=${frontendData} />`;
   }
 
-  return html`
+  return html`<div class="view-root">
     <div class="topbar" ref=${topbarRef}>
       <button class="hamburger" onClick=${function () { setMenuOpen(true); }}>☰</button>
       <span class="brand"><img src="logo.svg" alt="catalyzer" /></span>
@@ -1173,13 +1187,12 @@ function Report({ data, userKey }) {
 
     <${HamburgerMenu} isOpen=${menuOpen} onClose=${function () { setMenuOpen(false); }}
       shareData=${shareData}
-      onLogout=${logout} currentView=${view} onNavigate=${setView} />
+      onLogout=${logout} currentView=${view} onNavigate=${navigate} />
 
     <${KpiGrid} stats=${fePd.basic_stats} />
 
     ${pane}
-
-  `;
+  </div>`;
 }
 
 // --- Main app logic ---
@@ -1191,7 +1204,7 @@ function Skeleton() {
   function bar(w, h, mb) {
     return html`<div class="skel" style=${{ width: w, height: h + 'px', marginBottom: (mb || 0) + 'px' }}></div>`;
   }
-  return html`
+  return html`<div class="view-root">
     <div class="topbar">
       <button class="hamburger" onClick=${function () { setMenuOpen(true); }}>☰</button>
       <span class="brand"><img src="logo.svg" alt="catalyzer" /></span>
@@ -1220,7 +1233,7 @@ function Skeleton() {
       ${bar('24%', 16, 14)}
       ${[0, 1, 2, 3].map(function () { return bar('100%', 14, 10); })}
     </div>
-  `;
+  </div>`;
 }
 
 function showSkeleton() {

--- a/static/app.js
+++ b/static/app.js
@@ -19,7 +19,7 @@ import {
   buildShareText, SVG_X, SVG_BSKY, SVG_LINE, SVG_COPY, SVG_CHECK,
 } from './lib/format.js';
 import {
-  Tips, SortableTable, Table, SubSection,
+  Tips, SortableTable, Table, SubSection, RangeCalendar,
 } from './components/ui.js';
 import { SearchView } from './components/search.js';
 import {
@@ -29,6 +29,7 @@ import {
   TimeOfDayChart, DayOfWeekChart, DailyTrendChart, SeasonChart,
   WinRateBarChart, DmgContributionChart,
   FallOrderContent, BurstTimingContent, BurstTypeContent, BurstCountContent,
+  CompareRadar,
 } from './components/charts.js';
 
 // --- Constants ---
@@ -45,89 +46,6 @@ var STATUS_MESSAGES = {
 var activeJobId = null;
 
 var PERIOD_KEYS = ['all', '90d', '60d', '30d', '14d', '7d', '3d', '1d'];
-
-// --- Calendar component ---
-
-var DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
-
-function RangeCalendar({ startDate, endDate, onSelectStart, onSelectEnd }) {
-  var init = startDate ? new Date(startDate) : new Date();
-  var viewRef = useState({ year: init.getFullYear(), month: init.getMonth() });
-  var view = viewRef[0], setView = viewRef[1];
-  var phaseRef = useState(startDate ? (endDate ? 'done' : 'end') : 'start');
-  var phase = phaseRef[0], setPhase = phaseRef[1];
-
-  function prevMonth() {
-    setView(function (v) {
-      var m = v.month - 1;
-      return m < 0 ? { year: v.year - 1, month: 11 } : { year: v.year, month: m };
-    });
-  }
-  function nextMonth() {
-    setView(function (v) {
-      var m = v.month + 1;
-      return m > 11 ? { year: v.year + 1, month: 0 } : { year: v.year, month: m };
-    });
-  }
-
-  var firstDay = new Date(view.year, view.month, 1).getDay();
-  var daysInMonth = new Date(view.year, view.month + 1, 0).getDate();
-
-  var cells = [];
-  for (var i = 0; i < firstDay; i++) cells.push(null);
-  for (var d = 1; d <= daysInMonth; d++) cells.push(d);
-  while (cells.length < 42) cells.push(null);
-
-  function toStr(day) {
-    return view.year + '-' + String(view.month + 1).padStart(2, '0') + '-' + String(day).padStart(2, '0');
-  }
-
-  function handleClick(day) {
-    if (!day) return;
-    var s = toStr(day);
-    if (phase === 'start' || phase === 'done') {
-      onSelectStart(s);
-      onSelectEnd('');
-      setPhase('end');
-    } else {
-      if (s < startDate) {
-        onSelectStart(s);
-        onSelectEnd('');
-      } else {
-        onSelectEnd(s);
-        setPhase('done');
-      }
-    }
-  }
-
-  function dayClass(day) {
-    if (!day) return '';
-    var s = toStr(day);
-    var cls = 'cal-day';
-    if (s === startDate || s === endDate) cls += ' selected';
-    else if (startDate && endDate && s > startDate && s < endDate) cls += ' in-range';
-    return cls;
-  }
-
-  var hint = phase === 'start' || phase === 'done' ? '▶ 開始日を選択' : '▶ 終了日を選択';
-
-  return html`<div class="cal">
-    <div class="cal-header">
-      <button class="cal-nav" onClick=${prevMonth}>◀</button>
-      <span class="cal-title">${view.year}年${view.month + 1}月</span>
-      <button class="cal-nav" onClick=${nextMonth}>▶</button>
-    </div>
-    <div style="text-align:center;font-size:0.8em;color:var(--accent);margin-bottom:4px">${hint}</div>
-    <div class="cal-grid">
-      ${DOW_LABELS.map(function (d) { return html`<span class="cal-dow">${d}</span>`; })}
-      ${cells.map(function (day) {
-        if (!day) return html`<span class="cal-empty" />`;
-        return html`<button class=${dayClass(day)}
-          onClick=${function () { handleClick(day); }}>${day}</button>`;
-      })}
-    </div>
-  </div>`;
-}
 
 // --- Time selector ---
 
@@ -444,45 +362,6 @@ function KpiGrid({ stats }) {
 }
 
 // 2系列を重ねたレーダー（series: [{label, color, bg, data[]}]）
-function CompareRadar({ labels, series, showLegend }) {
-  var containerRef = useRef(null);
-  var canvasRef = useRef(null);
-  var chartRef = useRef(null);
-  var inView = useInView(containerRef);
-
-  useEffect(function () {
-    if (!inView || !canvasRef.current) return;
-    if (chartRef.current) chartRef.current.destroy();
-    chartRef.current = new Chart(canvasRef.current, {
-      type: 'radar',
-      data: {
-        labels: labels,
-        datasets: series.map(function (s) {
-          return {
-            label: s.label, data: s.data, hidden: !!s.hidden,
-            backgroundColor: s.bg, borderColor: s.color,
-            pointBackgroundColor: s.color, borderWidth: 2,
-          };
-        }),
-      },
-      options: {
-        responsive: true, maintainAspectRatio: false,
-        plugins: { legend: showLegend === false ? { display: false } : { labels: { color: '#8aa0b3' } } },
-        scales: {
-          r: {
-            min: 0, max: 100, ticks: { display: false, stepSize: 25 },
-            grid: { color: 'rgba(255,255,255,0.1)' }, angleLines: { color: 'rgba(255,255,255,0.1)' },
-            pointLabels: { color: '#aaa', font: { size: 12 } },
-          },
-        },
-      },
-    });
-    return function () { if (chartRef.current) { chartRef.current.destroy(); chartRef.current = null; } };
-  }, [labels, series, inView, showLegend]);
-
-  return html`<div class="chart-container chart-radar" ref=${containerRef}><canvas ref=${canvasRef} /></div>`;
-}
-
 // 全体・勝利時・敗北時を下のボタンで単一選択し、レーダーとテーブルを連動して切り替える
 // 軸はK/D比(頂点)→被ダメ(右)→EXダメ(下)→与ダメ(左)。勝率は分割で無意味なため含めない
 function BasicLensSection({ basic, pattern, lens }) {
@@ -886,7 +765,7 @@ function MatchupPane({ frontendData }) {
   var costPairEntries = (costPairData || []).map(function (p) { return { name: p.pair, winRate: p.win_rate }; });
 
   return html`<div class="tabpane">
-    ${enemyMatchup && html`<${Panel} title="敵機体との相性">
+    ${enemyMatchup && html`<${Panel} title="敵機との相性">
       ${enemyStrong.length > 0 && html`<h3>得意な相手</h3><${MsCompareChart} entries=${enemyStrong} />`}
       ${enemyWeak.length > 0 && html`<h3>苦手な相手</h3><${MsCompareChart} entries=${enemyWeak} />`}
       <${EnemyMatchupSection} matchup=${enemyMatchup} />
@@ -1118,7 +997,22 @@ function Report({ data, userKey }) {
   var allMatches = matchesRef[0], setAllMatches = matchesRef[1];
   var tagPartnersRef = useState(null);
   var tagPartners = tagPartnersRef[0], setTagPartners = tagPartnersRef[1];
+  var msImagesRef = useState(null);
+  var msImages = msImagesRef[0], setMsImages = msImagesRef[1];
   var topbarRef = useRef(null);
+
+  // 機体名→画像URLのマップを一度だけ取得（試合検索一覧のサムネイル表示用）。
+  useEffect(function () {
+    fetch('/ms-list')
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (list) {
+        if (!list) return;
+        var map = {};
+        list.forEach(function (m) { if (m && m.Name) map[m.Name] = m.ImageURL; });
+        setMsImages(map);
+      })
+      .catch(function () {});
+  }, []);
 
   useEffect(function () {
     if (!userKey) return;
@@ -1238,7 +1132,7 @@ function Report({ data, userKey }) {
       </div>
       <${HamburgerMenu} isOpen=${menuOpen} onClose=${function () { setMenuOpen(false); }}
         shareData=${shareData} onLogout=${logout} currentView=${view} onNavigate=${setView} />
-      <${SearchView} matches=${allMatches || []} />
+      <${SearchView} matches=${allMatches || []} msImages=${msImages || {}} />
     `;
   }
 

--- a/static/components/charts.js
+++ b/static/components/charts.js
@@ -653,3 +653,52 @@ export function BurstCountContent({ countData }) {
     <${Tips} tips=${countData.tips} />
   </div>`;
 }
+
+// レーダーの最低描画半径(%)。全軸が最低評価(0)でも中心の点に潰れず六角形の厚みを残すための底上げ。
+var RADAR_FLOOR_PCT = 15;
+// 0-100の正規化値を [RADAR_FLOOR_PCT, 100] に写像する（順序は保つ）。
+function radarFloor(v) {
+  var n = Math.max(0, Math.min(100, Number(v) || 0));
+  return RADAR_FLOOR_PCT + n / 100 * (100 - RADAR_FLOOR_PCT);
+}
+
+// 基本データ比較レーダー（複数系列を重ねて表示）。series は {label,data,color,bg,hidden} の配列。
+// 軸は0-100正規化済みの値を渡す前提。最低評価でも六角形を保つため内部で底上げする。
+export function CompareRadar({ labels, series, showLegend }) {
+  var containerRef = useRef(null);
+  var canvasRef = useRef(null);
+  var chartRef = useRef(null);
+  var inView = useInView(containerRef);
+
+  useEffect(function () {
+    if (!inView || !canvasRef.current) return;
+    if (chartRef.current) chartRef.current.destroy();
+    chartRef.current = new Chart(canvasRef.current, {
+      type: 'radar',
+      data: {
+        labels: labels,
+        datasets: series.map(function (s) {
+          return {
+            label: s.label, data: s.data.map(radarFloor), hidden: !!s.hidden,
+            backgroundColor: s.bg, borderColor: s.color,
+            pointBackgroundColor: s.color, borderWidth: 2,
+          };
+        }),
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: showLegend === false ? { display: false } : { labels: { color: '#8aa0b3' } } },
+        scales: {
+          r: {
+            min: 0, max: 100, ticks: { display: false, stepSize: 25 },
+            grid: { color: 'rgba(255,255,255,0.1)' }, angleLines: { color: 'rgba(255,255,255,0.1)' },
+            pointLabels: { color: '#aaa', font: { size: 12 } },
+          },
+        },
+      },
+    });
+    return function () { if (chartRef.current) { chartRef.current.destroy(); chartRef.current = null; } };
+  }, [labels, series, inView, showLegend]);
+
+  return html`<div class="chart-container chart-radar" ref=${containerRef}><canvas ref=${canvasRef} /></div>`;
+}

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -8,7 +8,7 @@ import {
   colorKills, colorDeaths, colorDmgGiven, colorDmgTaken, colorExDmg,
 } from '../lib/format.js';
 import { CompareRadar } from './charts.js';
-import { RangeCalendar, Dropdown, MultiSelect } from './ui.js';
+import { RangeCalendar, Dropdown, MultiSelect, Autocomplete } from './ui.js';
 import { PERIOD_DAYS, filterByPlayDays } from '../analysis/stats.js';
 
 var PAGE_SIZE = 20;
@@ -126,8 +126,9 @@ function FilterForm({ filters, options, onField, onReset, resultCount }) {
 
       <div class="search-field">
         <label class="search-label">プレイヤー名（相方・相手／部分一致）</label>
-        <input type="text" class="search-text" placeholder="名前の一部を入力"
-          value=${filters.playerName} onInput=${function (e) { onField('playerName', e.target.value); }} />
+        <${Autocomplete} value=${filters.playerName} placeholder="名前の一部を入力"
+          options=${options.playerNames.map(function (o) { return o.name; })}
+          onChange=${function (v) { onField('playerName', v); }} />
       </div>
 
       <div class="search-field">
@@ -167,8 +168,9 @@ function FilterForm({ filters, options, onField, onReset, resultCount }) {
           </div>
           <div class="search-field search-field-wide">
             <label class="search-label">相手タッグ名（部分一致）</label>
-            <input type="text" class="search-text" placeholder="タッグ名の一部を入力"
-              value=${filters.enemyTagName} onInput=${function (e) { onField('enemyTagName', e.target.value); }} />
+            <${Autocomplete} value=${filters.enemyTagName} placeholder="タッグ名の一部を入力"
+              options=${options.enemyTags.map(function (o) { return o.name; })}
+              onChange=${function (v) { onField('enemyTagName', v); }} />
           </div>
           <div class="search-field">
             <label class="search-label">自機コスト（複数選択可）</label>

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -91,7 +91,7 @@ function FilterForm({ filters, options, onField, onReset, resultCount }) {
       </div>
 
       <div class="search-field">
-        <label class="search-label">相方プレイヤー名（部分一致）</label>
+        <label class="search-label">プレイヤー名（相方・敵／部分一致）</label>
         <input type="text" class="search-text" placeholder="名前の一部を入力"
           value=${filters.playerName} onInput=${function (e) { onField('playerName', e.target.value); }} />
       </div>
@@ -123,9 +123,20 @@ function FilterForm({ filters, options, onField, onReset, resultCount }) {
   </div>`;
 }
 
+// 名前と機体を「名前（機体）」形式に整形する。名前が無ければ機体のみ。
+function nameWithMs(name, ms) {
+  var n = (name || '').trim();
+  var m = (ms || '').trim();
+  if (n && m) return n + '（' + m + '）';
+  return n || m || '?';
+}
+
 // 1試合分のサマリー行。クリックで詳細を開く。
 function ResultItem({ match, onOpen }) {
-  var enemies = [match.opponent1_ms, match.opponent2_ms].filter(Boolean).join(' / ');
+  var enemies = [
+    nameWithMs(match.opponent1_name, match.opponent1_ms),
+    nameWithMs(match.opponent2_name, match.opponent2_ms),
+  ].join(' / ');
   return html`<button class="search-item" onClick=${function () { onOpen(match); }}>
     <div class="search-item-top">
       <span class=${'badge ' + (match.win ? 'win' : 'lose')}>${match.win ? 'WIN' : 'LOSE'}</span>
@@ -134,9 +145,11 @@ function ResultItem({ match, onOpen }) {
     </div>
     <div class="search-item-ms">
       <span class="search-item-self">${esc(match.ms || '?')}</span>
-      <span class="search-item-partner">+ ${esc(match.partner_ms || '?')}</span>
+      <span class="search-item-partner">+ ${esc(nameWithMs(match.partner_name, match.partner_ms))}</span>
+    </div>
+    <div class="search-item-foes">
       <span class="search-item-vs">vs</span>
-      <span class="search-item-enemy">${esc(enemies || '?')}</span>
+      <span class="search-item-enemy">${esc(enemies)}</span>
     </div>
     <div class="search-item-stats">
       <span>撃墜 <b>${num(match.kills)}</b></span>
@@ -186,7 +199,10 @@ function DetailModal({ match, onClose }) {
     };
   }, []);
 
-  var enemies = [match.opponent1_ms, match.opponent2_ms].filter(Boolean).join(' / ');
+  var enemies = [
+    nameWithMs(match.opponent1_name, match.opponent1_ms),
+    nameWithMs(match.opponent2_name, match.opponent2_ms),
+  ].join(' / ');
   function row(label, mine, partner) {
     return html`<tr><th>${label}</th><td class="num">${mine}</td><td class="num">${partner}</td></tr>`;
   }
@@ -202,8 +218,8 @@ function DetailModal({ match, onClose }) {
       </div>
 
       <div class="search-detail-matchup">
-        <div><span class="search-detail-tag">自軍</span> ${esc(match.ms || '?')} ＋ ${esc(match.partner_ms || '?')}</div>
-        <div><span class="search-detail-tag enemy">敵軍</span> ${esc(enemies || '?')}</div>
+        <div><span class="search-detail-tag">自軍</span> ${esc(match.ms || '?')} ＋ ${esc(nameWithMs(match.partner_name, match.partner_ms))}</div>
+        <div><span class="search-detail-tag enemy">敵軍</span> ${esc(enemies)}</div>
       </div>
 
       <div class="table-wrap"><table class="search-detail-table">

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -238,17 +238,18 @@ export function SearchView({ matches }) {
     return sortMatches(filterMatches(matches, filters), sortKey, desc);
   }, [matches, filters, sortKey, desc]);
 
-  // 条件・並び順が変わったら1ページ目に戻す。
-  useEffect(function () { setPage(1); }, [filters, sortKey, desc]);
-
+  // 条件・並び順の変更時は1ページ目に戻す（各操作ハンドラで明示的にリセット）。
   function onField(key, value) {
     setFilters(function (prev) {
       var next = Object.assign({}, prev);
       next[key] = value;
       return next;
     });
+    setPage(1);
   }
-  function onReset() { setFilters(emptyFilters()); }
+  function onReset() { setFilters(emptyFilters()); setPage(1); }
+  function onSortKey(key) { setSortKey(key); setPage(1); }
+  function onToggleDir() { setDesc(!desc); setPage(1); }
 
   var total = filtered.length;
   var totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -265,10 +266,10 @@ export function SearchView({ matches }) {
         <h2><span class="dot" />検索結果 <span class="search-result-count">${total}件</span></h2>
         <div class="search-sort">
           <select class="search-select" value=${sortKey}
-            onChange=${function (e) { setSortKey(e.target.value); }}>
+            onChange=${function (e) { onSortKey(e.target.value); }}>
             ${SORT_OPTIONS.map(function (o) { return html`<option value=${o.key}>${o.label}</option>`; })}
           </select>
-          <button class="search-dir" onClick=${function () { setDesc(!desc); }}
+          <button class="search-dir" onClick=${onToggleDir}
             aria-label="並び順">${desc ? '降順 ↓' : '昇順 ↑'}</button>
         </div>
       </div>

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -5,7 +5,7 @@ import {
 } from '../analysis/search.js';
 import {
   esc, num, cellDisplay,
-  colorKills, colorDeaths, colorDmgGiven, colorDmgTaken, colorExDmg,
+  colorKillsInt, colorDeathsInt, colorDmgGiven, colorDmgTaken, colorExDmg,
 } from '../lib/format.js';
 import { CompareRadar } from './charts.js';
 import { RangeCalendar, Dropdown, MultiSelect, Autocomplete } from './ui.js';
@@ -411,8 +411,8 @@ function DetailModal({ match, msImages, onClose }) {
   // color は分析画面と同じ色分け関数。スコアは基準が無いため色分けしない。
   var rows = [
     { label: 'スコア', vals: [match.score, match.partner_score, match.opponent1_score, match.opponent2_score], color: null },
-    { label: '撃墜', vals: [match.kills, match.partner_kills, match.opponent1_kills, match.opponent2_kills], color: colorKills },
-    { label: '被撃墜', vals: [match.deaths, match.partner_deaths, match.opponent1_deaths, match.opponent2_deaths], color: colorDeaths },
+    { label: '撃墜', vals: [match.kills, match.partner_kills, match.opponent1_kills, match.opponent2_kills], color: colorKillsInt },
+    { label: '被撃墜', vals: [match.deaths, match.partner_deaths, match.opponent1_deaths, match.opponent2_deaths], color: colorDeathsInt },
     { label: '与ダメージ', vals: [match.dmg_given, match.partner_dmg_given, match.opponent1_dmg_given, match.opponent2_dmg_given], color: colorDmgGiven },
     { label: '被ダメージ', vals: [match.dmg_taken, match.partner_dmg_taken, match.opponent1_dmg_taken, match.opponent2_dmg_taken], color: colorDmgTaken },
     { label: 'EXダメージ', vals: [match.ex_dmg, match.partner_ex_dmg, match.opponent1_ex_dmg, match.opponent2_ex_dmg], color: colorExDmg },

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -7,7 +7,7 @@ import { esc, num } from '../lib/format.js';
 
 var PAGE_SIZE = 20;
 
-// タイムラインのアクション種別 → 表示ラベル。
+// 試合経過のアクション種別 → 表示ラベル。
 var ACTION_LABELS = {
   death: '被撃墜',
   'exbst-f': 'F覚醒',
@@ -160,7 +160,7 @@ function ResultItem({ match, onOpen }) {
   </button>`;
 }
 
-// 詳細モーダル内の統合タイムライン（自分・相方の被撃墜/覚醒を時系列で表示）。
+// 詳細モーダル内の統合「試合経過」（自分・相方の被撃墜/覚醒を時系列で表示）。
 function Timeline({ match }) {
   var events = [];
   function collect(actions, who) {
@@ -174,7 +174,7 @@ function Timeline({ match }) {
   events.sort(function (a, b) { return (a.sec || 0) - (b.sec || 0); });
 
   if (!events.length) {
-    return html`<p class="search-detail-empty">タイムラインデータがありません。</p>`;
+    return html`<p class="search-detail-empty">試合経過データがありません。</p>`;
   }
   return html`<ul class="search-timeline">
     ${events.map(function (ev) {
@@ -235,7 +235,7 @@ function DetailModal({ match, onClose }) {
         </tbody>
       </table></div>
 
-      <h3 class="search-detail-tl-title">タイムライン</h3>
+      <h3 class="search-detail-tl-title">試合経過</h3>
       <${Timeline} match=${match} />
     </div>
   </div>`;

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -125,7 +125,15 @@ function FilterForm({ filters, options, onField, onReset, resultCount }) {
       </div>
 
       <div class="search-field">
-        <label class="search-label">プレイヤー名（相方・相手／部分一致）</label>
+        <div class="search-label search-label-row">
+          <span>プレイヤー名（部分一致）</span>
+          <span class="search-andor">
+            ${[['both', '両方'], ['ally', '相方'], ['enemy', '相手']].map(function (o) {
+              return html`<button type="button" class=${'search-andor-btn' + (filters.playerNameScope === o[0] ? ' active' : '')}
+                onClick=${function () { onField('playerNameScope', o[0]); }}>${o[1]}</button>`;
+            })}
+          </span>
+        </div>
         <${Autocomplete} value=${filters.playerName} placeholder="名前の一部を入力"
           options=${options.playerNames.map(function (o) { return o.name; })}
           onChange=${function (v) { onField('playerName', v); }} />

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -9,7 +9,7 @@ import {
 } from '../lib/format.js';
 import { CompareRadar } from './charts.js';
 import { RangeCalendar, Dropdown, MultiSelect, Autocomplete } from './ui.js';
-import { PERIOD_DAYS, filterByPlayDays } from '../analysis/stats.js';
+import { PERIOD_DAYS, filterByPlayDays, clampMetric } from '../analysis/stats.js';
 
 var PAGE_SIZE = 20;
 
@@ -93,7 +93,7 @@ function FilterForm({ filters, options, onField, onReset, resultCount }) {
       <span class="search-chevron" aria-hidden="true"></span>
     </button>
     ${open && html`<div class="search-form">
-      <div class="search-field">
+      <div class="search-field search-field-wide">
         <label class="search-label">期間</label>
         <${Dropdown} value=${filters.playDays} placeholder="全データ"
           options=${Object.keys(PERIOD_DAYS).map(function (k) { return { value: k, label: PERIOD_DAYS[k] + '日' }; })}
@@ -110,7 +110,7 @@ function FilterForm({ filters, options, onField, onReset, resultCount }) {
         <${MsMulti} values=${filters.partnerMsList} options=${options.partners}
           onChange=${function (vs) { onField('partnerMsList', vs); }} />
       </div>
-      <div class="search-field search-field-wide">
+      <div class="search-field">
         <div class="search-label search-label-row">
           <span>敵機（複数選択可）</span>
           <span class="search-andor">
@@ -335,30 +335,28 @@ function Timeline({ match, msImages }) {
   </div>`;
 }
 
-// 基本データ比較レーダーの軸（基本データ画面と同趣旨。4人全員が持つ6指標）。
-var RADAR_LABELS = ['スコア', '撃墜', '与ダメ', 'EXダメ', '被ダメ', '被撃墜'];
-// 各軸が「高いほど良い」か。被ダメ・被撃墜は低いほど良いので反転する。
-var RADAR_GOOD_HIGH = [true, true, true, true, false, false];
+// 基本データ比較レーダーの軸（基本データ画面と同じ6指標）。スコアは基準が無いため除外。
+// 正規化の重み付け(基準レンジ)は基本データ分析と同じものを stats.js の METRIC_RANGE で共有する。
+var RADAR_AXES = [
+  { label: '与ダメ', key: 'dmgGiven' },
+  { label: '撃墜', key: 'kills' },
+  { label: '覚醒', key: 'bursts' },
+  { label: '被ダメ', key: 'dmgTaken' },
+  { label: '被撃墜', key: 'deaths' },
+  { label: 'EXダメ', key: 'exDmg' },
+];
+var RADAR_LABELS = RADAR_AXES.map(function (a) { return a.label; });
 
-// 4人分のレーダー系列を作る。各軸をその試合の4人中の最大値で0-100に正規化し、
-// 守備系(被ダメ・被撃墜)は反転して「外側=優秀」に統一する。
+// 4人分のレーダー系列を作る。各軸を基本データと同じ基準(clampMetric)で0-100に正規化（絶対評価）。
 function radarPlayers(match) {
   var players = [
-    { label: '自分', color: '#4fc3f7', bg: 'rgba(79,195,247,.25)', raw: [match.score, match.kills, match.dmg_given, match.ex_dmg, match.dmg_taken, match.deaths] },
-    { label: '相方', color: '#69f0ae', bg: 'rgba(105,240,174,.25)', raw: [match.partner_score, match.partner_kills, match.partner_dmg_given, match.partner_ex_dmg, match.partner_dmg_taken, match.partner_deaths] },
-    { label: '相手1', color: '#ef5350', bg: 'rgba(239,83,80,.22)', raw: [match.opponent1_score, match.opponent1_kills, match.opponent1_dmg_given, match.opponent1_ex_dmg, match.opponent1_dmg_taken, match.opponent1_deaths] },
-    { label: '相手2', color: '#ffca28', bg: 'rgba(255,202,40,.22)', raw: [match.opponent2_score, match.opponent2_kills, match.opponent2_dmg_given, match.opponent2_ex_dmg, match.opponent2_dmg_taken, match.opponent2_deaths] },
+    { label: '自分', color: '#4fc3f7', bg: 'rgba(79,195,247,.25)', raw: [match.dmg_given, match.kills, match.bursts, match.dmg_taken, match.deaths, match.ex_dmg] },
+    { label: '相方', color: '#69f0ae', bg: 'rgba(105,240,174,.25)', raw: [match.partner_dmg_given, match.partner_kills, match.partner_bursts, match.partner_dmg_taken, match.partner_deaths, match.partner_ex_dmg] },
+    { label: '相手1', color: '#ef5350', bg: 'rgba(239,83,80,.22)', raw: [match.opponent1_dmg_given, match.opponent1_kills, match.opponent1_bursts, match.opponent1_dmg_taken, match.opponent1_deaths, match.opponent1_ex_dmg] },
+    { label: '相手2', color: '#ffca28', bg: 'rgba(255,202,40,.22)', raw: [match.opponent2_dmg_given, match.opponent2_kills, match.opponent2_bursts, match.opponent2_dmg_taken, match.opponent2_deaths, match.opponent2_ex_dmg] },
   ];
-  var maxes = RADAR_LABELS.map(function (_, a) {
-    return players.reduce(function (mx, p) { return Math.max(mx, Number(p.raw[a]) || 0); }, 0);
-  });
   players.forEach(function (p) {
-    p.data = p.raw.map(function (v, a) {
-      var mx = maxes[a];
-      if (mx <= 0) return RADAR_GOOD_HIGH[a] ? 0 : 100;
-      var frac = (Number(v) || 0) / mx;
-      return Math.round((RADAR_GOOD_HIGH[a] ? frac : (1 - frac)) * 100);
-    });
+    p.data = p.raw.map(function (v, a) { return clampMetric(v, RADAR_AXES[a].key); });
   });
   return players;
 }
@@ -378,12 +376,21 @@ function DetailModal({ match, msImages, onClose }) {
   useEffect(function () {
     function onKey(e) { if (e.key === 'Escape') onClose(); }
     document.addEventListener('keydown', onKey);
+    // モーダル表示中は背景（body/html）のスクロールを止める。
+    var prevBody = document.body.style.overflow;
+    var prevHtml = document.documentElement.style.overflow;
     document.body.style.overflow = 'hidden';
+    document.documentElement.style.overflow = 'hidden';
     return function () {
       document.removeEventListener('keydown', onKey);
-      document.body.style.overflow = '';
+      document.body.style.overflow = prevBody;
+      document.documentElement.style.overflow = prevHtml;
     };
   }, []);
+
+  // 試合経過は既定で畳む（スマホで閉じる×のスペースに余裕を持たせる）。
+  var tlOpenRef = useState(false);
+  var tlOpen = tlOpenRef[0], setTlOpen = tlOpenRef[1];
 
   // レーダー: 4人分の系列とトグルによる表示切替（既定は自分＋相方＝自陣）。
   var players = useMemo(function () { return radarPlayers(match); }, [match]);
@@ -452,8 +459,12 @@ function DetailModal({ match, msImages, onClose }) {
         </tbody>
       </table></div>
 
-      <h3 class="search-detail-tl-title">試合経過</h3>
-      <${Timeline} match=${match} msImages=${msImages} />
+      <button type="button" class=${'search-detail-tl-toggle' + (tlOpen ? ' open' : '')}
+        onClick=${function () { setTlOpen(!tlOpen); }} aria-expanded=${tlOpen}>
+        <span class="search-detail-tl-title">試合経過</span>
+        <span class="search-chevron" aria-hidden="true"></span>
+      </button>
+      ${tlOpen && html`<${Timeline} match=${match} msImages=${msImages} />`}
     </div>
   </div>`;
 }

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -3,18 +3,32 @@ import {
   emptyFilters, hasActiveFilters, collectMsOptions,
   filterMatches, sortMatches, SORT_OPTIONS,
 } from '../analysis/search.js';
-import { esc, num } from '../lib/format.js';
+import {
+  esc, num, cellDisplay,
+  colorKills, colorDeaths, colorDmgGiven, colorDmgTaken, colorExDmg,
+} from '../lib/format.js';
+import { CompareRadar } from './charts.js';
+import { RangeCalendar, Dropdown, MultiSelect } from './ui.js';
+import { PERIOD_DAYS, filterByPlayDays } from '../analysis/stats.js';
 
 var PAGE_SIZE = 20;
 
-// 試合経過のアクション種別 → 表示ラベル。
-var ACTION_LABELS = {
-  death: '被撃墜',
-  'exbst-f': 'F覚醒',
-  'exbst-s': 'S覚醒',
-  'exbst-e': 'E覚醒',
-  'exbst-ov': 'OV覚醒',
+// 試合経過ガントのマッピング。lane 0=バースト行、lane 1=オーバーリミット行。
+// kind: 'bar'=可能域の帯（範囲）/ 'diamond'=発動タイミングの菱形（点）。
+var GANTT_BAR = {
+  'ex': { lane: 0, cls: 'ex', kind: 'bar' },            // EXバースト発動可能域（グレー帯）
+  'exbst-f': { lane: 0, cls: 'f', kind: 'diamond' },    // ファイティングバースト発動（橙）
+  'exbst-s': { lane: 0, cls: 's', kind: 'diamond' },    // シューティングバースト発動（青）
+  'exbst-e': { lane: 0, cls: 'e', kind: 'diamond' },    // エクステンドバースト発動（緑）
+  'ov': { lane: 1, cls: 'ov', kind: 'bar' },            // EXオーバーリミット発動可能域（白枠帯）
+  'exbst-ov': { lane: 1, cls: 'ov-on', kind: 'diamond' }, // EXオーバーリミット発動（白）
 };
+
+// ガント凡例の項目。
+var GANTT_LEGEND = [
+  ['ex', '覚醒可'], ['f', 'F覚醒'], ['s', 'S覚醒'], ['e', 'E覚醒'], ['death', '被撃墜'],
+  ['ov', 'OLスタンバイ'], ['ov-on', 'OL発動'],
+];
 
 // 秒数を M:SS 形式に整形する。
 function fmtSec(sec) {
@@ -24,15 +38,11 @@ function fmtSec(sec) {
   return m + ':' + String(s % 60).padStart(2, '0');
 }
 
-// ネイティブ <select>。value/onChange と選択肢配列を受け取る。
-function Select({ value, onChange, options, placeholder }) {
-  return html`<select class="search-select" value=${value}
-    onChange=${function (e) { onChange(e.target.value); }}>
-    <option value="">${placeholder}</option>
-    ${options.map(function (o) {
-      return html`<option value=${o.name}>${o.name}（${o.matches}戦）</option>`;
-    })}
-  </select>`;
+// 機体/タッグ/コスト編成用の複数選択（OR）。集計結果 [{name, matches}] を渡す。
+// 選択後のトリガーは名前のみ（chip）、ドロップダウン内は「名前（N戦）」を出す。
+function MsMulti({ values, onChange, options }) {
+  var opts = options.map(function (o) { return { value: o.name, label: o.name + '（' + o.matches + '戦）', chip: o.name }; });
+  return html`<${MultiSelect} values=${values} options=${opts} onChange=${onChange} placeholder="-" />`;
 }
 
 // 数値レンジ入力（最小〜最大）。
@@ -40,58 +50,82 @@ function RangeInput({ label, minVal, maxVal, onMin, onMax }) {
   return html`<div class="search-field">
     <label class="search-label">${label}</label>
     <div class="search-range">
-      <input type="number" class="search-num" inputmode="numeric" placeholder="最小"
+      <input type="number" class="search-num" inputmode="numeric" aria-label=${label + ' 最小'}
         value=${minVal} onInput=${function (e) { onMin(e.target.value); }} />
       <span class="search-range-sep">〜</span>
-      <input type="number" class="search-num" inputmode="numeric" placeholder="最大"
+      <input type="number" class="search-num" inputmode="numeric" aria-label=${label + ' 最大'}
         value=${maxVal} onInput=${function (e) { onMax(e.target.value); }} />
     </div>
   </div>`;
 }
 
 // フィルタフォーム。filters と個々のフィールド更新関数、リセットを受け取る。
+// 詳細設定（カスタム期間・マニアックな数値レンジ）に含めるフィルタ項目。
+var ADV_FIELDS = ['dateFrom', 'dateTo', 'enemyTagName',
+  'dmgGivenMin', 'dmgGivenMax', 'dmgTakenMin', 'dmgTakenMax', 'killsMin', 'killsMax', 'deathsMin', 'deathsMax',
+  'scoreMin', 'scoreMax', 'exDmgMin', 'exDmgMax', 'burstsMin', 'burstsMax'];
+// 詳細設定内の複数選択（配列）フィルタ。
+var ADV_LIST_FIELDS = ['myTagList', 'myCostList', 'partnerCostList', 'enemyCostPairList'];
+
+// 自機コストの選択肢（固定4種）。
+var COST_OPTIONS = [
+  { value: '3000', label: '3000' }, { value: '2500', label: '2500' },
+  { value: '2000', label: '2000' }, { value: '1500', label: '1500' },
+];
+
 function FilterForm({ filters, options, onField, onReset, resultCount }) {
-  var openRef = useState(true);
+  var openRef = useState(false);
   var open = openRef[0], setOpen = openRef[1];
   var active = hasActiveFilters(filters);
+  // 詳細設定に条件が入っていれば初期表示は開く。
+  var advActive = ADV_FIELDS.some(function (k) { return filters[k] !== '' && filters[k] != null; })
+    || ADV_LIST_FIELDS.some(function (k) { return filters[k] && filters[k].length; });
+  var advOpenRef = useState(advActive);
+  var advOpen = advOpenRef[0], setAdvOpen = advOpenRef[1];
+  // 期間カレンダーはクリックで開くプルダウン形式にする。
+  var dateOpenRef = useState(false);
+  var dateOpen = dateOpenRef[0], setDateOpen = dateOpenRef[1];
 
   return html`<div class="panel search-filter-panel">
-    <div class="search-filter-head">
-      <h2><span class="dot" />絞り込み条件</h2>
-      <button class="search-toggle" onClick=${function () { setOpen(!open); }}>
-        ${open ? '閉じる ▲' : '開く ▼'}
-      </button>
-    </div>
+    <button class=${'search-filter-head' + (open ? ' open' : '')}
+      onClick=${function () { setOpen(!open); }} aria-expanded=${open}>
+      <span class="search-filter-title"><span class="dot" />絞り込み条件${!open && active && html`<span class="search-filter-badge">適用中</span>`}</span>
+      <span class="search-chevron" aria-hidden="true"></span>
+    </button>
     ${open && html`<div class="search-form">
       <div class="search-field">
         <label class="search-label">期間</label>
-        <div class="search-range">
-          <input type="date" class="search-date" value=${filters.dateFrom}
-            onInput=${function (e) { onField('dateFrom', e.target.value); }} />
-          <span class="search-range-sep">〜</span>
-          <input type="date" class="search-date" value=${filters.dateTo}
-            onInput=${function (e) { onField('dateTo', e.target.value); }} />
+        <${Dropdown} value=${filters.playDays} placeholder="全データ"
+          options=${Object.keys(PERIOD_DAYS).map(function (k) { return { value: k, label: PERIOD_DAYS[k] + '日' }; })}
+          onChange=${function (v) { onField('playDays', v); }} />
+      </div>
+
+      <div class="search-field">
+        <label class="search-label">自機（複数選択可）</label>
+        <${MsMulti} values=${filters.myMsList} options=${options.mine}
+          onChange=${function (vs) { onField('myMsList', vs); }} />
+      </div>
+      <div class="search-field">
+        <label class="search-label">僚機（複数選択可）</label>
+        <${MsMulti} values=${filters.partnerMsList} options=${options.partners}
+          onChange=${function (vs) { onField('partnerMsList', vs); }} />
+      </div>
+      <div class="search-field search-field-wide">
+        <div class="search-label search-label-row">
+          <span>敵機（複数選択可）</span>
+          <span class="search-andor">
+            ${['and', 'or'].map(function (mode) {
+              return html`<button type="button" class=${'search-andor-btn' + (filters.enemyMsMode === mode ? ' active' : '')}
+                onClick=${function () { onField('enemyMsMode', mode); }}>${mode.toUpperCase()}</button>`;
+            })}
+          </span>
         </div>
+        <${MsMulti} values=${filters.enemyMsList} options=${options.enemies}
+          onChange=${function (vs) { onField('enemyMsList', vs); }} />
       </div>
 
       <div class="search-field">
-        <label class="search-label">使用機体</label>
-        <${Select} value=${filters.myMs} placeholder="すべての自機"
-          options=${options.mine} onChange=${function (v) { onField('myMs', v); }} />
-      </div>
-      <div class="search-field">
-        <label class="search-label">相方機体</label>
-        <${Select} value=${filters.partnerMs} placeholder="すべての相方"
-          options=${options.partners} onChange=${function (v) { onField('partnerMs', v); }} />
-      </div>
-      <div class="search-field">
-        <label class="search-label">敵機体</label>
-        <${Select} value=${filters.enemyMs} placeholder="すべての敵機"
-          options=${options.enemies} onChange=${function (v) { onField('enemyMs', v); }} />
-      </div>
-
-      <div class="search-field">
-        <label class="search-label">プレイヤー名（相方・敵／部分一致）</label>
+        <label class="search-label">プレイヤー名（相方・相手／部分一致）</label>
         <input type="text" class="search-text" placeholder="名前の一部を入力"
           value=${filters.playerName} onInput=${function (e) { onField('playerName', e.target.value); }} />
       </div>
@@ -106,14 +140,67 @@ function FilterForm({ filters, options, onField, onReset, resultCount }) {
         </div>
       </div>
 
-      <${RangeInput} label="与ダメージ" minVal=${filters.dmgGivenMin} maxVal=${filters.dmgGivenMax}
-        onMin=${function (v) { onField('dmgGivenMin', v); }} onMax=${function (v) { onField('dmgGivenMax', v); }} />
-      <${RangeInput} label="被ダメージ" minVal=${filters.dmgTakenMin} maxVal=${filters.dmgTakenMax}
-        onMin=${function (v) { onField('dmgTakenMin', v); }} onMax=${function (v) { onField('dmgTakenMax', v); }} />
-      <${RangeInput} label="撃墜数" minVal=${filters.killsMin} maxVal=${filters.killsMax}
-        onMin=${function (v) { onField('killsMin', v); }} onMax=${function (v) { onField('killsMax', v); }} />
-      <${RangeInput} label="被撃墜数" minVal=${filters.deathsMin} maxVal=${filters.deathsMax}
-        onMin=${function (v) { onField('deathsMin', v); }} onMax=${function (v) { onField('deathsMax', v); }} />
+      <div class="search-adv">
+        <button type="button" class=${'search-adv-toggle' + (advOpen ? ' open' : '')}
+          onClick=${function () { setAdvOpen(!advOpen); }} aria-expanded=${advOpen}>
+          <span>詳細設定${!advOpen && advActive && html`<span class="search-filter-badge">適用中</span>`}</span>
+          <span class="search-chevron" aria-hidden="true"></span>
+        </button>
+        ${advOpen && html`<div class="search-adv-grid">
+          <div class="search-field search-field-wide">
+            <label class="search-label">期間（カスタム指定）</label>
+            <button type="button" class=${'panel-select-trigger search-date-trigger' + (dateOpen ? ' open' : '')}
+              onClick=${function () { setDateOpen(!dateOpen); }} aria-expanded=${dateOpen}>
+              <span class="panel-select-label">${filters.dateFrom
+                ? esc(filters.dateFrom + ' 〜 ' + (filters.dateTo || '…'))
+                : '-'}</span>
+              <span class="period-arrow">${dateOpen ? '▲' : '▼'}</span>
+            </button>
+            ${dateOpen && html`<${RangeCalendar} startDate=${filters.dateFrom} endDate=${filters.dateTo}
+              onSelectStart=${function (v) { onField('dateFrom', v); }}
+              onSelectEnd=${function (v) { onField('dateTo', v); if (v) setDateOpen(false); }} />`}
+          </div>
+          <div class="search-field search-field-wide">
+            <label class="search-label">味方タッグ名（複数選択可）</label>
+            <${MsMulti} values=${filters.myTagList} options=${options.myTags}
+              onChange=${function (vs) { onField('myTagList', vs); }} />
+          </div>
+          <div class="search-field search-field-wide">
+            <label class="search-label">相手タッグ名（部分一致）</label>
+            <input type="text" class="search-text" placeholder="タッグ名の一部を入力"
+              value=${filters.enemyTagName} onInput=${function (e) { onField('enemyTagName', e.target.value); }} />
+          </div>
+          <div class="search-field">
+            <label class="search-label">自機コスト（複数選択可）</label>
+            <${MultiSelect} values=${filters.myCostList} placeholder="-" options=${COST_OPTIONS}
+              onChange=${function (vs) { onField('myCostList', vs); }} />
+          </div>
+          <div class="search-field">
+            <label class="search-label">僚機コスト（複数選択可）</label>
+            <${MultiSelect} values=${filters.partnerCostList} placeholder="-" options=${COST_OPTIONS}
+              onChange=${function (vs) { onField('partnerCostList', vs); }} />
+          </div>
+          <div class="search-field search-field-wide">
+            <label class="search-label">相手コスト編成（複数選択可）</label>
+            <${MsMulti} values=${filters.enemyCostPairList} options=${options.enemyCostPairs}
+              onChange=${function (vs) { onField('enemyCostPairList', vs); }} />
+          </div>
+          <${RangeInput} label="与ダメージ" minVal=${filters.dmgGivenMin} maxVal=${filters.dmgGivenMax}
+            onMin=${function (v) { onField('dmgGivenMin', v); }} onMax=${function (v) { onField('dmgGivenMax', v); }} />
+          <${RangeInput} label="被ダメージ" minVal=${filters.dmgTakenMin} maxVal=${filters.dmgTakenMax}
+            onMin=${function (v) { onField('dmgTakenMin', v); }} onMax=${function (v) { onField('dmgTakenMax', v); }} />
+          <${RangeInput} label="撃墜数" minVal=${filters.killsMin} maxVal=${filters.killsMax}
+            onMin=${function (v) { onField('killsMin', v); }} onMax=${function (v) { onField('killsMax', v); }} />
+          <${RangeInput} label="被撃墜数" minVal=${filters.deathsMin} maxVal=${filters.deathsMax}
+            onMin=${function (v) { onField('deathsMin', v); }} onMax=${function (v) { onField('deathsMax', v); }} />
+          <${RangeInput} label="スコア" minVal=${filters.scoreMin} maxVal=${filters.scoreMax}
+            onMin=${function (v) { onField('scoreMin', v); }} onMax=${function (v) { onField('scoreMax', v); }} />
+          <${RangeInput} label="EXダメージ" minVal=${filters.exDmgMin} maxVal=${filters.exDmgMax}
+            onMin=${function (v) { onField('exDmgMin', v); }} onMax=${function (v) { onField('exDmgMax', v); }} />
+          <${RangeInput} label="覚醒回数" minVal=${filters.burstsMin} maxVal=${filters.burstsMax}
+            onMin=${function (v) { onField('burstsMin', v); }} onMax=${function (v) { onField('burstsMax', v); }} />
+        </div>`}
+      </div>
 
       <div class="search-form-actions">
         <span class="search-count">${resultCount}件ヒット</span>
@@ -123,72 +210,169 @@ function FilterForm({ filters, options, onField, onReset, resultCount }) {
   </div>`;
 }
 
-// 名前と機体を「名前（機体）」形式に整形する。名前が無ければ機体のみ。
-function nameWithMs(name, ms) {
-  var n = (name || '').trim();
-  var m = (ms || '').trim();
-  if (n && m) return n + '（' + m + '）';
-  return n || m || '?';
+// 並べ替え中の指標を一覧カードにも小さく出すためのラベル。SORT_OPTIONSと二重管理しないよう流用する。
+var METRIC_LABELS = SORT_OPTIONS.reduce(function (m, o) { m[o.key] = o.label; return m; }, {});
+
+// 機体サムネイル。画像URLが引ければ画像、無ければ機体名テキストにフォールバック。
+function MsThumb({ name, msImages }) {
+  var nm = (name || '').trim();
+  var url = nm && msImages ? msImages[nm] : '';
+  if (url) {
+    return html`<img class="search-ms-thumb" src=${url} alt=${nm} title=${nm} loading="lazy" />`;
+  }
+  return html`<span class="search-ms-thumb search-ms-thumb-text" title=${nm}>${esc(nm || '?')}</span>`;
 }
 
-// 1試合分のサマリー行。クリックで詳細を開く。
-function ResultItem({ match, onOpen }) {
-  var enemies = [
-    nameWithMs(match.opponent1_name, match.opponent1_ms),
-    nameWithMs(match.opponent2_name, match.opponent2_ms),
-  ].join(' / ');
+// プレイヤー名を整形（空は「—」）。名前は最大12文字。
+function playerName(n) {
+  return (n || '').trim() || '—';
+}
+
+// 1試合分のサマリーカード（公式戦績風）。機体は画像で並べ、詳細な数値は詳細モーダルへ寄せる。
+// クリックで詳細を開く。
+function ResultItem({ match, msImages, sortKey, onOpen }) {
+  var metricLabel = sortKey && sortKey !== 'date' ? METRIC_LABELS[sortKey] : null;
   return html`<button class="search-item" onClick=${function () { onOpen(match); }}>
     <div class="search-item-top">
       <span class=${'badge ' + (match.win ? 'win' : 'lose')}>${match.win ? 'WIN' : 'LOSE'}</span>
       <span class="search-item-date">${esc(match.date)}</span>
-      <span class="search-item-score">${num(match.score)}pt</span>
+      ${metricLabel && html`<span class="search-item-metric">${metricLabel} ${num(match[sortKey])}</span>`}
     </div>
-    <div class="search-item-ms">
-      <span class="search-item-self">${esc(match.ms || '?')}</span>
-      <span class="search-item-partner">+ ${esc(nameWithMs(match.partner_name, match.partner_ms))}</span>
+    <div class="search-item-battle">
+      <div class="search-ms-imgs self">
+        <${MsThumb} name=${match.ms} msImages=${msImages} />
+        <${MsThumb} name=${match.partner_ms} msImages=${msImages} />
+      </div>
+      <span class="search-item-vs" role="img" aria-label="VS"></span>
+      <div class="search-ms-imgs enemy">
+        <${MsThumb} name=${match.opponent1_ms} msImages=${msImages} />
+        <${MsThumb} name=${match.opponent2_ms} msImages=${msImages} />
+      </div>
     </div>
-    <div class="search-item-foes">
-      <span class="search-item-vs">vs</span>
-      <span class="search-item-enemy">${esc(enemies)}</span>
-    </div>
-    <div class="search-item-stats">
-      <span>撃墜 <b>${num(match.kills)}</b></span>
-      <span>被撃墜 <b>${num(match.deaths)}</b></span>
-      <span>与 <b>${num(match.dmg_given)}</b></span>
-      <span>被 <b>${num(match.dmg_taken)}</b></span>
+    <div class="search-item-namesrow">
+      <div class="search-item-names">
+        <div class="search-name-line self" title=${playerName(match.name)}>${esc(playerName(match.name))}</div>
+        <div class="search-name-line" title=${playerName(match.partner_name)}>${esc(playerName(match.partner_name))}</div>
+      </div>
+      <div class="search-item-names enemy">
+        <div class="search-name-line" title=${playerName(match.opponent1_name)}>${esc(playerName(match.opponent1_name))}</div>
+        <div class="search-name-line" title=${playerName(match.opponent2_name)}>${esc(playerName(match.opponent2_name))}</div>
+      </div>
     </div>
   </button>`;
 }
 
-// 詳細モーダル内の統合「試合経過」（自分・相方の被撃墜/覚醒を時系列で表示）。
-function Timeline({ match }) {
-  var events = [];
-  function collect(actions, who) {
-    (actions || []).forEach(function (a) {
-      if (!ACTION_LABELS[a.action]) return;
-      events.push({ who: who, label: ACTION_LABELS[a.action], sec: a.action_start_sec, isDeath: a.action === 'death' });
+// 公式「試合経過」風のガント式タイムライン（4人分・横棒）。
+// 各行に機体画像＋2レーン（バースト行/オーバーリミット行）＋被撃墜×、下に時間軸。
+function Timeline({ match, msImages }) {
+  var rows = [
+    { ms: match.ms, actions: match.actions },
+    { ms: match.partner_ms, actions: match.partner_actions },
+    { ms: match.opponent1_ms, actions: match.opponent1_actions },
+    { ms: match.opponent2_ms, actions: match.opponent2_actions },
+  ];
+  // 実時間 = GameEndSec（無ければ全アクションの最大終了秒）。
+  var raw = match.game_end_sec || 0;
+  rows.forEach(function (r) {
+    (r.actions || []).forEach(function (a) {
+      raw = Math.max(raw, a.action_end_sec || 0, a.action_start_sec || 0);
     });
-  }
-  collect(match.actions, '自分');
-  collect(match.partner_actions, '相方');
-  events.sort(function (a, b) { return (a.sec || 0) - (b.sec || 0); });
-
-  if (!events.length) {
+  });
+  if (raw <= 0) {
     return html`<p class="search-detail-empty">試合経過データがありません。</p>`;
   }
-  return html`<ul class="search-timeline">
-    ${events.map(function (ev) {
-      return html`<li class=${'search-tl-item' + (ev.isDeath ? ' death' : ' burst')}>
-        <span class="search-tl-time">${fmtSec(ev.sec)}</span>
-        <span class="search-tl-who">${ev.who}</span>
-        <span class="search-tl-label">${ev.label}</span>
-      </li>`;
+  // 終盤が詰まって見えるため末尾に余白（7%）を足して描画スケールを広げる。目盛りは実終了まで。
+  var total = raw * 1.07;
+  function pct(sec) { return Math.max(0, Math.min(100, (sec || 0) / total * 100)); }
+  function bar(a) {
+    var m = GANTT_BAR[a.action];
+    var left = pct(a.action_start_sec);
+    var w = Math.max(0.6, pct(a.action_end_sec) - left); // 極小でも視認できる最小幅
+    var barEl = html`<span class=${'gantt-bar gantt-' + m.cls} style=${'left:' + left + '%;width:' + w + '%'}></span>`;
+    // 発動系は「発動の瞬間＝菱形」＋「その後の発動中＝色付きバー」の両方を描く。
+    if (m.kind === 'diamond') {
+      return html`${barEl}<span class=${'gantt-diamond gantt-' + m.cls} style=${'left:' + left + '%'}></span>`;
+    }
+    return barEl;
+  }
+  // 10秒刻みの目盛り（実終了時刻まで。余白部分には目盛りを出さない）。
+  var ticks = [];
+  for (var t = 0; t <= raw; t += 10) ticks.push(t);
+
+  return html`<div class="gantt">
+    ${rows.map(function (r) {
+      var acts = r.actions || [];
+      var lane0 = acts.filter(function (a) { return GANTT_BAR[a.action] && GANTT_BAR[a.action].lane === 0; });
+      var lane1 = acts.filter(function (a) { return GANTT_BAR[a.action] && GANTT_BAR[a.action].lane === 1; });
+      var deaths = acts.filter(function (a) { return a.action === 'death'; });
+      return html`<div class="gantt-row">
+        <${DetailThumb} name=${r.ms} msImages=${msImages} />
+        <div class="gantt-track">
+          <div class="gantt-lane">
+            ${lane0.map(bar)}
+            ${deaths.map(function (a) {
+              return html`<span class="gantt-death" style=${'left:' + pct(a.action_start_sec) + '%'}>✕</span>`;
+            })}
+          </div>
+          <div class="gantt-lane">${lane1.map(bar)}</div>
+        </div>
+      </div>`;
     })}
-  </ul>`;
+    <div class="gantt-axis">
+      ${ticks.map(function (t) {
+        return html`<span class="gantt-tick" style=${'left:' + pct(t) + '%'}>${fmtSec(t)}</span>`;
+      })}
+    </div>
+    <div class="gantt-legend">
+      ${GANTT_LEGEND.map(function (l) {
+        // OL系の手前で改行し、2行目に「OLスタンバイ / OL発動 / 被撃墜」を並べる。
+        var brk = l[0] === 'ov' ? html`<span class="gantt-legend-break"></span>` : '';
+        return html`${brk}<span class="gantt-legend-item"><span class=${'gantt-legend-swatch gantt-' + l[0]}></span>${l[1]}</span>`;
+      })}
+    </div>
+  </div>`;
+}
+
+// 基本データ比較レーダーの軸（基本データ画面と同趣旨。4人全員が持つ6指標）。
+var RADAR_LABELS = ['スコア', '撃墜', '与ダメ', 'EXダメ', '被ダメ', '被撃墜'];
+// 各軸が「高いほど良い」か。被ダメ・被撃墜は低いほど良いので反転する。
+var RADAR_GOOD_HIGH = [true, true, true, true, false, false];
+
+// 4人分のレーダー系列を作る。各軸をその試合の4人中の最大値で0-100に正規化し、
+// 守備系(被ダメ・被撃墜)は反転して「外側=優秀」に統一する。
+function radarPlayers(match) {
+  var players = [
+    { label: '自分', color: '#4fc3f7', bg: 'rgba(79,195,247,.25)', raw: [match.score, match.kills, match.dmg_given, match.ex_dmg, match.dmg_taken, match.deaths] },
+    { label: '相方', color: '#69f0ae', bg: 'rgba(105,240,174,.25)', raw: [match.partner_score, match.partner_kills, match.partner_dmg_given, match.partner_ex_dmg, match.partner_dmg_taken, match.partner_deaths] },
+    { label: '相手1', color: '#ef5350', bg: 'rgba(239,83,80,.22)', raw: [match.opponent1_score, match.opponent1_kills, match.opponent1_dmg_given, match.opponent1_ex_dmg, match.opponent1_dmg_taken, match.opponent1_deaths] },
+    { label: '相手2', color: '#ffca28', bg: 'rgba(255,202,40,.22)', raw: [match.opponent2_score, match.opponent2_kills, match.opponent2_dmg_given, match.opponent2_ex_dmg, match.opponent2_dmg_taken, match.opponent2_deaths] },
+  ];
+  var maxes = RADAR_LABELS.map(function (_, a) {
+    return players.reduce(function (mx, p) { return Math.max(mx, Number(p.raw[a]) || 0); }, 0);
+  });
+  players.forEach(function (p) {
+    p.data = p.raw.map(function (v, a) {
+      var mx = maxes[a];
+      if (mx <= 0) return RADAR_GOOD_HIGH[a] ? 0 : 100;
+      var frac = (Number(v) || 0) / mx;
+      return Math.round((RADAR_GOOD_HIGH[a] ? frac : (1 - frac)) * 100);
+    });
+  });
+  return players;
+}
+
+// 詳細モーダルの列見出し用の機体サムネイル（固定サイズ）。画像が無ければ機体名テキスト。
+function DetailThumb({ name, msImages }) {
+  var nm = (name || '').trim();
+  var url = nm && msImages ? msImages[nm] : '';
+  if (url) {
+    return html`<img class="search-detail-thumb" src=${url} alt=${nm} title=${nm} loading="lazy" />`;
+  }
+  return html`<span class="search-detail-thumb search-detail-thumb-text" title=${nm}>${esc(nm || '?')}</span>`;
 }
 
 // 試合詳細モーダル。
-function DetailModal({ match, onClose }) {
+function DetailModal({ match, msImages, onClose }) {
   useEffect(function () {
     function onKey(e) { if (e.key === 'Escape') onClose(); }
     document.addEventListener('keydown', onKey);
@@ -199,21 +383,30 @@ function DetailModal({ match, onClose }) {
     };
   }, []);
 
-  // 4人分のスコア列（自分・相方・敵1・敵2）。プレイヤー名は出さず、役割＋機体で識別する。
-  var cols = [
-    { role: '自分', ms: match.ms, enemy: false },
-    { role: '相方', ms: match.partner_ms, enemy: false },
-    { role: '敵1', ms: match.opponent1_ms, enemy: true },
-    { role: '敵2', ms: match.opponent2_ms, enemy: true },
-  ];
+  // レーダー: 4人分の系列とトグルによる表示切替（既定は自分＋相方＝自陣）。
+  var players = useMemo(function () { return radarPlayers(match); }, [match]);
+  var checkedRef = useState([true, true, false, false]);
+  var checked = checkedRef[0], setChecked = checkedRef[1];
+  var series = useMemo(function () {
+    return players.map(function (p, i) {
+      return { label: p.label, data: p.data, color: p.color, bg: p.bg, hidden: !checked[i] };
+    });
+  }, [players, checked]);
+  function toggle(i) {
+    setChecked(function (prev) { var next = prev.slice(); next[i] = !next[i]; return next; });
+  }
+
+  // 4人分の機体（自分・相方・敵1・敵2）。列見出しの画像に使う。自陣/敵陣は列位置(index 2)の区切り線で示す。
+  var cols = [match.ms, match.partner_ms, match.opponent1_ms, match.opponent2_ms];
   // 公式「スコア」画面と同じ項目（覚醒回数は試合経過側で表示するため含めない）。
+  // color は分析画面と同じ色分け関数。スコアは基準が無いため色分けしない。
   var rows = [
-    ['スコア', [match.score, match.partner_score, match.opponent1_score, match.opponent2_score]],
-    ['撃墜', [match.kills, match.partner_kills, match.opponent1_kills, match.opponent2_kills]],
-    ['被撃墜', [match.deaths, match.partner_deaths, match.opponent1_deaths, match.opponent2_deaths]],
-    ['与ダメージ', [match.dmg_given, match.partner_dmg_given, match.opponent1_dmg_given, match.opponent2_dmg_given]],
-    ['被ダメージ', [match.dmg_taken, match.partner_dmg_taken, match.opponent1_dmg_taken, match.opponent2_dmg_taken]],
-    ['EXダメージ', [match.ex_dmg, match.partner_ex_dmg, match.opponent1_ex_dmg, match.opponent2_ex_dmg]],
+    { label: 'スコア', vals: [match.score, match.partner_score, match.opponent1_score, match.opponent2_score], color: null },
+    { label: '撃墜', vals: [match.kills, match.partner_kills, match.opponent1_kills, match.opponent2_kills], color: colorKills },
+    { label: '被撃墜', vals: [match.deaths, match.partner_deaths, match.opponent1_deaths, match.opponent2_deaths], color: colorDeaths },
+    { label: '与ダメージ', vals: [match.dmg_given, match.partner_dmg_given, match.opponent1_dmg_given, match.opponent2_dmg_given], color: colorDmgGiven },
+    { label: '被ダメージ', vals: [match.dmg_taken, match.partner_dmg_taken, match.opponent1_dmg_taken, match.opponent2_dmg_taken], color: colorDmgTaken },
+    { label: 'EXダメージ', vals: [match.ex_dmg, match.partner_ex_dmg, match.opponent1_ex_dmg, match.opponent2_ex_dmg], color: colorExDmg },
   ];
 
   return html`<div class="modal-backdrop" onClick=${function (e) { if (e.target === e.currentTarget) onClose(); }}>
@@ -226,33 +419,82 @@ function DetailModal({ match, onClose }) {
         <button class="search-detail-close" onClick=${onClose} aria-label="閉じる">✕</button>
       </div>
 
+      <div class="search-radar-toggles">
+        ${players.map(function (p, i) {
+          return html`<button type="button" class=${'search-radar-toggle' + (checked[i] ? '' : ' off')}
+            onClick=${function () { toggle(i); }} aria-pressed=${checked[i]}>
+            <span class="search-radar-swatch" style=${'background:' + p.color}></span>
+            <${DetailThumb} name=${cols[i]} msImages=${msImages} />
+          </button>`;
+        })}
+      </div>
+      <${CompareRadar} labels=${RADAR_LABELS} series=${series} showLegend=${false} />
+
       <div class="table-wrap"><table class="search-detail-table">
         <thead><tr>
           <th></th>
-          ${cols.map(function (c) {
-            return html`<th class=${'num search-detail-col' + (c.enemy ? ' enemy' : '')}>
-              <span class="search-detail-col-role">${c.role}</span>
-              <span class="search-detail-col-ms">${esc(c.ms || '?')}</span>
+          ${cols.map(function (ms, i) {
+            return html`<th class=${'num search-detail-col' + (i === 2 ? ' team-sep' : '')}>
+              <${DetailThumb} name=${ms} msImages=${msImages} />
             </th>`;
           })}
         </tr></thead>
         <tbody>
           ${rows.map(function (r) {
-            return html`<tr><th>${r[0]}</th>${r[1].map(function (v, i) {
-              return html`<td class=${'num' + (cols[i].enemy ? ' enemy' : '')}>${num(v)}</td>`;
+            return html`<tr><th>${r.label}</th>${r.vals.map(function (v, i) {
+              // 分析画面と同じ色分け関数を通す（cellDisplayが色付きspanを返す）。基準の無いスコアはそのまま。
+              var content = r.color ? cellDisplay(r.color(v)) : num(v);
+              return html`<td class=${'num' + (i === 2 ? ' team-sep' : '')}>${content}</td>`;
             })}</tr>`;
           })}
         </tbody>
       </table></div>
 
       <h3 class="search-detail-tl-title">試合経過</h3>
-      <${Timeline} match=${match} />
+      <${Timeline} match=${match} msImages=${msImages} />
     </div>
   </div>`;
 }
 
+// 並べ替えコントロール。ソートアイコン付きのカスタムドロップダウン（項目選択）＋昇順/降順アイコン。
+// native selectの浮いた見た目を避け、外側クリックで閉じる。
+function SortControl({ sortKey, desc, onSortKey, onToggleDir }) {
+  var openRef = useState(false);
+  var open = openRef[0], setOpen = openRef[1];
+  var ref = useRef(null);
+  useEffect(function () {
+    if (!open) return;
+    function onDoc(e) { if (ref.current && !ref.current.contains(e.target)) setOpen(false); }
+    document.addEventListener('mousedown', onDoc);
+    return function () { document.removeEventListener('mousedown', onDoc); };
+  }, [open]);
+  var current = SORT_OPTIONS.find(function (o) { return o.key === sortKey; }) || SORT_OPTIONS[0];
+
+  return html`<div class="search-sort" ref=${ref}>
+    <div class="search-sort-dd">
+      <button type="button" class=${'search-sort-trigger' + (open ? ' open' : '')}
+        onClick=${function () { setOpen(!open); }} aria-expanded=${open}
+        aria-label=${'並べ替え: ' + current.label} title=${'並べ替え: ' + current.label}>
+        <svg class="search-sort-ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18v2H3V6zm0 5h12v2H3v-2zm0 5h6v2H3v-2z"/></svg>
+      </button>
+      ${open && html`<div class="search-sort-menu">
+        ${SORT_OPTIONS.map(function (o) {
+          return html`<button type="button" class=${'search-sort-opt' + (o.key === sortKey ? ' active' : '')}
+            onClick=${function () { onSortKey(o.key); setOpen(false); }}>${o.label}</button>`;
+        })}
+      </div>`}
+    </div>
+    <button type="button" class="search-dir" onClick=${onToggleDir}
+      aria-label=${desc ? '降順（クリックで昇順）' : '昇順（クリックで降順）'} title=${desc ? '降順' : '昇順'}>
+      <svg class="search-dir-ico" viewBox="0 0 24 24" aria-hidden="true">
+        <path d=${desc ? 'M12 16l-6-6h12z' : 'M12 8l6 6H6z'} />
+      </svg>
+    </button>
+  </div>`;
+}
+
 // 試合検索ビュー本体。matches はIndexedDBから読み込んだ全試合。
-export function SearchView({ matches }) {
+export function SearchView({ matches, msImages }) {
   var filtersRef = useState(emptyFilters);
   var filters = filtersRef[0], setFilters = filtersRef[1];
   var sortRef = useState('date');
@@ -261,13 +503,19 @@ export function SearchView({ matches }) {
   var desc = descRef[0], setDesc = descRef[1];
   var pageRef = useState(1);
   var page = pageRef[0], setPage = pageRef[1];
+  var pageSizeRef = useState(PAGE_SIZE);
+  var pageSize = pageSizeRef[0], setPageSize = pageSizeRef[1];
   var detailRef = useState(null);
   var detail = detailRef[0], setDetail = detailRef[1];
 
   var options = useMemo(function () { return collectMsOptions(matches); }, [matches]);
 
   var filtered = useMemo(function () {
-    return sortMatches(filterMatches(matches, filters), sortKey, desc);
+    // 期間プリセット（直近Nプレイ日）はレポートと同じ filterByPlayDays で先に絞る。
+    var base = filters.playDays && PERIOD_DAYS[filters.playDays]
+      ? filterByPlayDays(matches, PERIOD_DAYS[filters.playDays])
+      : matches;
+    return sortMatches(filterMatches(base, filters), sortKey, desc);
   }, [matches, filters, sortKey, desc]);
 
   // 条件・並び順の変更時は1ページ目に戻す（各操作ハンドラで明示的にリセット）。
@@ -284,10 +532,13 @@ export function SearchView({ matches }) {
   function onToggleDir() { setDesc(!desc); setPage(1); }
 
   var total = filtered.length;
-  var totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  var wins = filtered.reduce(function (n, m) { return n + (m.win ? 1 : 0); }, 0);
+  var winRate = total ? Math.round(wins / total * 1000) / 10 : 0;
+  var totalPages = Math.max(1, Math.ceil(total / pageSize));
   var curPage = Math.min(page, totalPages);
-  var start = (curPage - 1) * PAGE_SIZE;
-  var pageItems = filtered.slice(start, start + PAGE_SIZE);
+  var start = (curPage - 1) * pageSize;
+  var pageItems = filtered.slice(start, start + pageSize);
+  function onPageSize(n) { setPageSize(n); setPage(1); }
 
   return html`<div class="search-view">
     <${FilterForm} filters=${filters} options=${options}
@@ -295,14 +546,14 @@ export function SearchView({ matches }) {
 
     <div class="panel">
       <div class="search-result-head">
-        <h2><span class="dot" />検索結果 <span class="search-result-count">${total}件</span></h2>
-        <div class="search-sort">
-          <select class="search-select" value=${sortKey}
-            onChange=${function (e) { onSortKey(e.target.value); }}>
-            ${SORT_OPTIONS.map(function (o) { return html`<option value=${o.key}>${o.label}</option>`; })}
-          </select>
-          <button class="search-dir" onClick=${onToggleDir}
-            aria-label="並び順">${desc ? '降順 ↓' : '昇順 ↑'}</button>
+        <h2><span class="dot" /><span class="search-result-label">検索結果 </span><span class="search-result-count">${total}戦（${winRate}%）</span></h2>
+        <div class="search-result-tools">
+          <div class="search-pagesize">
+            <${Dropdown} value=${String(pageSize)} noClear=${true}
+              options=${[10, 20, 50, 100, 200].map(function (n) { return { value: String(n), label: n + '件' }; })}
+              onChange=${function (v) { onPageSize(Number(v)); }} />
+          </div>
+          <${SortControl} sortKey=${sortKey} desc=${desc} onSortKey=${onSortKey} onToggleDir=${onToggleDir} />
         </div>
       </div>
 
@@ -310,19 +561,19 @@ export function SearchView({ matches }) {
         ? html`<p class="search-empty">条件に一致する試合がありません。</p>`
         : html`<div class="search-list">
             ${pageItems.map(function (m) {
-              return html`<${ResultItem} match=${m} onOpen=${setDetail} />`;
+              return html`<${ResultItem} match=${m} msImages=${msImages || {}} sortKey=${sortKey} onOpen=${setDetail} />`;
             })}
           </div>`}
 
       ${totalPages > 1 && html`<div class="search-pager">
         <button class="search-page-btn" disabled=${curPage <= 1}
           onClick=${function () { setPage(curPage - 1); }}>← 前へ</button>
-        <span class="search-page-info">${start + 1}〜${Math.min(start + PAGE_SIZE, total)} / ${total}件（${curPage}/${totalPages}）</span>
+        <span class="search-page-info">${start + 1}〜${Math.min(start + pageSize, total)} / ${total}件（${curPage}/${totalPages}）</span>
         <button class="search-page-btn" disabled=${curPage >= totalPages}
           onClick=${function () { setPage(curPage + 1); }}>次へ →</button>
       </div>`}
     </div>
 
-    ${detail && html`<${DetailModal} match=${detail} onClose=${function () { setDetail(null); }} />`}
+    ${detail && html`<${DetailModal} match=${detail} msImages=${msImages || {}} onClose=${function () { setDetail(null); }} />`}
   </div>`;
 }

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -91,6 +91,12 @@ function FilterForm({ filters, options, onField, onReset, resultCount }) {
       </div>
 
       <div class="search-field">
+        <label class="search-label">相方プレイヤー名（部分一致）</label>
+        <input type="text" class="search-text" placeholder="名前の一部を入力"
+          value=${filters.playerName} onInput=${function (e) { onField('playerName', e.target.value); }} />
+      </div>
+
+      <div class="search-field">
         <label class="search-label">勝敗</label>
         <div class="lens-toggle">
           ${[['all', '全て'], ['win', '勝利'], ['loss', '敗北']].map(function (o) {

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -199,13 +199,22 @@ function DetailModal({ match, onClose }) {
     };
   }, []);
 
-  var enemies = [
-    nameWithMs(match.opponent1_name, match.opponent1_ms),
-    nameWithMs(match.opponent2_name, match.opponent2_ms),
-  ].join(' / ');
-  function row(label, mine, partner) {
-    return html`<tr><th>${label}</th><td class="num">${mine}</td><td class="num">${partner}</td></tr>`;
-  }
+  // 4人分のスコア列（自分・相方・敵1・敵2）。プレイヤー名は出さず、役割＋機体で識別する。
+  var cols = [
+    { role: '自分', ms: match.ms, enemy: false },
+    { role: '相方', ms: match.partner_ms, enemy: false },
+    { role: '敵1', ms: match.opponent1_ms, enemy: true },
+    { role: '敵2', ms: match.opponent2_ms, enemy: true },
+  ];
+  // 公式「スコア」画面と同じ項目（覚醒回数は試合経過側で表示するため含めない）。
+  var rows = [
+    ['スコア', [match.score, match.partner_score, match.opponent1_score, match.opponent2_score]],
+    ['撃墜', [match.kills, match.partner_kills, match.opponent1_kills, match.opponent2_kills]],
+    ['被撃墜', [match.deaths, match.partner_deaths, match.opponent1_deaths, match.opponent2_deaths]],
+    ['与ダメージ', [match.dmg_given, match.partner_dmg_given, match.opponent1_dmg_given, match.opponent2_dmg_given]],
+    ['被ダメージ', [match.dmg_taken, match.partner_dmg_taken, match.opponent1_dmg_taken, match.opponent2_dmg_taken]],
+    ['EXダメージ', [match.ex_dmg, match.partner_ex_dmg, match.opponent1_ex_dmg, match.opponent2_ex_dmg]],
+  ];
 
   return html`<div class="modal-backdrop" onClick=${function (e) { if (e.target === e.currentTarget) onClose(); }}>
     <div class="search-detail">
@@ -217,21 +226,22 @@ function DetailModal({ match, onClose }) {
         <button class="search-detail-close" onClick=${onClose} aria-label="閉じる">✕</button>
       </div>
 
-      <div class="search-detail-matchup">
-        <div><span class="search-detail-tag">自軍</span> ${esc(match.ms || '?')} ＋ ${esc(nameWithMs(match.partner_name, match.partner_ms))}</div>
-        <div><span class="search-detail-tag enemy">敵軍</span> ${esc(enemies)}</div>
-      </div>
-
       <div class="table-wrap"><table class="search-detail-table">
-        <thead><tr><th></th><th class="num">自分</th><th class="num">相方 (${esc(match.partner_name || '-')})</th></tr></thead>
+        <thead><tr>
+          <th></th>
+          ${cols.map(function (c) {
+            return html`<th class=${'num search-detail-col' + (c.enemy ? ' enemy' : '')}>
+              <span class="search-detail-col-role">${c.role}</span>
+              <span class="search-detail-col-ms">${esc(c.ms || '?')}</span>
+            </th>`;
+          })}
+        </tr></thead>
         <tbody>
-          ${row('スコア', num(match.score), num(match.partner_score))}
-          ${row('撃墜', num(match.kills), num(match.partner_kills))}
-          ${row('被撃墜', num(match.deaths), num(match.partner_deaths))}
-          ${row('与ダメージ', num(match.dmg_given), num(match.partner_dmg_given))}
-          ${row('被ダメージ', num(match.dmg_taken), num(match.partner_dmg_taken))}
-          ${row('EXダメージ', num(match.ex_dmg), num(match.partner_ex_dmg))}
-          ${row('覚醒回数', num(match.bursts), num(match.partner_bursts))}
+          ${rows.map(function (r) {
+            return html`<tr><th>${r[0]}</th>${r[1].map(function (v, i) {
+              return html`<td class=${'num' + (cols[i].enemy ? ' enemy' : '')}>${num(v)}</td>`;
+            })}</tr>`;
+          })}
         </tbody>
       </table></div>
 

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -1,0 +1,295 @@
+import { html, useState, useMemo, useEffect, useRef } from '../htm-preact-standalone.js';
+import {
+  emptyFilters, hasActiveFilters, collectMsOptions,
+  filterMatches, sortMatches, SORT_OPTIONS,
+} from '../analysis/search.js';
+import { esc, num } from '../lib/format.js';
+
+var PAGE_SIZE = 20;
+
+// タイムラインのアクション種別 → 表示ラベル。
+var ACTION_LABELS = {
+  death: '被撃墜',
+  'exbst-f': 'F覚醒',
+  'exbst-s': 'S覚醒',
+  'exbst-e': 'E覚醒',
+  'exbst-ov': 'OV覚醒',
+};
+
+// 秒数を M:SS 形式に整形する。
+function fmtSec(sec) {
+  if (sec == null || isNaN(sec)) return '';
+  var s = Math.max(0, Math.round(sec));
+  var m = Math.floor(s / 60);
+  return m + ':' + String(s % 60).padStart(2, '0');
+}
+
+// ネイティブ <select>。value/onChange と選択肢配列を受け取る。
+function Select({ value, onChange, options, placeholder }) {
+  return html`<select class="search-select" value=${value}
+    onChange=${function (e) { onChange(e.target.value); }}>
+    <option value="">${placeholder}</option>
+    ${options.map(function (o) {
+      return html`<option value=${o.name}>${o.name}（${o.matches}戦）</option>`;
+    })}
+  </select>`;
+}
+
+// 数値レンジ入力（最小〜最大）。
+function RangeInput({ label, minVal, maxVal, onMin, onMax }) {
+  return html`<div class="search-field">
+    <label class="search-label">${label}</label>
+    <div class="search-range">
+      <input type="number" class="search-num" inputmode="numeric" placeholder="最小"
+        value=${minVal} onInput=${function (e) { onMin(e.target.value); }} />
+      <span class="search-range-sep">〜</span>
+      <input type="number" class="search-num" inputmode="numeric" placeholder="最大"
+        value=${maxVal} onInput=${function (e) { onMax(e.target.value); }} />
+    </div>
+  </div>`;
+}
+
+// フィルタフォーム。filters と個々のフィールド更新関数、リセットを受け取る。
+function FilterForm({ filters, options, onField, onReset, resultCount }) {
+  var openRef = useState(true);
+  var open = openRef[0], setOpen = openRef[1];
+  var active = hasActiveFilters(filters);
+
+  return html`<div class="panel search-filter-panel">
+    <div class="search-filter-head">
+      <h2><span class="dot" />絞り込み条件</h2>
+      <button class="search-toggle" onClick=${function () { setOpen(!open); }}>
+        ${open ? '閉じる ▲' : '開く ▼'}
+      </button>
+    </div>
+    ${open && html`<div class="search-form">
+      <div class="search-field">
+        <label class="search-label">期間</label>
+        <div class="search-range">
+          <input type="date" class="search-date" value=${filters.dateFrom}
+            onInput=${function (e) { onField('dateFrom', e.target.value); }} />
+          <span class="search-range-sep">〜</span>
+          <input type="date" class="search-date" value=${filters.dateTo}
+            onInput=${function (e) { onField('dateTo', e.target.value); }} />
+        </div>
+      </div>
+
+      <div class="search-field">
+        <label class="search-label">使用機体</label>
+        <${Select} value=${filters.myMs} placeholder="すべての自機"
+          options=${options.mine} onChange=${function (v) { onField('myMs', v); }} />
+      </div>
+      <div class="search-field">
+        <label class="search-label">相方機体</label>
+        <${Select} value=${filters.partnerMs} placeholder="すべての相方"
+          options=${options.partners} onChange=${function (v) { onField('partnerMs', v); }} />
+      </div>
+      <div class="search-field">
+        <label class="search-label">敵機体</label>
+        <${Select} value=${filters.enemyMs} placeholder="すべての敵機"
+          options=${options.enemies} onChange=${function (v) { onField('enemyMs', v); }} />
+      </div>
+
+      <div class="search-field">
+        <label class="search-label">勝敗</label>
+        <div class="lens-toggle">
+          ${[['all', '全て'], ['win', '勝利'], ['loss', '敗北']].map(function (o) {
+            return html`<button class=${'lens-btn' + (filters.result === o[0] ? ' active' : '')}
+              onClick=${function () { onField('result', o[0]); }}>${o[1]}</button>`;
+          })}
+        </div>
+      </div>
+
+      <${RangeInput} label="与ダメージ" minVal=${filters.dmgGivenMin} maxVal=${filters.dmgGivenMax}
+        onMin=${function (v) { onField('dmgGivenMin', v); }} onMax=${function (v) { onField('dmgGivenMax', v); }} />
+      <${RangeInput} label="被ダメージ" minVal=${filters.dmgTakenMin} maxVal=${filters.dmgTakenMax}
+        onMin=${function (v) { onField('dmgTakenMin', v); }} onMax=${function (v) { onField('dmgTakenMax', v); }} />
+      <${RangeInput} label="撃墜数" minVal=${filters.killsMin} maxVal=${filters.killsMax}
+        onMin=${function (v) { onField('killsMin', v); }} onMax=${function (v) { onField('killsMax', v); }} />
+      <${RangeInput} label="被撃墜数" minVal=${filters.deathsMin} maxVal=${filters.deathsMax}
+        onMin=${function (v) { onField('deathsMin', v); }} onMax=${function (v) { onField('deathsMax', v); }} />
+
+      <div class="search-form-actions">
+        <span class="search-count">${resultCount}件ヒット</span>
+        ${active && html`<button class="search-reset" onClick=${onReset}>条件をクリア</button>`}
+      </div>
+    </div>`}
+  </div>`;
+}
+
+// 1試合分のサマリー行。クリックで詳細を開く。
+function ResultItem({ match, onOpen }) {
+  var enemies = [match.opponent1_ms, match.opponent2_ms].filter(Boolean).join(' / ');
+  return html`<button class="search-item" onClick=${function () { onOpen(match); }}>
+    <div class="search-item-top">
+      <span class=${'badge ' + (match.win ? 'win' : 'lose')}>${match.win ? 'WIN' : 'LOSE'}</span>
+      <span class="search-item-date">${esc(match.date)}</span>
+      <span class="search-item-score">${num(match.score)}pt</span>
+    </div>
+    <div class="search-item-ms">
+      <span class="search-item-self">${esc(match.ms || '?')}</span>
+      <span class="search-item-partner">+ ${esc(match.partner_ms || '?')}</span>
+      <span class="search-item-vs">vs</span>
+      <span class="search-item-enemy">${esc(enemies || '?')}</span>
+    </div>
+    <div class="search-item-stats">
+      <span>撃墜 <b>${num(match.kills)}</b></span>
+      <span>被撃墜 <b>${num(match.deaths)}</b></span>
+      <span>与 <b>${num(match.dmg_given)}</b></span>
+      <span>被 <b>${num(match.dmg_taken)}</b></span>
+    </div>
+  </button>`;
+}
+
+// 詳細モーダル内の統合タイムライン（自分・相方の被撃墜/覚醒を時系列で表示）。
+function Timeline({ match }) {
+  var events = [];
+  function collect(actions, who) {
+    (actions || []).forEach(function (a) {
+      if (!ACTION_LABELS[a.action]) return;
+      events.push({ who: who, label: ACTION_LABELS[a.action], sec: a.action_start_sec, isDeath: a.action === 'death' });
+    });
+  }
+  collect(match.actions, '自分');
+  collect(match.partner_actions, '相方');
+  events.sort(function (a, b) { return (a.sec || 0) - (b.sec || 0); });
+
+  if (!events.length) {
+    return html`<p class="search-detail-empty">タイムラインデータがありません。</p>`;
+  }
+  return html`<ul class="search-timeline">
+    ${events.map(function (ev) {
+      return html`<li class=${'search-tl-item' + (ev.isDeath ? ' death' : ' burst')}>
+        <span class="search-tl-time">${fmtSec(ev.sec)}</span>
+        <span class="search-tl-who">${ev.who}</span>
+        <span class="search-tl-label">${ev.label}</span>
+      </li>`;
+    })}
+  </ul>`;
+}
+
+// 試合詳細モーダル。
+function DetailModal({ match, onClose }) {
+  useEffect(function () {
+    function onKey(e) { if (e.key === 'Escape') onClose(); }
+    document.addEventListener('keydown', onKey);
+    document.body.style.overflow = 'hidden';
+    return function () {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  var enemies = [match.opponent1_ms, match.opponent2_ms].filter(Boolean).join(' / ');
+  function row(label, mine, partner) {
+    return html`<tr><th>${label}</th><td class="num">${mine}</td><td class="num">${partner}</td></tr>`;
+  }
+
+  return html`<div class="modal-backdrop" onClick=${function (e) { if (e.target === e.currentTarget) onClose(); }}>
+    <div class="search-detail">
+      <div class="search-detail-head">
+        <div>
+          <span class=${'badge ' + (match.win ? 'win' : 'lose')}>${match.win ? 'WIN' : 'LOSE'}</span>
+          <span class="search-detail-date">${esc(match.date)}</span>
+        </div>
+        <button class="search-detail-close" onClick=${onClose} aria-label="閉じる">✕</button>
+      </div>
+
+      <div class="search-detail-matchup">
+        <div><span class="search-detail-tag">自軍</span> ${esc(match.ms || '?')} ＋ ${esc(match.partner_ms || '?')}</div>
+        <div><span class="search-detail-tag enemy">敵軍</span> ${esc(enemies || '?')}</div>
+      </div>
+
+      <div class="table-wrap"><table class="search-detail-table">
+        <thead><tr><th></th><th class="num">自分</th><th class="num">相方 (${esc(match.partner_name || '-')})</th></tr></thead>
+        <tbody>
+          ${row('スコア', num(match.score), num(match.partner_score))}
+          ${row('撃墜', num(match.kills), num(match.partner_kills))}
+          ${row('被撃墜', num(match.deaths), num(match.partner_deaths))}
+          ${row('与ダメージ', num(match.dmg_given), num(match.partner_dmg_given))}
+          ${row('被ダメージ', num(match.dmg_taken), num(match.partner_dmg_taken))}
+          ${row('EXダメージ', num(match.ex_dmg), num(match.partner_ex_dmg))}
+          ${row('覚醒回数', num(match.bursts), num(match.partner_bursts))}
+        </tbody>
+      </table></div>
+
+      <h3 class="search-detail-tl-title">タイムライン</h3>
+      <${Timeline} match=${match} />
+    </div>
+  </div>`;
+}
+
+// 試合検索ビュー本体。matches はIndexedDBから読み込んだ全試合。
+export function SearchView({ matches }) {
+  var filtersRef = useState(emptyFilters);
+  var filters = filtersRef[0], setFilters = filtersRef[1];
+  var sortRef = useState('date');
+  var sortKey = sortRef[0], setSortKey = sortRef[1];
+  var descRef = useState(true);
+  var desc = descRef[0], setDesc = descRef[1];
+  var pageRef = useState(1);
+  var page = pageRef[0], setPage = pageRef[1];
+  var detailRef = useState(null);
+  var detail = detailRef[0], setDetail = detailRef[1];
+
+  var options = useMemo(function () { return collectMsOptions(matches); }, [matches]);
+
+  var filtered = useMemo(function () {
+    return sortMatches(filterMatches(matches, filters), sortKey, desc);
+  }, [matches, filters, sortKey, desc]);
+
+  // 条件・並び順が変わったら1ページ目に戻す。
+  useEffect(function () { setPage(1); }, [filters, sortKey, desc]);
+
+  function onField(key, value) {
+    setFilters(function (prev) {
+      var next = Object.assign({}, prev);
+      next[key] = value;
+      return next;
+    });
+  }
+  function onReset() { setFilters(emptyFilters()); }
+
+  var total = filtered.length;
+  var totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  var curPage = Math.min(page, totalPages);
+  var start = (curPage - 1) * PAGE_SIZE;
+  var pageItems = filtered.slice(start, start + PAGE_SIZE);
+
+  return html`<div class="search-view">
+    <${FilterForm} filters=${filters} options=${options}
+      onField=${onField} onReset=${onReset} resultCount=${total} />
+
+    <div class="panel">
+      <div class="search-result-head">
+        <h2><span class="dot" />検索結果 <span class="search-result-count">${total}件</span></h2>
+        <div class="search-sort">
+          <select class="search-select" value=${sortKey}
+            onChange=${function (e) { setSortKey(e.target.value); }}>
+            ${SORT_OPTIONS.map(function (o) { return html`<option value=${o.key}>${o.label}</option>`; })}
+          </select>
+          <button class="search-dir" onClick=${function () { setDesc(!desc); }}
+            aria-label="並び順">${desc ? '降順 ↓' : '昇順 ↑'}</button>
+        </div>
+      </div>
+
+      ${total === 0
+        ? html`<p class="search-empty">条件に一致する試合がありません。</p>`
+        : html`<div class="search-list">
+            ${pageItems.map(function (m) {
+              return html`<${ResultItem} match=${m} onOpen=${setDetail} />`;
+            })}
+          </div>`}
+
+      ${totalPages > 1 && html`<div class="search-pager">
+        <button class="search-page-btn" disabled=${curPage <= 1}
+          onClick=${function () { setPage(curPage - 1); }}>← 前へ</button>
+        <span class="search-page-info">${start + 1}〜${Math.min(start + PAGE_SIZE, total)} / ${total}件（${curPage}/${totalPages}）</span>
+        <button class="search-page-btn" disabled=${curPage >= totalPages}
+          onClick=${function () { setPage(curPage + 1); }}>次へ →</button>
+      </div>`}
+    </div>
+
+    ${detail && html`<${DetailModal} match=${detail} onClose=${function () { setDetail(null); }} />`}
+  </div>`;
+}

--- a/static/components/ui.js
+++ b/static/components/ui.js
@@ -1,5 +1,5 @@
-import { html, useState, useMemo } from '../htm-preact-standalone.js';
-import { boldText, cellValue, cellDisplay } from '../lib/format.js';
+import { html, useState, useMemo, useRef, useEffect } from '../htm-preact-standalone.js';
+import { boldText, cellValue, cellDisplay, esc } from '../lib/format.js';
 
 export function Tips({ tips }) {
   if (!tips || !tips.length) return null;
@@ -80,4 +80,193 @@ export function SubSection({ title, open, children }) {
     <summary>${title}</summary>
     ${children}
   </details>`;
+}
+
+// --- 範囲カレンダー（開始日〜終了日を2クリックで選択） ---
+var DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
+
+// startDate/endDate は 'YYYY-MM-DD' 文字列。onSelectStart/onSelectEnd で親に通知する。
+export function RangeCalendar({ startDate, endDate, onSelectStart, onSelectEnd }) {
+  var init = startDate ? new Date(startDate) : new Date();
+  var viewRef = useState({ year: init.getFullYear(), month: init.getMonth() });
+  var view = viewRef[0], setView = viewRef[1];
+  var phaseRef = useState(startDate ? (endDate ? 'done' : 'end') : 'start');
+  var phase = phaseRef[0], setPhase = phaseRef[1];
+
+  function prevMonth() {
+    setView(function (v) {
+      var m = v.month - 1;
+      return m < 0 ? { year: v.year - 1, month: 11 } : { year: v.year, month: m };
+    });
+  }
+  function nextMonth() {
+    setView(function (v) {
+      var m = v.month + 1;
+      return m > 11 ? { year: v.year + 1, month: 0 } : { year: v.year, month: m };
+    });
+  }
+
+  var firstDay = new Date(view.year, view.month, 1).getDay();
+  var daysInMonth = new Date(view.year, view.month + 1, 0).getDate();
+
+  var cells = [];
+  for (var i = 0; i < firstDay; i++) cells.push(null);
+  for (var d = 1; d <= daysInMonth; d++) cells.push(d);
+  while (cells.length < 42) cells.push(null);
+
+  function toStr(day) {
+    return view.year + '-' + String(view.month + 1).padStart(2, '0') + '-' + String(day).padStart(2, '0');
+  }
+
+  function handleClick(day) {
+    if (!day) return;
+    var s = toStr(day);
+    if (phase === 'start' || phase === 'done') {
+      onSelectStart(s);
+      onSelectEnd('');
+      setPhase('end');
+    } else {
+      if (s < startDate) {
+        onSelectStart(s);
+        onSelectEnd('');
+      } else {
+        onSelectEnd(s);
+        setPhase('done');
+      }
+    }
+  }
+
+  function dayClass(day) {
+    if (!day) return '';
+    var s = toStr(day);
+    var cls = 'cal-day';
+    if (s === startDate || s === endDate) cls += ' selected';
+    else if (startDate && endDate && s > startDate && s < endDate) cls += ' in-range';
+    return cls;
+  }
+
+  var hint = phase === 'start' || phase === 'done' ? '▶ 開始日を選択' : '▶ 終了日を選択';
+
+  return html`<div class="cal">
+    <div class="cal-header">
+      <button class="cal-nav" onClick=${prevMonth}>◀</button>
+      <span class="cal-title">${view.year}年${view.month + 1}月</span>
+      <button class="cal-nav" onClick=${nextMonth}>▶</button>
+    </div>
+    <div style="text-align:center;font-size:0.8em;color:var(--accent);margin-bottom:4px">${hint}</div>
+    <div class="cal-grid">
+      ${DOW_LABELS.map(function (d) { return html`<span class="cal-dow">${d}</span>`; })}
+      ${cells.map(function (day) {
+        if (!day) return html`<span class="cal-empty" />`;
+        return html`<button class=${dayClass(day)}
+          onClick=${function () { handleClick(day); }}>${day}</button>`;
+      })}
+    </div>
+  </div>`;
+}
+
+// --- 汎用カスタムドロップダウン（レポート画面の .panel-select-* スタイル） ---
+// options は [{value, label}]。value===placeholder用の空値('')は先頭のクリア項目として自動追加する。
+// 項目が多い(8件超)ときは検索ボックスを出し、ラベル部分一致で絞り込める。
+var DROPDOWN_SEARCH_THRESHOLD = 8;
+
+export function Dropdown({ value, options, onChange, placeholder, noClear }) {
+  var openRef = useState(false);
+  var isOpen = openRef[0], setIsOpen = openRef[1];
+  var queryRef = useState('');
+  var query = queryRef[0], setQuery = queryRef[1];
+  var ref = useRef(null);
+  var inputRef = useRef(null);
+
+  function close() { setIsOpen(false); setQuery(''); }
+
+  useEffect(function () {
+    if (!isOpen) return;
+    function onDoc(e) { if (ref.current && !ref.current.contains(e.target)) close(); }
+    document.addEventListener('click', onDoc, true);
+    if (inputRef.current) inputRef.current.focus();
+    return function () { document.removeEventListener('click', onDoc, true); };
+  }, [isOpen]);
+
+  var ph = placeholder || '-';
+  var current = options.find(function (o) { return o.value === value; });
+  var label = current ? current.label : ph;
+
+  function pick(v) { onChange(v); close(); }
+
+  var showSearch = options.length > DROPDOWN_SEARCH_THRESHOLD;
+  var q = query.trim().toLowerCase();
+  var filtered = q ? options.filter(function (o) { return String(o.label).toLowerCase().indexOf(q) >= 0; }) : options;
+
+  return html`<div class="panel-select-wrap" ref=${ref}>
+    <button type="button" class="panel-select-trigger" aria-expanded=${isOpen}
+      onClick=${function () { isOpen ? close() : setIsOpen(true); }}>
+      <span class="panel-select-label">${esc(label)}</span>
+      <span class="period-arrow">${isOpen ? '▲' : '▼'}</span>
+    </button>
+    ${isOpen && html`<div class="panel-select-dropdown">
+      ${showSearch && html`<input type="text" class="panel-select-search" ref=${inputRef}
+        placeholder="絞り込み..." value=${query}
+        onInput=${function (e) { setQuery(e.target.value); }} />`}
+      ${!q && !noClear && html`<button type="button" class=${'panel-select-item' + (value === '' ? ' active' : '')}
+        onClick=${function () { pick(''); }}>${ph}</button>`}
+      ${filtered.map(function (o) {
+        return html`<button type="button" class=${'panel-select-item' + (o.value === value ? ' active' : '')}
+          onClick=${function () { pick(o.value); }}>${esc(o.label)}</button>`;
+      })}
+      ${q && !filtered.length && html`<div class="panel-select-empty">該当なし</div>`}
+    </div>`}
+  </div>`;
+}
+
+// --- 複数選択ドロップダウン（.panel-select-* スタイル。項目内AND/ORは呼び出し側で扱う） ---
+// values は選択済み value の配列。options は [{value,label}]。トグルで追加/削除する。
+export function MultiSelect({ values, options, onChange, placeholder }) {
+  var openRef = useState(false);
+  var isOpen = openRef[0], setIsOpen = openRef[1];
+  var queryRef = useState('');
+  var query = queryRef[0], setQuery = queryRef[1];
+  var ref = useRef(null);
+  var inputRef = useRef(null);
+  var sel = values || [];
+
+  function close() { setIsOpen(false); setQuery(''); }
+  useEffect(function () {
+    if (!isOpen) return;
+    function onDoc(e) { if (ref.current && !ref.current.contains(e.target)) close(); }
+    document.addEventListener('click', onDoc, true);
+    if (inputRef.current) inputRef.current.focus();
+    return function () { document.removeEventListener('click', onDoc, true); };
+  }, [isOpen]);
+
+  function toggle(v) {
+    onChange(sel.indexOf(v) >= 0 ? sel.filter(function (x) { return x !== v; }) : sel.concat([v]));
+  }
+
+  // トリガー表示は chip（無ければ label）。ドロップダウン内は label（対戦数付き等）を使う。
+  var chipOf = function (v) { var o = options.find(function (o) { return o.value === v; }); return o ? (o.chip || o.label) : v; };
+  var triggerLabel = sel.length ? sel.map(chipOf).join('、') : (placeholder || '-');
+  var showSearch = options.length > DROPDOWN_SEARCH_THRESHOLD;
+  var q = query.trim().toLowerCase();
+  var filtered = q ? options.filter(function (o) { return String(o.label).toLowerCase().indexOf(q) >= 0; }) : options;
+
+  return html`<div class="panel-select-wrap" ref=${ref}>
+    <button type="button" class="panel-select-trigger" aria-expanded=${isOpen}
+      onClick=${function () { isOpen ? close() : setIsOpen(true); }}>
+      <span class="panel-select-label">${esc(triggerLabel)}</span>
+      <span class="period-arrow">${isOpen ? '▲' : '▼'}</span>
+    </button>
+    ${isOpen && html`<div class="panel-select-dropdown">
+      ${showSearch && html`<input type="text" class="panel-select-search" ref=${inputRef}
+        placeholder="絞り込み..." value=${query} onInput=${function (e) { setQuery(e.target.value); }} />`}
+      ${filtered.map(function (o) {
+        var on = sel.indexOf(o.value) >= 0;
+        return html`<button type="button" class=${'panel-select-item' + (on ? ' active' : '')}
+          onClick=${function () { toggle(o.value); }}>
+          <span>${esc(o.label)}</span><span class="panel-select-check">${on ? '✓' : ''}</span>
+        </button>`;
+      })}
+      ${q && !filtered.length && html`<div class="panel-select-empty">該当なし</div>`}
+    </div>`}
+  </div>`;
 }

--- a/static/components/ui.js
+++ b/static/components/ui.js
@@ -270,3 +270,35 @@ export function MultiSelect({ values, options, onChange, placeholder }) {
     </div>`}
   </div>`;
 }
+
+// --- テキスト入力＋自前の候補ドロップダウン（部分一致・入力直下に表示） ---
+// options は候補文字列の配列。入力が空のときは候補を出さない。
+export function Autocomplete({ value, onChange, options, placeholder }) {
+  var openRef = useState(false);
+  var open = openRef[0], setOpen = openRef[1];
+  var ref = useRef(null);
+  useEffect(function () {
+    if (!open) return;
+    function onDoc(e) { if (ref.current && !ref.current.contains(e.target)) setOpen(false); }
+    document.addEventListener('click', onDoc, true);
+    return function () { document.removeEventListener('click', onDoc, true); };
+  }, [open]);
+
+  var q = (value || '').trim().toLowerCase();
+  var matches = q
+    ? (options || []).filter(function (o) { return String(o).toLowerCase().indexOf(q) >= 0; }).slice(0, 30)
+    : [];
+  var showMenu = open && q && matches.length > 0;
+
+  return html`<div class="search-ac" ref=${ref}>
+    <input type="text" class="search-text" placeholder=${placeholder} value=${value}
+      onInput=${function (e) { onChange(e.target.value); setOpen(true); }}
+      onFocus=${function () { setOpen(true); }} />
+    ${showMenu && html`<div class="search-ac-menu">
+      ${matches.map(function (m) {
+        return html`<button type="button" class="search-ac-item"
+          onClick=${function () { onChange(m); setOpen(false); }}>${esc(m)}</button>`;
+      })}
+    </div>`}
+  </div>`;
+}

--- a/static/index.html
+++ b/static/index.html
@@ -346,7 +346,7 @@
     .info-icon:hover { color: var(--accent-2); }
 
     /* ===== Modal ===== */
-    .modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 300; display: flex; align-items: center; justify-content: center; }
+    .modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 300; display: flex; align-items: center; justify-content: center; overscroll-behavior: contain; }
     .modal-content { background: var(--panel); border: 1px solid var(--line); border-radius: 12px; padding: 24px; max-width: 400px; margin: 16px; box-shadow: 0 16px 48px rgba(0,0,0,0.5); }
     .modal-content p { color: var(--text); font-size: 0.9em; line-height: 1.7; margin-bottom: 10px; }
     .modal-close { margin-top: 12px; padding: 10px 24px; border: none; border-radius: 8px; background: var(--accent); color: #062536; font-size: 0.95em; font-weight: bold; cursor: pointer; }
@@ -372,7 +372,7 @@
     .search-chevron { width: 9px; height: 9px; flex-shrink: 0; margin-right: 4px; margin-top: -3px;
       border-right: 2px solid var(--accent); border-bottom: 2px solid var(--accent);
       transform: rotate(45deg); transition: transform 0.2s ease; }
-    .search-filter-head.open .search-chevron, .search-adv-toggle.open .search-chevron { transform: rotate(-135deg); margin-top: 3px; }
+    .search-filter-head.open .search-chevron, .search-adv-toggle.open .search-chevron, .search-detail-tl-toggle.open .search-chevron { transform: rotate(-135deg); margin-top: 3px; }
     .search-form { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; margin-top: 6px; padding: 0 10px 8px; }
     .search-field { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
     .search-field-wide { grid-column: 1 / -1; }
@@ -480,7 +480,7 @@
     .search-detail {
       background: var(--panel); border: 1px solid var(--line); border-radius: 16px; padding: 20px;
       max-width: 520px; width: 100%; margin: 16px; max-height: calc(100vh - 32px); overflow-y: auto;
-      box-shadow: 0 16px 48px rgba(0,0,0,0.5);
+      overscroll-behavior: contain; box-shadow: 0 16px 48px rgba(0,0,0,0.5);
     }
     .search-detail-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 14px; }
     .search-detail-date { margin-left: 8px; color: var(--muted); font-size: 0.88em; font-variant-numeric: tabular-nums; }
@@ -510,7 +510,11 @@
     .search-radar-swatch { width: 12px; height: 12px; border-radius: 3px; flex-shrink: 0; }
     .search-radar-toggle .search-detail-thumb { width: 26px; height: 26px; margin: 0; border-radius: 5px; }
     .search-radar-toggle .search-detail-thumb-text { font-size: 0.42em; }
-    .search-detail-tl-title { font-size: 0.95em; color: var(--accent-2); margin: 18px 0 8px; }
+    /* 試合経過の折りたたみトグル（既定は畳む） */
+    .search-detail-tl-toggle { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 8px; background: none; border: none; border-top: 1px solid var(--line); margin-top: 14px; padding: 12px 2px 4px; cursor: pointer; color: inherit; font-size: 1em; }
+    .search-detail-tl-toggle:hover, .search-detail-tl-toggle:focus { background: none; }
+    .search-detail-tl-toggle:hover .search-detail-tl-title { color: var(--accent); }
+    .search-detail-tl-title { font-size: 0.95em; color: var(--accent-2); margin: 0; }
     .search-detail-empty { color: var(--muted); font-size: 0.88em; }
     /* 試合経過ガント（公式風の横棒タイムライン） */
     .gantt { display: flex; flex-direction: column; gap: 6px; }

--- a/static/index.html
+++ b/static/index.html
@@ -397,6 +397,7 @@
     .search-item-date { color: var(--muted); font-size: 0.82em; font-variant-numeric: tabular-nums; }
     .search-item-score { margin-left: auto; color: var(--accent-2); font-size: 0.82em; font-weight: 600; }
     .search-item-ms { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; font-size: 0.92em; }
+    .search-item-foes { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; font-size: 0.88em; }
     .search-item-self { color: var(--text); font-weight: 700; }
     .search-item-partner { color: var(--muted); font-size: 0.85em; }
     .search-item-vs { color: var(--muted); font-size: 0.78em; }

--- a/static/index.html
+++ b/static/index.html
@@ -421,14 +421,16 @@
     .search-detail-date { margin-left: 8px; color: var(--muted); font-size: 0.88em; font-variant-numeric: tabular-nums; }
     .search-detail-close { width: auto; background: none; border: none; color: var(--muted); font-size: 1.1em; cursor: pointer; padding: 4px 8px; line-height: 1; }
     .search-detail-close:hover { color: var(--text); }
-    .search-detail-matchup { display: flex; flex-direction: column; gap: 6px; margin-bottom: 14px; font-size: 0.92em; }
-    .search-detail-tag { display: inline-block; padding: 1px 8px; border-radius: 999px; font-size: 0.72em; font-weight: 700; background: rgba(79,195,247,0.15); color: var(--accent); margin-right: 4px; }
-    .search-detail-tag.enemy { background: rgba(255,138,101,0.15); color: var(--bad); }
     .search-detail-table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
-    .search-detail-table th, .search-detail-table td { padding: 7px 10px; border-bottom: 1px solid var(--line); text-align: left; }
-    .search-detail-table thead th { color: var(--accent); font-weight: 600; }
+    .search-detail-table th, .search-detail-table td { padding: 7px 10px; border-bottom: 1px solid var(--line); text-align: left; white-space: nowrap; }
+    .search-detail-table thead th { color: var(--accent); font-weight: 600; vertical-align: bottom; }
     .search-detail-table tbody th { color: var(--muted); font-weight: 400; }
     .search-detail-table td.num, .search-detail-table th.num { text-align: right; font-variant-numeric: tabular-nums; }
+    .search-detail-col { display: inline-flex; flex-direction: column; align-items: flex-end; gap: 2px; }
+    .search-detail-col-role { font-weight: 700; }
+    .search-detail-col-ms { font-size: 0.72em; font-weight: 400; color: var(--muted); max-width: 88px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .search-detail-col.enemy .search-detail-col-role { color: var(--accent-2); }
+    .search-detail-table td.enemy { color: var(--accent-2); }
     .search-detail-tl-title { font-size: 0.95em; color: var(--accent-2); margin: 18px 0 8px; }
     .search-detail-empty { color: var(--muted); font-size: 0.88em; }
     .search-timeline { list-style: none; display: flex; flex-direction: column; gap: 4px; padding: 0; }

--- a/static/index.html
+++ b/static/index.html
@@ -394,6 +394,12 @@
       width: 100%; padding: 9px 10px; border: 1px solid var(--line); border-radius: 8px;
       background: var(--bg); color: var(--text); font-size: 0.9em; color-scheme: dark;
     }
+    /* 自前の候補ドロップダウン（入力直下に表示） */
+    .search-ac { position: relative; }
+    .search-ac-menu { position: absolute; top: calc(100% + 4px); left: 0; right: 0; z-index: 30; max-height: 220px; overflow-y: auto;
+      background: var(--panel); border: 1px solid var(--line); border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.45); padding: 4px; }
+    .search-ac-item { width: 100%; text-align: left; background: none; border: none; border-radius: 6px; color: var(--text); font-size: 0.9em; padding: 8px 10px; cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .search-ac-item:hover, .search-ac-item:focus { background: var(--panel-2); }
     /* 絞り込みのプルダウンはレポート画面の .panel-select-* を流用。フォーム内では下マージンを詰め、
        文字サイズは他の入力欄(0.9em)に合わせて統一する（モバイルの1emも上書き） */
     .search-field .panel-select-wrap { margin-bottom: 0; }

--- a/static/index.html
+++ b/static/index.html
@@ -351,6 +351,94 @@
 
     .disclaimer { margin-top: 30px; padding: 16px 0; border-top: 1px solid var(--line); text-align: center; font-size: 0.72em; color: #5a6b7a; line-height: 1.8; }
 
+    /* ===== 試合検索 (SearchView) ===== */
+    .search-view { padding-bottom: 40px; }
+    .search-filter-panel { padding-bottom: 18px; }
+    .search-filter-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 12px; }
+    .search-filter-head h2 { font-size: 1.05em; color: var(--accent); display: flex; align-items: center; gap: 8px; margin: 0; }
+    .search-filter-head .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 10px var(--accent); }
+    .search-toggle { width: auto; background: none; border: 1px solid var(--line); border-radius: 999px; color: var(--accent); font-size: 0.8em; padding: 5px 14px; cursor: pointer; white-space: nowrap; transition: all 0.15s; }
+    .search-toggle:hover { border-color: var(--accent); background: rgba(79,195,247,0.1); }
+    .search-form { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; }
+    .search-field { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+    .search-label { margin: 0; color: var(--muted); font-size: 0.8em; }
+    .search-select, .search-num, .search-date {
+      width: 100%; padding: 9px 10px; border: 1px solid var(--line); border-radius: 8px;
+      background: var(--bg); color: var(--text); font-size: 0.9em; color-scheme: dark;
+    }
+    .search-select:focus, .search-num:focus, .search-date:focus { outline: none; border-color: var(--accent); }
+    .search-range { display: flex; align-items: center; gap: 8px; min-width: 0; }
+    .search-range .search-num, .search-range .search-date { flex: 1; min-width: 0; }
+    .search-range-sep { color: var(--muted); font-size: 0.85em; flex-shrink: 0; }
+    .search-field .lens-toggle { align-self: flex-start; }
+    .search-form-actions { grid-column: 1 / -1; display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 4px; }
+    .search-count { color: var(--accent); font-size: 0.9em; font-weight: 600; }
+    .search-reset { width: auto; background: none; border: 1px solid var(--line); border-radius: 999px; color: var(--muted); font-size: 0.8em; padding: 6px 14px; cursor: pointer; transition: all 0.15s; }
+    .search-reset:hover { border-color: var(--bad); color: var(--bad); }
+
+    .search-result-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 14px; flex-wrap: wrap; }
+    .search-result-head h2 { font-size: 1.05em; color: var(--accent); display: flex; align-items: center; gap: 8px; margin: 0; }
+    .search-result-head .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 10px var(--accent); }
+    .search-result-count { color: var(--muted); font-size: 0.8em; font-weight: 400; }
+    .search-sort { display: flex; align-items: center; gap: 8px; }
+    .search-sort .search-select { width: auto; }
+    .search-dir { width: auto; background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; color: var(--text); font-size: 0.85em; padding: 8px 12px; cursor: pointer; white-space: nowrap; transition: all 0.15s; }
+    .search-dir:hover { border-color: var(--accent); }
+
+    .search-list { display: flex; flex-direction: column; gap: 10px; }
+    .search-item {
+      width: 100%; text-align: left; display: flex; flex-direction: column; gap: 8px;
+      background: var(--panel-2); border: 1px solid var(--line); border-radius: 12px; padding: 12px 14px;
+      cursor: pointer; transition: border-color 0.15s, transform 0.1s;
+    }
+    .search-item:hover { border-color: var(--accent); }
+    .search-item:active { transform: scale(0.995); }
+    .search-item-top { display: flex; align-items: center; gap: 10px; }
+    .search-item-date { color: var(--muted); font-size: 0.82em; font-variant-numeric: tabular-nums; }
+    .search-item-score { margin-left: auto; color: var(--accent-2); font-size: 0.82em; font-weight: 600; }
+    .search-item-ms { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; font-size: 0.92em; }
+    .search-item-self { color: var(--text); font-weight: 700; }
+    .search-item-partner { color: var(--muted); font-size: 0.85em; }
+    .search-item-vs { color: var(--muted); font-size: 0.78em; }
+    .search-item-enemy { color: var(--accent-2); }
+    .search-item-stats { display: flex; gap: 14px; flex-wrap: wrap; color: var(--muted); font-size: 0.8em; }
+    .search-item-stats b { color: var(--text); font-variant-numeric: tabular-nums; font-weight: 700; }
+    .search-empty { color: var(--muted); text-align: center; padding: 24px 0; }
+
+    .search-pager { display: flex; align-items: center; justify-content: center; gap: 12px; margin-top: 16px; }
+    .search-page-btn { width: auto; background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; color: var(--accent); font-size: 0.85em; padding: 8px 16px; cursor: pointer; white-space: nowrap; transition: all 0.15s; }
+    .search-page-btn:hover:not(:disabled) { border-color: var(--accent); background: rgba(79,195,247,0.1); }
+    .search-page-btn:disabled { color: #566; cursor: default; opacity: 0.5; }
+    .search-page-info { color: var(--muted); font-size: 0.82em; font-variant-numeric: tabular-nums; }
+
+    .search-detail {
+      background: var(--panel); border: 1px solid var(--line); border-radius: 16px; padding: 20px;
+      max-width: 520px; width: 100%; margin: 16px; max-height: calc(100vh - 32px); overflow-y: auto;
+      box-shadow: 0 16px 48px rgba(0,0,0,0.5);
+    }
+    .search-detail-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 14px; }
+    .search-detail-date { margin-left: 8px; color: var(--muted); font-size: 0.88em; font-variant-numeric: tabular-nums; }
+    .search-detail-close { width: auto; background: none; border: none; color: var(--muted); font-size: 1.1em; cursor: pointer; padding: 4px 8px; line-height: 1; }
+    .search-detail-close:hover { color: var(--text); }
+    .search-detail-matchup { display: flex; flex-direction: column; gap: 6px; margin-bottom: 14px; font-size: 0.92em; }
+    .search-detail-tag { display: inline-block; padding: 1px 8px; border-radius: 999px; font-size: 0.72em; font-weight: 700; background: rgba(79,195,247,0.15); color: var(--accent); margin-right: 4px; }
+    .search-detail-tag.enemy { background: rgba(255,138,101,0.15); color: var(--bad); }
+    .search-detail-table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
+    .search-detail-table th, .search-detail-table td { padding: 7px 10px; border-bottom: 1px solid var(--line); text-align: left; }
+    .search-detail-table thead th { color: var(--accent); font-weight: 600; }
+    .search-detail-table tbody th { color: var(--muted); font-weight: 400; }
+    .search-detail-table td.num, .search-detail-table th.num { text-align: right; font-variant-numeric: tabular-nums; }
+    .search-detail-tl-title { font-size: 0.95em; color: var(--accent-2); margin: 18px 0 8px; }
+    .search-detail-empty { color: var(--muted); font-size: 0.88em; }
+    .search-timeline { list-style: none; display: flex; flex-direction: column; gap: 4px; padding: 0; }
+    .search-tl-item { display: flex; align-items: center; gap: 10px; padding: 6px 10px; border-radius: 8px; background: var(--panel-2); font-size: 0.85em; border-left: 3px solid var(--line); }
+    .search-tl-item.death { border-left-color: var(--terrible); }
+    .search-tl-item.burst { border-left-color: var(--accent); }
+    .search-tl-time { color: var(--muted); font-variant-numeric: tabular-nums; min-width: 42px; }
+    .search-tl-who { color: var(--text); min-width: 36px; font-size: 0.9em; }
+    .search-tl-label { color: var(--accent-2); }
+    .search-tl-item.death .search-tl-label { color: var(--bad); }
+
     @media (max-width: 720px) {
       .kpi-grid { grid-template-columns: repeat(2, 1fr); }
       .two-col { grid-template-columns: 1fr; }
@@ -384,6 +472,8 @@
       .panel-select-item { padding: 14px 16px; font-size: 1em; }
       .period-custom-range { flex-direction: column; }
       .period-custom { min-width: 0; }
+      .search-form { grid-template-columns: 1fr; }
+      .search-result-head { align-items: flex-start; }
     }
   </style>
 </head>

--- a/static/index.html
+++ b/static/index.html
@@ -318,8 +318,14 @@
     /* ===== Panel-inline dropdown (固定相方等) ===== */
     .panel-select-wrap { position: relative; margin-bottom: 14px; }
     .panel-select-trigger { display: flex; align-items: center; justify-content: space-between; gap: 8px; width: 100%; padding: 10px 14px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel-2); color: var(--text); font-size: 0.95em; cursor: pointer; transition: all 0.2s; text-align: left; }
-    .panel-select-trigger:hover { border-color: var(--accent); }
+    .panel-select-trigger:hover, .panel-select-trigger:focus { border-color: var(--accent); background: var(--panel-2); }
+    .panel-select-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
     .panel-select-dropdown { position: absolute; top: 100%; left: 0; right: 0; margin-top: 4px; background: var(--panel); border: 1px solid var(--line); border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.4); z-index: 100; max-height: 60vh; overflow-y: auto; }
+    /* ドロップダウン内の絞り込み入力（項目が多いとき表示）。スクロールしても上部に固定 */
+    .panel-select-search { position: sticky; top: 0; z-index: 1; width: 100%; box-sizing: border-box; padding: 9px 14px; border: none; border-bottom: 1px solid var(--line); background: var(--panel-2); color: var(--text); font-size: 0.9em; color-scheme: dark; }
+    .panel-select-search:focus { outline: none; }
+    .panel-select-empty { padding: 12px 16px; color: var(--muted); font-size: 0.85em; text-align: center; }
+    .panel-select-check { color: var(--accent); font-weight: 700; }
     .panel-select-item { display: flex; justify-content: space-between; align-items: center; width: 100%; padding: 12px 16px; border: none; background: none; color: var(--text); font-size: 0.9em; cursor: pointer; text-align: left; transition: all 0.15s; }
     .panel-select-item:hover { background: var(--panel-2); }
     .panel-select-item.active { color: var(--accent); background: var(--bg); font-weight: bold; }
@@ -353,19 +359,46 @@
 
     /* ===== 試合検索 (SearchView) ===== */
     .search-view { padding-bottom: 40px; }
-    .search-filter-panel { padding-bottom: 18px; }
-    .search-filter-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 12px; }
-    .search-filter-head h2 { font-size: 1.05em; color: var(--accent); display: flex; align-items: center; gap: 8px; margin: 0; }
+    .search-filter-panel { padding: 4px; border-radius: 12px; margin-bottom: 12px; }
+    /* タイル全体がクリック可能な開閉ボタン。専用ボタンは廃止しシェブロンで開閉を示す */
+    .search-filter-head { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 8px;
+      background: none; border: none; padding: 8px 10px; border-radius: 9px; cursor: pointer; text-align: left;
+      color: inherit; font-size: 1em; transition: background 0.15s; }
+    .search-filter-head:hover { background: rgba(79,195,247,0.08); }
+    .search-filter-title { font-size: 1.05em; color: var(--accent); display: flex; align-items: center; gap: 8px; margin: 0; }
     .search-filter-head .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 10px var(--accent); }
-    .search-toggle { width: auto; background: none; border: 1px solid var(--line); border-radius: 999px; color: var(--accent); font-size: 0.8em; padding: 5px 14px; cursor: pointer; white-space: nowrap; transition: all 0.15s; }
-    .search-toggle:hover { border-color: var(--accent); background: rgba(79,195,247,0.1); }
-    .search-form { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; }
+    .search-filter-badge { font-size: 0.62em; font-weight: 600; color: var(--accent); border: 1px solid var(--accent); border-radius: 999px; padding: 2px 8px; letter-spacing: 0.02em; }
+    /* 開閉を示すシェブロン: 閉=下向き(▽)、開=上向き(△)にアニメーション回転 */
+    .search-chevron { width: 9px; height: 9px; flex-shrink: 0; margin-right: 4px; margin-top: -3px;
+      border-right: 2px solid var(--accent); border-bottom: 2px solid var(--accent);
+      transform: rotate(45deg); transition: transform 0.2s ease; }
+    .search-filter-head.open .search-chevron, .search-adv-toggle.open .search-chevron { transform: rotate(-135deg); margin-top: 3px; }
+    .search-form { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; margin-top: 6px; padding: 0 10px 8px; }
     .search-field { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+    .search-field-wide { grid-column: 1 / -1; }
+    /* 詳細設定（マニアックな数値レンジ）を折りたたむ */
+    .search-adv { grid-column: 1 / -1; border-top: 1px solid var(--line); margin-top: 2px; }
+    .search-adv-toggle { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 8px 2px; background: none; border: none; color: var(--muted); font-size: 0.85em; font-weight: 400; cursor: pointer; }
+    .search-adv-toggle:hover, .search-adv-toggle:focus { background: none; color: var(--accent); }
+    .search-adv-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; margin: 4px 0 8px; }
     .search-label { margin: 0; color: var(--muted); font-size: 0.8em; }
+    .search-label-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+    /* 敵機などの AND/OR 切り替え（ラベル横の小さなセグメント） */
+    .search-andor { display: inline-flex; border: 1px solid var(--line); border-radius: 6px; overflow: hidden; flex-shrink: 0; }
+    .search-andor-btn { width: auto; background: var(--panel-2); border: none; color: var(--muted); font-size: 0.9em; font-weight: 400; padding: 2px 8px; cursor: pointer; }
+    .search-andor-btn.active { background: var(--accent); color: var(--bg); font-weight: 700; }
+    .search-andor-btn:hover:not(.active), .search-andor-btn:focus:not(.active) { background: var(--panel-2); color: var(--text); }
+    /* 期間トリガー: プルダウン風。クリックで下にカレンダーを開く */
+    .search-date-trigger.open + .cal { margin-top: 8px; }
     .search-select, .search-num, .search-date, .search-text {
       width: 100%; padding: 9px 10px; border: 1px solid var(--line); border-radius: 8px;
       background: var(--bg); color: var(--text); font-size: 0.9em; color-scheme: dark;
     }
+    /* 絞り込みのプルダウンはレポート画面の .panel-select-* を流用。フォーム内では下マージンを詰め、
+       文字サイズは他の入力欄(0.9em)に合わせて統一する（モバイルの1emも上書き） */
+    .search-field .panel-select-wrap { margin-bottom: 0; }
+    .search-form .panel-select-trigger { font-size: 0.9em; padding: 9px 12px; }
+    .search-form .panel-select-item { font-size: 0.9em; padding: 10px 12px; }
     .search-select:focus, .search-num:focus, .search-date:focus, .search-text:focus { outline: none; border-color: var(--accent); }
     .search-range { display: flex; align-items: center; gap: 8px; min-width: 0; }
     .search-range .search-num, .search-range .search-date { flex: 1; min-width: 0; }
@@ -376,14 +409,28 @@
     .search-reset { width: auto; background: none; border: 1px solid var(--line); border-radius: 999px; color: var(--muted); font-size: 0.8em; padding: 6px 14px; cursor: pointer; transition: all 0.15s; }
     .search-reset:hover { border-color: var(--bad); color: var(--bad); }
 
-    .search-result-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 14px; flex-wrap: wrap; }
-    .search-result-head h2 { font-size: 1.05em; color: var(--accent); display: flex; align-items: center; gap: 8px; margin: 0; }
-    .search-result-head .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 10px var(--accent); }
+    .search-result-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 14px; flex-wrap: nowrap; }
+    .search-result-head h2 { font-size: 1.05em; color: var(--accent); display: flex; align-items: center; gap: 8px; margin: 0; min-width: 0; white-space: nowrap; }
+    .search-result-head .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 10px var(--accent); flex-shrink: 0; }
     .search-result-count { color: var(--muted); font-size: 0.8em; font-weight: 400; }
-    .search-sort { display: flex; align-items: center; gap: 8px; }
-    .search-sort .search-select { width: auto; }
-    .search-dir { width: auto; background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; color: var(--text); font-size: 0.85em; padding: 8px 12px; cursor: pointer; white-space: nowrap; transition: all 0.15s; }
-    .search-dir:hover { border-color: var(--accent); }
+    .search-result-tools { display: flex; align-items: center; gap: 8px; flex-wrap: nowrap; flex-shrink: 0; }
+    .search-pagesize { min-width: 0; }
+    .search-pagesize .panel-select-wrap { margin-bottom: 0; }
+    .search-pagesize .panel-select-trigger { padding: 6px 10px; font-size: 0.85em; }
+    .search-sort { display: flex; align-items: center; gap: 6px; }
+    /* ソート項目: アイコン付きトリガー＋カスタムドロップダウン */
+    .search-sort-dd { position: relative; }
+    .search-sort-trigger { width: auto; display: inline-flex; align-items: center; justify-content: center; background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; padding: 6px; cursor: pointer; }
+    .search-sort-trigger:hover, .search-sort-trigger:focus, .search-sort-trigger.open { border-color: var(--accent); background: var(--panel-2); }
+    .search-sort-ico { width: 24px; height: 24px; fill: var(--accent); display: block; }
+    .search-sort-menu { position: absolute; top: calc(100% + 4px); right: 0; z-index: 20; min-width: 140px; background: var(--panel); border: 1px solid var(--line); border-radius: 10px; box-shadow: 0 8px 24px rgba(0,0,0,0.45); padding: 4px; }
+    .search-sort-opt { width: 100%; text-align: left; background: none; border: none; border-radius: 6px; color: var(--text); font-size: 0.85em; font-weight: 400; padding: 8px 10px; cursor: pointer; }
+    .search-sort-opt:hover, .search-sort-opt:focus { background: var(--panel-2); }
+    .search-sort-opt.active { color: var(--accent); font-weight: 700; }
+    /* 昇順/降順: 三角アイコンのみのボタン */
+    .search-dir { width: auto; display: inline-flex; align-items: center; justify-content: center; background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; color: var(--text); padding: 6px; cursor: pointer; }
+    .search-dir:hover, .search-dir:focus { border-color: var(--accent); background: var(--panel-2); }
+    .search-dir-ico { width: 24px; height: 24px; fill: var(--accent); display: block; }
 
     .search-list { display: flex; flex-direction: column; gap: 10px; }
     .search-item {
@@ -395,15 +442,27 @@
     .search-item:active { transform: scale(0.995); }
     .search-item-top { display: flex; align-items: center; gap: 10px; }
     .search-item-date { color: var(--muted); font-size: 0.82em; font-variant-numeric: tabular-nums; }
-    .search-item-score { margin-left: auto; color: var(--accent-2); font-size: 0.82em; font-weight: 600; }
-    .search-item-ms { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; font-size: 0.92em; }
-    .search-item-foes { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; font-size: 0.88em; }
-    .search-item-self { color: var(--text); font-weight: 700; }
-    .search-item-partner { color: var(--muted); font-size: 0.85em; }
-    .search-item-vs { color: var(--muted); font-size: 0.78em; }
-    .search-item-enemy { color: var(--accent-2); }
-    .search-item-stats { display: flex; gap: 14px; flex-wrap: wrap; color: var(--muted); font-size: 0.8em; }
-    .search-item-stats b { color: var(--text); font-variant-numeric: tabular-nums; font-weight: 700; }
+    .search-item-metric { margin-left: auto; color: var(--accent-2); font-size: 0.82em; font-weight: 600; font-variant-numeric: tabular-nums; }
+    /* 対戦カード: 自陣（自機＋相方）VS 敵陣（敵1＋敵2）を機体画像で並べる */
+    /* 画像行: 自陣(自機+相方) VS 敵陣(敵1+敵2)。画像は枠内で伸縮し被らない */
+    .search-item-battle { display: flex; align-items: center; gap: 10px; }
+    .search-ms-imgs { flex: 1; min-width: 0; display: flex; gap: 6px; }
+    .search-ms-imgs.enemy { justify-content: flex-end; }
+    .search-ms-thumb { flex: 0 1 74px; min-width: 0; width: auto; height: auto; aspect-ratio: 1 / 1; border-radius: 8px; border: 1px solid var(--line); object-fit: cover; background: var(--bg); }
+    .search-ms-thumb-text { display: flex; align-items: center; justify-content: center; text-align: center; padding: 3px; font-size: 0.66em; line-height: 1.2; color: var(--muted); overflow: hidden; }
+    /* 公式スプライト win_lose_vs.png(451x138) から VS 部分だけを background-position で切り出す */
+    .search-item-vs { flex-shrink: 0; width: 54px; height: 44px;
+      background-image: url("https://resource.exvs2ib.vsmobile.jp/css/images/common/win_lose_vs.png");
+      background-repeat: no-repeat; background-size: 161px 49px; background-position: -99px 0;
+      filter: drop-shadow(0 1px 2px rgba(0,0,0,0.5)); }
+    /* 名前行: 画像の下に全幅で配置し左右50/50。各欄が半カード幅を使えるのでスマホでも文字が入る */
+    .search-item-namesrow { display: flex; gap: 12px; margin-top: 2px; }
+    .search-item-names { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+    .search-item-names.enemy { align-items: flex-end; text-align: right; }
+    /* プレイヤー名は最大12文字。小さめ＋省略(保険)。狭幅では更に縮小して12文字を確保 */
+    .search-name-line { font-size: 0.74em; line-height: 1.35; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+    @media (max-width: 480px) { .search-name-line { font-size: 0.66em; } }
+    @media (max-width: 380px) { .search-name-line { font-size: 0.6em; } }
     .search-empty { color: var(--muted); text-align: center; padding: 24px 0; }
 
     .search-pager { display: flex; align-items: center; justify-content: center; gap: 12px; margin-top: 16px; }
@@ -422,25 +481,60 @@
     .search-detail-close { width: auto; background: none; border: none; color: var(--muted); font-size: 1.1em; cursor: pointer; padding: 4px 8px; line-height: 1; }
     .search-detail-close:hover { color: var(--text); }
     .search-detail-table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
-    .search-detail-table th, .search-detail-table td { padding: 7px 10px; border-bottom: 1px solid var(--line); text-align: left; white-space: nowrap; }
+    .search-detail-table th, .search-detail-table td { padding: 7px 8px; border-bottom: 1px solid var(--line); text-align: left; white-space: nowrap; }
     .search-detail-table thead th { color: var(--accent); font-weight: 600; vertical-align: bottom; }
     .search-detail-table tbody th { color: var(--muted); font-weight: 400; }
-    .search-detail-table td.num, .search-detail-table th.num { text-align: right; font-variant-numeric: tabular-nums; }
-    .search-detail-col { display: inline-flex; flex-direction: column; align-items: flex-end; gap: 2px; }
-    .search-detail-col-role { font-weight: 700; }
-    .search-detail-col-ms { font-size: 0.72em; font-weight: 400; color: var(--muted); max-width: 88px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .search-detail-col.enemy .search-detail-col-role { color: var(--accent-2); }
-    .search-detail-table td.enemy { color: var(--accent-2); }
+    /* 数値列は機体画像の下に中央揃えで並べる */
+    .search-detail-table td.num, .search-detail-table th.num { text-align: center; font-variant-numeric: tabular-nums; }
+    /* 列見出し: 機体画像を中央配置（役割文字・名前は出さない） */
+    .search-detail-col { text-align: center; vertical-align: bottom; }
+    .search-detail-thumb { display: block; width: 48px; height: 48px; margin: 0 auto; border-radius: 7px; border: 1px solid var(--line); object-fit: cover; background: var(--bg); }
+    .search-detail-thumb-text { display: flex; align-items: center; justify-content: center; text-align: center; padding: 2px; font-size: 0.5em; line-height: 1.1; color: var(--muted); overflow: hidden; }
+    /* 自陣と敵陣の間(敵1列の左)に区切り線。値の色は分析と同じ基準で色分け */
+    .search-detail-table th.team-sep, .search-detail-table td.team-sep { border-left: 2px solid var(--line); }
+    /* レーダーの表示切替チェックボックス（機体画像＋系列色スウォッチ。役割文字なし） */
+    .search-radar-toggles { display: flex; flex-wrap: wrap; justify-content: center; gap: 8px; margin: 4px 0 2px; }
+    /* トグルボタン: 活性=通常表示、非活性(off)=淡色化で状態を示す（チェックボックスは廃止） */
+    .search-radar-toggle { width: auto; display: inline-flex; align-items: center; gap: 6px; padding: 4px 8px 4px 6px; border: 1px solid var(--line); border-radius: 999px; cursor: pointer; background: var(--panel-2); color: inherit; font-size: 1em; font-weight: 400; transition: opacity 0.15s; }
+    /* 状態は活性/非活性(不透明度)だけで示す。hover/focusでグローバルbuttonの青背景が出ないよう固定 */
+    .search-radar-toggle:hover, .search-radar-toggle:focus { background: var(--panel-2); }
+    .search-radar-toggle.off { opacity: 0.4; background: transparent; }
+    .search-radar-toggle.off:hover, .search-radar-toggle.off:focus { background: transparent; }
+    .search-radar-toggle.off .search-radar-swatch { filter: grayscale(1); }
+    .search-radar-swatch { width: 12px; height: 12px; border-radius: 3px; flex-shrink: 0; }
+    .search-radar-toggle .search-detail-thumb { width: 26px; height: 26px; margin: 0; border-radius: 5px; }
+    .search-radar-toggle .search-detail-thumb-text { font-size: 0.42em; }
     .search-detail-tl-title { font-size: 0.95em; color: var(--accent-2); margin: 18px 0 8px; }
     .search-detail-empty { color: var(--muted); font-size: 0.88em; }
-    .search-timeline { list-style: none; display: flex; flex-direction: column; gap: 4px; padding: 0; }
-    .search-tl-item { display: flex; align-items: center; gap: 10px; padding: 6px 10px; border-radius: 8px; background: var(--panel-2); font-size: 0.85em; border-left: 3px solid var(--line); }
-    .search-tl-item.death { border-left-color: var(--terrible); }
-    .search-tl-item.burst { border-left-color: var(--accent); }
-    .search-tl-time { color: var(--muted); font-variant-numeric: tabular-nums; min-width: 42px; }
-    .search-tl-who { color: var(--text); min-width: 36px; font-size: 0.9em; }
-    .search-tl-label { color: var(--accent-2); }
-    .search-tl-item.death .search-tl-label { color: var(--bad); }
+    /* 試合経過ガント（公式風の横棒タイムライン） */
+    .gantt { display: flex; flex-direction: column; gap: 6px; }
+    .gantt-row { display: flex; align-items: center; gap: 8px; }
+    .gantt-row .search-detail-thumb { width: 34px; height: 34px; margin: 0; flex-shrink: 0; }
+    .gantt-track { position: relative; flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+    .gantt-lane { position: relative; height: 11px; background: var(--bg); border-radius: 3px; }
+    .gantt-bar { position: absolute; top: 0; height: 100%; border-radius: 3px; min-width: 2px; }
+    .gantt-bar.gantt-ex, .gantt-bar.gantt-ov { z-index: 1; }
+    .gantt-bar.gantt-f, .gantt-bar.gantt-s, .gantt-bar.gantt-e, .gantt-bar.gantt-ov-on { z-index: 2; }
+    /* 帯・凡例スウォッチ共通の色 */
+    .gantt-ex { background: #5a6b7a; }
+    .gantt-f { background: #ff5722; }
+    .gantt-s { background: #2196f3; }
+    .gantt-e { background: #4caf50; }
+    .gantt-ov { background: rgba(255,255,255,0.18); border: 1px solid #cfd8e0; }
+    .gantt-ov-on { background: #eef2f5; }
+    /* 発動タイミングの菱形（覚醒・OL）。色は .gantt-{f,s,e,ov-on} を流用 */
+    .gantt-diamond { position: absolute; top: 50%; width: 9px; height: 9px; transform: translate(-50%, -50%) rotate(45deg); border-radius: 1px; z-index: 3; box-shadow: 0 0 0 1px rgba(0,0,0,0.35); }
+    .gantt-death { position: absolute; top: 50%; transform: translate(-50%, -50%); color: var(--terrible); font-weight: 800; font-size: 0.9em; z-index: 3; text-shadow: 0 0 2px var(--bg); pointer-events: none; }
+    .gantt-axis { position: relative; height: 14px; margin-left: 42px; margin-top: 2px; }
+    .gantt-tick { position: absolute; transform: translateX(-50%); color: var(--muted); font-size: 0.6em; font-variant-numeric: tabular-nums; white-space: nowrap; }
+    .gantt-legend { display: flex; flex-wrap: wrap; gap: 8px 12px; margin-top: 10px; font-size: 0.75em; color: var(--muted); }
+    .gantt-legend-item { display: inline-flex; align-items: center; gap: 5px; }
+    .gantt-legend-break { flex-basis: 100%; height: 0; }
+    .gantt-legend-swatch { width: 16px; height: 10px; border-radius: 2px; flex-shrink: 0; }
+    /* 発動系（菱形）は凡例も菱形で示す */
+    .gantt-legend-swatch.gantt-f, .gantt-legend-swatch.gantt-s, .gantt-legend-swatch.gantt-e, .gantt-legend-swatch.gantt-ov-on { width: 10px; height: 10px; transform: rotate(45deg); border-radius: 1px; }
+    .gantt-legend-swatch.gantt-death { position: static; transform: none; width: 16px; height: 10px; background: none; border: none; display: inline-flex; align-items: center; justify-content: center; line-height: 1; color: var(--terrible); font-weight: 800; text-shadow: none; }
+    .gantt-legend-swatch.gantt-death::before { content: '✕'; display: block; }
 
     @media (max-width: 720px) {
       .kpi-grid { grid-template-columns: repeat(2, 1fr); }
@@ -476,7 +570,9 @@
       .period-custom-range { flex-direction: column; }
       .period-custom { min-width: 0; }
       .search-form { grid-template-columns: 1fr; }
-      .search-result-head { align-items: flex-start; }
+      /* 狭幅では1行維持のため「検索結果」ラベルを省きカウントのみ表示 */
+      .search-result-label { display: none; }
+      .search-pagesize .panel-select-trigger { padding: 6px 8px; }
     }
   </style>
 </head>

--- a/static/index.html
+++ b/static/index.html
@@ -362,11 +362,11 @@
     .search-form { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; }
     .search-field { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
     .search-label { margin: 0; color: var(--muted); font-size: 0.8em; }
-    .search-select, .search-num, .search-date {
+    .search-select, .search-num, .search-date, .search-text {
       width: 100%; padding: 9px 10px; border: 1px solid var(--line); border-radius: 8px;
       background: var(--bg); color: var(--text); font-size: 0.9em; color-scheme: dark;
     }
-    .search-select:focus, .search-num:focus, .search-date:focus { outline: none; border-color: var(--accent); }
+    .search-select:focus, .search-num:focus, .search-date:focus, .search-text:focus { outline: none; border-color: var(--accent); }
     .search-range { display: flex; align-items: center; gap: 8px; min-width: 0; }
     .search-range .search-num, .search-range .search-date { flex: 1; min-width: 0; }
     .search-range-sep { color: var(--muted); font-size: 0.85em; flex-shrink: 0; }

--- a/static/lib/format.js
+++ b/static/lib/format.js
@@ -55,8 +55,14 @@ export function colorDE(n, d) {
 
 export function colorDmgGiven(n) { return colorVal(n, 1100, 900, 900, 700, true, 0); }
 export function colorDmgTaken(n) { return colorVal(n, 700, 800, 800, 900, false, 0); }
-export function colorKills(n) { return colorVal(n, 1.8, 1.5, 1.5, 1.0, true, 2); }
-export function colorDeaths(n) { return colorVal(n, 1.0, 1.5, 1.5, 2.5, false, 2); }
+// 撃墜/被撃墜のしきい値[great,good,bad,terrible]。平均用(小数2桁)と単発試合用(整数)で共有する。
+var KILLS_T = [1.8, 1.5, 1.5, 1.0];
+var DEATHS_T = [1.0, 1.5, 1.5, 2.5];
+export function colorKills(n) { return colorVal(n, KILLS_T[0], KILLS_T[1], KILLS_T[2], KILLS_T[3], true, 2); }
+export function colorDeaths(n) { return colorVal(n, DEATHS_T[0], DEATHS_T[1], DEATHS_T[2], DEATHS_T[3], false, 2); }
+// 整数表示版（単発試合のスコア表など。色分けは同じ、小数点なし）
+export function colorKillsInt(n) { return colorVal(n, KILLS_T[0], KILLS_T[1], KILLS_T[2], KILLS_T[3], true, 0); }
+export function colorDeathsInt(n) { return colorVal(n, DEATHS_T[0], DEATHS_T[1], DEATHS_T[2], DEATHS_T[3], false, 0); }
 export function colorKD(n) { return colorVal(n, 1.5, 1.0, 1.0, 0.6, true, 2); }
 export function colorExDmg(n) { return colorVal(n, 200, 160, 160, 100, true, 0); }
 export function colorBursts(n) { return colorVal(n, 2.0, 1.5, 1.5, 1.0, true, 2); }


### PR DESCRIPTION
## 概要

#295 の試合検索機能を実装しました。ハンバーガーメニューの「試合検索（coming soon）」を有効化し、#293 で導入した IndexedDB キャッシュの全試合を対象に、条件指定で検索・閲覧できる専用ビューを追加します。

分析レポートでは集計結果しか見られませんでしたが、これにより「あの試合どうだったっけ」「この機体で負けた試合を振り返りたい」といった個別試合へのアクセスが可能になります。

## 対応したこと（イシューのチェックリスト）

- [x] 検索UIの設計・実装（フィルタフォーム + 結果一覧）
- [x] 検索条件: 日付範囲 / 使用機体 / 相方機体 / 敵機体 / 勝敗 / ダメージ範囲（与・被）/ 撃墜数・被撃墜数
- [x] 検索結果の一覧表示（日付・機体・勝敗・スコア・撃墜/被撃墜・与被ダメージ）
- [x] 個別試合の詳細表示（自分/相方のスコア比較 + 被撃墜・覚醒のタイムライン）
- [x] ソート機能（日付・与/被ダメージ・撃墜数・被撃墜数・EXダメージ・スコア、昇順/降順）
- [x] ページネーション（20件/ページ）

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `static/analysis/search.js` (新規) | 機体名一覧の集計・条件絞り込み・並べ替えの純粋関数 |
| `static/components/search.js` (新規) | `SearchView`（フィルタフォーム＋結果一覧＋詳細モーダル） |
| `static/__tests__/search.test.js` (新規) | 絞り込み・並べ替え・集計の単体テスト（21ケース） |
| `static/app.js` | `Report` にレポート/検索のビュー切替を追加し、メニューから遷移。`allMatches` を共有 |
| `static/index.html` | 検索UI用スタイル（ダークテーマ・レスポンシブ対応） |
| `CLAUDE.md` | 新規ファイルの説明を追記 |

## 設計方針

既存フロントエンドの流儀に合わせています。

- 検索ロジックは `analysis/search.js` に純粋関数として分離し単体テスト可能に（`stats.js` と同じ方針）
- UI は htm/Preact、CSP 準拠で外部モジュール化、CSS 変数によるダークテーマとレスポンシブ対応
- 既存の `loadMatchesFromDB` で読み込み済みの全試合を共有し、メモリ上でフィルタ（レポート集計と同じ方式）

## 動作確認

- `make test-js`: 全97件パス（新規21件を含む）
- Chromium で実描画を確認: 絞り込みの AND 動作（例 57→38→10件）、ソート、ページネーション、詳細モーダルのタイムライン表示、Esc/背景クリックでの閉じる操作 — コンソールエラーなし

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pzWFHASzKXYpx18u15HyV

---
_Generated by [Claude Code](https://claude.ai/code/session_014pzWFHASzKXYpx18u15HyV)_