### PR TITLE
feat: MatchDataにスキーマバージョンを持たせ全件キャッシュ再構築を可能に (#362)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Go HTTPサーバーによる**非同期ジョブパイプライン**（最大同
 フロントエンドがIndexedDBにmatchesを保存し、JS分析関数で統計を計算・表示
 ```
 
-**主要エンドポイント:** `POST /analyze`, `GET /status/{id}`, `GET /result/{id}`, `POST /cancel/{id}`（実行中スクレイピングの中断。ログアウト時に使用）, `GET /matches`, `GET /tag-partners`, `GET /session`, `DELETE /session`, `POST /reanalyze`, `GET /health`, `GET /`（静的UI）
+**主要エンドポイント:** `POST /analyze`, `GET /status/{id}`, `GET /result/{id}`, `POST /cancel/{id}`（実行中スクレイピングの中断。ログアウト時に使用）, `GET /matches`, `GET /schema-version`（MatchDataの現行スキーマバージョン。Firestore未アクセス。フロントのIndexedDBキャッシュ再構築判定に使用）, `GET /tag-partners`, `GET /session`, `DELETE /session`, `POST /reanalyze`, `GET /health`, `GET /`（静的UI）
 
 ## コード構成
 

--- a/internal/pipeline/matchdata.go
+++ b/internal/pipeline/matchdata.go
@@ -17,6 +17,11 @@ type ActionJSON struct {
 	ActionEndSec   float64 `json:"action_end_sec"`
 }
 
+// MatchDataSchemaVersion はMatchDataの構造バージョン。
+// MatchDataにフィールドを追加/変更しクライアントの全件キャッシュ再構築が
+// 必要になったら +1 する（フロントは /schema-version 経由で自動追従する）。
+const MatchDataSchemaVersion = 1
+
 // MatchData はフロントエンド向けの試合データ（プレイヤー視点）
 type MatchData struct {
 	Date             string `json:"date"`

--- a/internal/server/schema_version_test.go
+++ b/internal/server/schema_version_test.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/yuki9431/catalyzer/internal/pipeline"
+)
+
+func TestHandleSchemaVersion(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/schema-version", nil)
+	rec := httptest.NewRecorder()
+	handleSchemaVersion(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var body struct {
+		SchemaVersion int `json:"schema_version"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	if body.SchemaVersion != pipeline.MatchDataSchemaVersion {
+		t.Errorf("expected schema_version=%d, got %d", pipeline.MatchDataSchemaVersion, body.SchemaVersion)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -223,6 +223,9 @@ func StartServer() {
 		handleMatches(w, r)
 	})
 
+	// GET /schema-version → 現行MatchDataスキーマバージョン（Firestore未アクセス）
+	http.HandleFunc("/schema-version", handleSchemaVersion)
+
 	// GET /ms-list → MSリスト（機体名→画像URL）を配信。
 	// フロントの試合検索一覧が機体名から公式CDNのサムネイル画像を解決するために使う。
 	// 起動時に一度だけ読み込む（静的データ。失敗時は空を返し、フロントは機体名テキストにフォールバック）。
@@ -312,10 +315,11 @@ func handleResult(w http.ResponseWriter, r *http.Request, id string) {
 	}
 
 	resp := matchesResponse{
-		Matches:      json.RawMessage(snap.Report),
-		UserKey:      snap.UserKey,
-		Partial:      snap.PartialData,
-		SessionSaved: sessionSaved,
+		Matches:       json.RawMessage(snap.Report),
+		UserKey:       snap.UserKey,
+		Partial:       snap.PartialData,
+		SessionSaved:  sessionSaved,
+		SchemaVersion: pipeline.MatchDataSchemaVersion,
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -376,8 +380,17 @@ func handleMatches(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sendJSON(w, http.StatusOK, map[string]interface{}{
-		"matches": matches,
-		"total":   len(matches),
+		"matches":        matches,
+		"total":          len(matches),
+		"schema_version": pipeline.MatchDataSchemaVersion,
+	})
+}
+
+// handleSchemaVersion はFirestoreにアクセスせず現行のMatchDataスキーマバージョンを返す。
+// フロントが起動時にIndexedDBキャッシュとの不一致を軽量に検知するために使う。
+func handleSchemaVersion(w http.ResponseWriter, r *http.Request) {
+	sendJSON(w, http.StatusOK, map[string]interface{}{
+		"schema_version": pipeline.MatchDataSchemaVersion,
 	})
 }
 
@@ -400,20 +413,22 @@ func sendJSON(w http.ResponseWriter, code int, data interface{}) {
 }
 
 type matchesResponse struct {
-	Matches      json.RawMessage `json:"matches"`
-	Status       string          `json:"status,omitempty"`
-	Preliminary  bool            `json:"preliminary,omitempty"`
-	Partial      bool            `json:"partial,omitempty"`
-	UserKey      string          `json:"user_key,omitempty"`
-	SessionSaved bool            `json:"session_saved,omitempty"`
+	Matches       json.RawMessage `json:"matches"`
+	Status        string          `json:"status,omitempty"`
+	Preliminary   bool            `json:"preliminary,omitempty"`
+	Partial       bool            `json:"partial,omitempty"`
+	UserKey       string          `json:"user_key,omitempty"`
+	SessionSaved  bool            `json:"session_saved,omitempty"`
+	SchemaVersion int             `json:"schema_version"`
 }
 
 func sendMatchesResponse(w http.ResponseWriter, code int, matchesJSON, status, userKey string, preliminary bool) {
 	resp := matchesResponse{
-		Matches:     json.RawMessage(matchesJSON),
-		Status:      status,
-		Preliminary: preliminary,
-		UserKey:     userKey,
+		Matches:       json.RawMessage(matchesJSON),
+		Status:        status,
+		Preliminary:   preliminary,
+		UserKey:       userKey,
+		SchemaVersion: pipeline.MatchDataSchemaVersion,
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)

--- a/static/__tests__/db.test.js
+++ b/static/__tests__/db.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { matchRecordId } from '../lib/db.js';
+import { matchRecordId, schemaMismatch } from '../lib/db.js';
 
 describe('matchRecordId', function () {
   it('produces distinct ids for same date but different match_id (#358 regression)', function () {
@@ -17,5 +17,27 @@ describe('matchRecordId', function () {
   it('is stable for the same input (idempotent)', function () {
     var m = { date: '2026-07-04 21:30', match_id: 'match-a' };
     assert.equal(matchRecordId('user1', m), matchRecordId('user1', m));
+  });
+});
+
+describe('schemaMismatch', function () {
+  it('treats missing cached version as mismatch (undefined,1)', function () {
+    assert.equal(schemaMismatch(undefined, 1), true);
+  });
+
+  it('matches when versions are equal (1,1)', function () {
+    assert.equal(schemaMismatch(1, 1), false);
+  });
+
+  it('mismatches when cached is older (1,2)', function () {
+    assert.equal(schemaMismatch(1, 2), true);
+  });
+
+  it('mismatches when cached is newer (2,1)', function () {
+    assert.equal(schemaMismatch(2, 1), true);
+  });
+
+  it('treats unresolvable server version as no mismatch (1,null)', function () {
+    assert.equal(schemaMismatch(1, null), false);
   });
 });

--- a/static/app.js
+++ b/static/app.js
@@ -11,7 +11,7 @@ import {
   clampMetric,
 } from './analysis/stats.js';
 import {
-  loadMatchesFromDB, saveMatchesToDB,
+  loadMatchesFromDB, saveMatchesToDB, replaceMatchesForUser, schemaMismatch,
 } from './lib/db.js';
 import {
   esc, pct, num, colorPct, colorDE,
@@ -238,7 +238,7 @@ function ShareArea({ shareData }) {
 
 // --- Hamburger menu & topbar controls ---
 
-function HamburgerMenu({ isOpen, onClose, shareData, onLogout, currentView, onNavigate }) {
+function HamburgerMenu({ isOpen, onClose, shareData, onLogout, currentView, onNavigate, onRebuildCache }) {
   useEffect(function () {
     if (isOpen) {
       document.body.style.overflow = 'hidden';
@@ -272,6 +272,7 @@ function HamburgerMenu({ isOpen, onClose, shareData, onLogout, currentView, onNa
           <${ShareArea} shareData=${shareData} />
         </div>
         <div class="menu-divider" />
+        ${onRebuildCache && html`<button class="menu-item" onClick=${function () { onClose(); onRebuildCache(); }}><span class="menu-icon">🔄</span>データを再取得</button>`}
         <button class="menu-item" style="color: var(--bad)" onClick=${function () { onClose(); onLogout(); }}>ログアウト</button>
       </div>
     </div>
@@ -906,7 +907,7 @@ async function reanalyzeWithSession() {
         if (activeJobId !== jobId) return;
         if (prelimData.matches && prelimData.preliminary) {
           if (prelimData.user_key) {
-            saveMatchesToDB(prelimData.user_key, prelimData.matches);
+            saveMatchesToDB(prelimData.user_key, prelimData.matches, prelimData.schema_version);
           }
           renderReport({ matches: prelimData.matches }, prelimData.user_key);
           statusText.textContent = STATUS_MESSAGES.refreshing;
@@ -933,7 +934,7 @@ async function reanalyzeWithSession() {
         if (activeJobId !== jobId) return;
         if (resultData.error) throw new Error(resultData.error);
         if (resultData.user_key && resultData.matches) {
-          await saveMatchesToDB(resultData.user_key, resultData.matches);
+          await saveMatchesToDB(resultData.user_key, resultData.matches, resultData.schema_version);
         }
         renderReport({ matches: resultData.matches }, resultData.user_key);
         break;
@@ -1145,7 +1146,7 @@ function Report({ data, userKey }) {
         <button class="topbar-refresh" onClick=${reAnalyze}>再分析</button>
       </div>
       <${HamburgerMenu} isOpen=${menuOpen} onClose=${function () { setMenuOpen(false); }}
-        shareData=${shareData} onLogout=${logout} currentView=${view} onNavigate=${navigate} />
+        shareData=${shareData} onLogout=${logout} currentView=${view} onNavigate=${navigate} onRebuildCache=${rebuildCache} />
       <${SearchView} matches=${allMatches || []} msImages=${msImages || {}} />
     </div>`;
   }
@@ -1187,7 +1188,7 @@ function Report({ data, userKey }) {
 
     <${HamburgerMenu} isOpen=${menuOpen} onClose=${function () { setMenuOpen(false); }}
       shareData=${shareData}
-      onLogout=${logout} currentView=${view} onNavigate=${navigate} />
+      onLogout=${logout} currentView=${view} onNavigate=${navigate} onRebuildCache=${rebuildCache} />
 
     <${KpiGrid} stats=${fePd.basic_stats} />
 
@@ -1220,7 +1221,7 @@ function Skeleton() {
       </div>
     </div>
     <${HamburgerMenu} isOpen=${menuOpen} onClose=${function () { setMenuOpen(false); }}
-      shareData=${null} onLogout=${logout} />
+      shareData=${null} onLogout=${logout} onRebuildCache=${rebuildCache} />
     <div class="kpi-grid">
       ${[0, 1, 2, 3, 4, 5].map(function () {
         return html`<div class="kpi">${bar('50%', 12, 12)}${bar('70%', 28)}</div>`;
@@ -1253,6 +1254,28 @@ function renderReport(data, userKey) {
 
   try {
     if (userKey) localStorage.setItem('catalyzer_user_key', userKey);
+  } catch (e) {}
+}
+
+// IndexedDBキャッシュをサーバー側の全件データで丸ごと置き換える（スクレイピング無し）。
+// スキーマバージョン不一致の自動検知、またはHamburgerMenuの「データを再取得」導線から呼ばれる。
+async function rebuildCacheFromServer(userKey) {
+  var res = await fetch('/matches?user_key=' + encodeURIComponent(userKey));
+  var data = await res.json();
+  // 空配列(0件)はサーバー側の異常応答の可能性があるため再構築せず既存キャッシュを温存する
+  if (!res.ok || !data.matches || !data.matches.length) return;
+  await replaceMatchesForUser(userKey, data.matches, data.schema_version);
+  renderReport({ matches: data.matches }, userKey);
+}
+
+// HamburgerMenuの「データを再取得」ボタンから呼ばれる明示操作版。確認ダイアログを挟む。
+async function rebuildCache() {
+  var userKey = null;
+  try { userKey = localStorage.getItem('catalyzer_user_key'); } catch (e) {}
+  if (!userKey) return;
+  if (!window.confirm('試合データをサーバーから全件取得し直します。よろしいですか?')) return;
+  try {
+    await rebuildCacheFromServer(userKey);
   } catch (e) {}
 }
 
@@ -1363,7 +1386,7 @@ async function analyze() {
         if (activeJobId !== jobId) return;
         if (prelimData.matches && prelimData.preliminary) {
           if (prelimData.user_key) {
-            saveMatchesToDB(prelimData.user_key, prelimData.matches);
+            saveMatchesToDB(prelimData.user_key, prelimData.matches, prelimData.schema_version);
           }
           renderReport({ matches: prelimData.matches }, prelimData.user_key);
           renderedReal = true;
@@ -1389,7 +1412,7 @@ async function analyze() {
         }
 
         if (resultData.user_key && resultData.matches) {
-          await saveMatchesToDB(resultData.user_key, resultData.matches);
+          await saveMatchesToDB(resultData.user_key, resultData.matches, resultData.schema_version);
         }
         renderReport({ matches: resultData.matches }, resultData.user_key);
         renderedReal = true;
@@ -1475,6 +1498,20 @@ if (rememberInfoBtn && rememberModal) {
         renderedFromCache = true;
       }
     } catch (e) {}
+  }
+
+  // キャッシュのスキーマバージョンをサーバーの現行版と非ブロッキングで照合し、
+  // 不一致なら（Firestore再構築のみの）全件再取得でキャッシュを作り直す。
+  // 一致時は/matchesを叩かない。取得不能(サーバー未応答等)なら判定不能として何もしない。
+  if (renderedFromCache) {
+    fetch('/schema-version').then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (d) {
+        if (!d) return;
+        if (schemaMismatch(cachedMatches[0].schema_version, d.schema_version)) {
+          rebuildCacheFromServer(cachedUserKey).catch(function () {});
+        }
+      })
+      .catch(function () {});
   }
 
   // キャッシュからレポートを表示したらログイン画面を隠す。

--- a/static/lib/db.js
+++ b/static/lib/db.js
@@ -31,7 +31,7 @@ export function matchRecordId(userKey, match) {
   return userKey + '_' + (match.match_id || match.date);
 }
 
-export function saveMatchesToDB(userKey, matches) {
+export function saveMatchesToDB(userKey, matches, schemaVersion) {
   return openMatchDB().then(function (db) {
     return new Promise(function (resolve, reject) {
       var tx = db.transaction(MATCH_STORE, 'readwrite');
@@ -39,7 +39,8 @@ export function saveMatchesToDB(userKey, matches) {
       for (var i = 0; i < matches.length; i++) {
         var m = Object.assign({}, matches[i], {
           id: matchRecordId(userKey, matches[i]),
-          user_key: userKey
+          user_key: userKey,
+          schema_version: schemaVersion
         });
         store.put(m);
       }
@@ -47,6 +48,45 @@ export function saveMatchesToDB(userKey, matches) {
       tx.onerror = function (e) { reject(e.target.error); };
     });
   });
+}
+
+// replaceMatchesForUser は指定ユーザーの既存レコードを1トランザクションで全削除してから
+// 新規matchesをputする（スキーマ不一致時の全件再構築で孤児レコードを残さないため）。
+export function replaceMatchesForUser(userKey, matches, schemaVersion) {
+  return openMatchDB().then(function (db) {
+    return new Promise(function (resolve, reject) {
+      var tx = db.transaction(MATCH_STORE, 'readwrite');
+      var store = tx.objectStore(MATCH_STORE);
+      var index = store.index('userKey');
+      var cursorReq = index.openCursor(IDBKeyRange.only(userKey));
+      cursorReq.onsuccess = function (e) {
+        var cursor = e.target.result;
+        if (cursor) {
+          cursor.delete();
+          cursor.continue();
+          return;
+        }
+        for (var i = 0; i < matches.length; i++) {
+          var m = Object.assign({}, matches[i], {
+            id: matchRecordId(userKey, matches[i]),
+            user_key: userKey,
+            schema_version: schemaVersion
+          });
+          store.put(m);
+        }
+      };
+      cursorReq.onerror = function (e) { reject(e.target.error); };
+      tx.oncomplete = function () { resolve(); };
+      tx.onerror = function (e) { reject(e.target.error); };
+    });
+  });
+}
+
+// schemaMismatch はIndexedDBキャッシュ済みバージョンとサーバー側バージョンを比較する純粋関数。
+// serverVersionが取得できない(null/undefined)場合は判定不能として再構築しない。
+export function schemaMismatch(cachedVersion, serverVersion) {
+  if (serverVersion == null) return false;
+  return cachedVersion !== serverVersion;
 }
 
 export function loadMatchesFromDB(userKey) {


### PR DESCRIPTION
## 概要
Closes #362

`MatchData` のスキーマ更新（フィールド追加）が既存の IndexedDB キャッシュの**過去試合に反映されない**問題を解消する。相手タイムライン等の生データは Firestore の埋め込みタイムラインに既に存在するため、**再スクレイピング無しで `/matches` 全件再取得**すれば過去試合にも反映できる（読み取りコストを増やさない）。

## 方針
サーバの `pipeline.MatchDataSchemaVersion` を**単一の真実源**とし、全試合データ応答のエンベロープに `schema_version` を含める。フロントは起動時に **Firestore 非アクセスの `GET /schema-version`** で現行版を取得し、キャッシュのバージョンと不一致なら `/matches`（全件・スクレイピング無し）でキャッシュを作り直す。一致時は `/matches` を叩かない。フロントにバージョン数値をハードコードしないため Go/JS 定数のドリフトが構造的に起きない（フィールド追加時は Go 定数を +1 するだけ）。

## 変更点
- **pipeline** (`internal/pipeline/matchdata.go`): `MatchDataSchemaVersion = 1` 定数を追加
- **server** (`internal/server/server.go`): `/result`・速報・`/matches` 応答エンベロープに `schema_version`（`omitempty` なし）、新 `GET /schema-version`（Firestore 非アクセス）+ テスト
- **db.js** (`static/lib/db.js`): `replaceMatchesForUser`（1トランザクションで全削除→再構築、孤児レコード防止）/ 純粋関数 `schemaMismatch` を追加、`saveMatchesToDB` に版を刻印
- **app.js** (`static/app.js`): 起動時の非ブロッキング不一致検知→全件再構築、`HamburgerMenu` に明示的な「データを再取得」導線（confirm 付き）
- IndexedDB の `MATCH_DB_VERSION` は **2 のまま**（既存キャッシュ非破壊）
- `db.test.js` に `schemaMismatch` の純粋関数テスト（5ケース）、`CLAUDE.md` にエンドポイント追記

## 受け入れ条件
- [x] `MatchData` にスキーマバージョンを持たせ、フロントが不一致を検知できる
- [x] バージョン不一致 or 明示操作で全試合の `MatchData` を再取得し IndexedDB を再構築できる
- [x] フィールド追加（例: 相手タイムライン）が過去試合にも反映される（`GetMatchData` が Firestore 生データから再構築）
- [x] Firestore 読み取りが不必要に増えない（一致時は `/matches` を叩かない。起動時は Firestore 非アクセスの `/schema-version` のみ）

## 検証
- `go build ./cmd/server` ✅ / `go test -race ./internal/...` ✅ / `go vet ./...` ✅
- `gofmt -l .` 差分ゼロ ✅ / `golangci-lint run` 0 issues ✅（ローカル `CGO_ENABLED=0` で確認）
- `node --test 'static/__tests__/*.test.js'` ✅ 118 tests, 0 fail

## 残課題（スコープ外）
- IndexedDB 容量見積り（タイムライン込み全件保存時の実測・上限対策）は別 issue 化を推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)