### PR TITLE
fix: キャッシュ表示時にログイン画面を隠す (#364)

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1536,18 +1536,25 @@ if (rememberInfoBtn && rememberModal) {
     hasSession = !!localStorage.getItem('catalyzer_has_session');
   } catch (e) {}
 
+  var renderedFromCache = false;
   if (cachedUserKey) {
     try {
       var cachedMatches = await loadMatchesFromDB(cachedUserKey);
       if (cachedMatches && cachedMatches.length > 0) {
         renderReport({ matches: cachedMatches }, cachedUserKey);
+        renderedFromCache = true;
       }
     } catch (e) {}
   }
 
+  // キャッシュからレポートを表示したらログイン画面を隠す。
+  // セッション有無に関わらず、レポートの上にログイン画面が残るのを防ぐ
+  // （ログインが必要な場合は再分析ボタン経由で reAnalyze が再表示する）。
+  if (renderedFromCache && loginForm) loginForm.style.display = 'none';
+
   if (hasSession) {
     if (loginForm) loginForm.style.display = 'none';
-    var hasLocalData = cachedUserKey && document.getElementById('report').children.length > 0;
+    var hasLocalData = renderedFromCache;
 
     fetch('/session').then(function (r) { return r.json(); }).then(function (data) {
       if (!data.valid) {


### PR DESCRIPTION
## 概要

issue #364「速報のキャッシュがある時はログイン画面の表示いる？」への対応。キャッシュはあるがセッションが無い状態で、レポートの上にログイン画面が残る問題を修正する。

Closes #364

## 問題

ページロード時の `initSession()`（`static/app.js`）は、IndexedDBにキャッシュがあれば `renderReport()` でレポートを描画する。しかし `loginForm` を隠すのは `catalyzer_has_session` が真のときだけだった。

そのため **キャッシュはあるがセッションが無い** 場合、レポートが描画されてもログイン画面が上に残り、「ログイン画面の下に速報レポートが表示される」状態になっていた。

## 変更内容

`static/app.js` の `initSession()`:

- キャッシュからレポートを描画したかを `renderedFromCache` フラグで追跡
- 描画した場合はセッション有無に関わらず `loginForm` を非表示に
- `hasLocalData` の判定を DOM子要素数チェックから `renderedFromCache` に統一（等価かつ明快）

ログインが必要な場面（再分析でセッション切れ等）は既存の `reAnalyze()` がログイン画面を再表示するため、動線は維持される。

## 検証

- `node --test 'static/__tests__/*.test.js'` → 76 pass / 0 fail（全緑）
- Go・index.html には変更なし（純粋なフロントの表示ロジック修正）