### PR TITLE
fix: セッション失効時にログイン画面の下に残るレポートをクリアする (#366)

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1488,8 +1488,14 @@ if (rememberInfoBtn && rememberModal) {
 
     fetch('/session').then(function (r) { return r.json(); }).then(function (data) {
       if (!data.valid) {
+        // セッション失効時は、キャッシュから描画済みのレポートを隠さないと
+        // ログイン画面の下に古いレポートが残る（reanalyzeWithSession の401経路と同じ後始末）。
         localStorage.removeItem('catalyzer_has_session');
+        var rep = document.getElementById('report');
+        if (rep) { render(null, rep); rep.style.display = 'none'; }
         if (loginForm) loginForm.style.display = 'block';
+        var t = document.getElementById('pageTitle');
+        if (t) t.style.display = '';
       } else if (!hasLocalData) {
         reanalyzeWithSession();
       }


### PR DESCRIPTION
## 概要

セッション失効時にログイン画面の下に古いレポートが残る問題（#366）を修正。#364/PR #365 と同種のUIバグの別経路。

## 問題

`static/app.js` の `initSession()` で以下が揃うと、ログイン画面の下に古いレポートが表示されていた：

1. `catalyzer_has_session` あり（`hasSession=true`）
2. IndexedDB キャッシュがあり `renderReport()` で描画済み
3. `/session` がサーバ側で `valid: false` を返す（セッション失効・サーバ側失効）

該当分岐（`!data.valid`）が `loginForm` を `block` 表示するだけで、描画済みの `#report` を隠さない・クリアしないのが原因。

## 修正

`reanalyzeWithSession()` の401経路（`app.js:966-971`）と同じ後始末を `!data.valid` 分岐に追加：

- `render(null, rep); rep.style.display = 'none'`（レポートをクリア・非表示）
- `pageTitle`（ロゴ）を復帰

## 検証

- `make test-js` → 113 pass / 0 fail
- Go 側の変更なし（フロントのみ）

## 関連

- Closes #366
- 調査中に別問題（Firestore の浮いたセッションの TTL 未設定）を発見し #368 として起票済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
