### PR TITLE
feat: Firestoreの浮いたセッションをTTLで自動削除する (#368)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
   - `SCRAPER_MAX_DETAIL`: 詳細取得件数の上限。0または未設定で無制限（既定 0）
   - 例（バースト無効・全件低レート）: `SCRAPER_BURST_COUNT=0 SCRAPER_THROTTLE_DELAY_MS=1200`
 - 速報レポートは初回 `prelimFirstBatchSize`(5)試合、以降 `prelimBatchSize`(20)試合ごとに段階更新される（`onBatchReady`→`PreliminaryVersion++`、フロントがポーリングで再描画）
-- セッション保持機能: `SESSION_ENCRYPTION_KEY`（64文字hex、AES-256-GCM鍵）設定時に有効化。バンナムCookieJarを暗号化してFirestoreに保存し、次回アクセス時にパスワード不要で再分析。catalyzer_session Cookie（HttpOnly/Secure/SameSite=Strict、30日有効）でセッション識別。試合データはIndexedDBにキャッシュし即時表示
+- セッション保持機能: `SESSION_ENCRYPTION_KEY`（64文字hex、AES-256-GCM鍵）設定時に有効化。バンナムCookieJarを暗号化してFirestoreに保存し、次回アクセス時にパスワード不要で再分析。catalyzer_session Cookie（HttpOnly/Secure/SameSite=Strict、30日有効）でセッション識別。試合データはIndexedDBにキャッシュし即時表示。Firestoreのセッションドキュメントは `expire_at`（保存時+30日）フィールドのTTLポリシー（`infra/shared/firestore.ts`）で自動削除され、Cookie失効後に浮いたセッションが残らない
 - 試合の一意キーは詳細ページURL由来の `MatchID`（`model.DatedScore.GroupKey()` に一元化）。MatchID未設定のlegacyデータは分精度日時にフォールバックする（同一分に複数試合があっても区別できるようにするための設計。#358）
 
 ## Goコーディング規約

--- a/infra/shared/firestore.ts
+++ b/infra/shared/firestore.ts
@@ -11,3 +11,22 @@ export const firestoreDb = new gcp.firestore.Database(
   },
   { dependsOn: services }
 );
+
+// sessions コレクションの TTL ポリシー。
+// アプリが SaveSession 時に書く expire_at（失効時刻 = 保存時 + 30日）を対象にし、
+// 到来後 GCP が浮いたセッションドキュメントを自動削除する（通常24時間以内）。
+// Cookie 失効後もログアウト・再分析が起きず残り続けるドキュメントの掃除が目的（issue #368）。
+// ttlConfig は空オブジェクトで有効化（フィールド値そのものが削除時刻）。
+// indexConfig: {} で single-field インデックスを無効化し、TTL タイムスタンプ列の
+// ホットスポットを回避する（Firestore 公式推奨。expire_at で検索しないため実害なし）。
+export const sessionTtlField = new gcp.firestore.Field(
+  "session-expire-at-ttl",
+  {
+    database: firestoreDb.name,
+    collection: "sessions",
+    field: "expire_at",
+    ttlConfig: {},
+    indexConfig: {},
+  },
+  { dependsOn: [firestoreDb] }
+);

--- a/internal/firestore/session.go
+++ b/internal/firestore/session.go
@@ -5,11 +5,18 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"time"
 
 	"cloud.google.com/go/firestore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// sessionTTL はセッションドキュメントの有効期間。Cookie の MaxAge（server.sessionMaxAge = 30日）
+// と揃える。SaveSession が expire_at に now+sessionTTL を書き、Firestore の TTL ポリシー
+// （infra/shared/firestore.ts の sessions.expire_at）が期限到来後に浮いたドキュメントを
+// 自動削除する。TTL の削除時刻はフィールド値そのものなので ServerTimestamp は使えない。
+const sessionTTL = 30 * 24 * time.Hour
 
 // SaveSession は暗号化されたCookieJarをFirestoreに保存する。
 // token はセッション識別子（ランダムUUID）、userKey はユーザー識別子。
@@ -27,6 +34,7 @@ func SaveSession(token, userKey string, encryptedJar []byte) error {
 		"user_key":   userKey,
 		"jar":        base64.StdEncoding.EncodeToString(encryptedJar),
 		"updated_at": firestore.ServerTimestamp,
+		"expire_at":  time.Now().Add(sessionTTL),
 	})
 	if err != nil {
 		return fmt.Errorf("save session: %w", err)


### PR DESCRIPTION
## 概要

Firestore の浮いたセッションドキュメントを TTL で自動削除する（#368）。

## 問題

`sessions` コレクションには TTL/有効期限が無く、明示的な `DeleteSession`（ログアウト・鍵ローテーション・認証失敗）でしか削除されなかった。`catalyzer_session` Cookie は30日で失効するが、ユーザーがログアウトも再分析もせず放置すると、ブラウザからトークンが消えても Firestore の `sessions/{token}` ドキュメントが**永久に残り続けていた**。

## 修正

- **アプリ側** (`internal/firestore/session.go`): `SaveSession` が `expire_at`（= 保存時 + 30日、Cookie の `sessionMaxAge` と同値）を書く。`SaveSession` は remember ログイン時と再分析時（`Remember=true`）の両方で呼ばれるため、アクティブ利用中は失効時刻が更新される。
- **インフラ** (`infra/shared/firestore.ts`): `gcp.firestore.Field` で `sessions.expire_at` に TTL ポリシー（`ttlConfig: {}`）を定義。到来後 GCP が自動削除（通常24時間以内）。ドキュメントごと消えるため暗号化 jar・user_key も確実に削除される。`indexConfig: {}` で TTL タイムスタンプ列のインデックスを無効化（ホットスポット回避、Firestore 公式推奨）。

## 設計上の要点（調査で確定）

- Native mode の TTL 削除時刻は**フィールド値そのもの**（オフセット加算なし）→ アプリ側で `now+30日` を書く方式が正解。
- `firestore.ServerTimestamp` は未来時刻を指定できない → 通常の `time.Time` を書く。
- `ttlConfig.expirationOffset` は Enterprise edition 専用のため使わない。

## 検証

- `go build ./cmd/server` → ok
- `go vet ./internal/...` → ok
- `go test -race ./internal/...` → 全 pass
- `gofmt -l` → 差分なし
- `golangci-lint` はローカル未インストールのため CI で確認
- **インフラ**: Pulumi はローカル未導入のため `infra-ci.yml` の shared preview が検証 oracle

## ⚠️ マージ後の手動作業（重要）

`deploy.yml` は `infra/app` のみ `pulumi up` する。**`infra/shared` の TTL Field は自動適用されない**ため、マージ後に手動で反映が必要:

```
make pulumi-shared-shell
# シェル内で: pulumi up
```

これを実行するまで TTL ポリシーは有効化されない（既存の浮いたセッションも削除されない）。

## 既知の制限

- 既存のセッションドキュメント（`expire_at` を持たない）は、次回の再分析で `expire_at` が書かれるまで TTL 対象にならない。過去分の一括削除はスコープ外。

## 関連

- Closes #368
- 発見元: #366（セッション失効時のUIバグ、PR #369）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
