### PR TITLE
fix: 試合検索カードがiOS Safariで横に溢れる不具合を修正

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -452,9 +452,12 @@
     /* 対戦カード: 自陣（自機＋相方）VS 敵陣（敵1＋敵2）を機体画像で並べる */
     /* 画像行: 自陣(自機+相方) VS 敵陣(敵1+敵2)。画像は枠内で伸縮し被らない */
     .search-item-battle { display: flex; align-items: center; gap: 10px; }
-    .search-ms-imgs { flex: 1; min-width: 0; display: flex; gap: 6px; }
+    .search-ms-imgs { flex: 1; min-width: 0; display: flex; gap: 6px; align-items: center; }
     .search-ms-imgs.enemy { justify-content: flex-end; }
-    .search-ms-thumb { flex: 0 1 74px; min-width: 0; width: auto; height: auto; aspect-ratio: 1 / 1; border-radius: 8px; border: 1px solid var(--line); object-fit: cover; background: var(--bg); }
+    /* 幅はフレックス配分(basis 0)で決め、intrinsicサイズを基準にしない。
+       iOS Safariは aspect-ratio + flex-basis:auto の img で intrinsic 幅を採用して縮まず、
+       カードから溢れてレイアウトが崩れる（#iphone15-ios18）。basis 0 + max-width で回避する。 */
+    .search-ms-thumb { flex: 1 1 0; min-width: 0; max-width: 74px; width: 100%; height: auto; aspect-ratio: 1 / 1; border-radius: 8px; border: 1px solid var(--line); object-fit: cover; background: var(--bg); }
     .search-ms-thumb-text { display: flex; align-items: center; justify-content: center; text-align: center; padding: 3px; font-size: 0.66em; line-height: 1.2; color: var(--muted); overflow: hidden; }
     /* 公式スプライト win_lose_vs.png(451x138) から VS 部分だけを background-position で切り出す */
     .search-item-vs { flex-shrink: 0; width: 54px; height: 44px;

--- a/static/index.html
+++ b/static/index.html
@@ -455,9 +455,9 @@
     .search-ms-imgs { flex: 1; min-width: 0; display: flex; gap: 6px; align-items: center; }
     .search-ms-imgs.enemy { justify-content: flex-end; }
     /* 幅はフレックス配分(basis 0)で決め、intrinsicサイズを基準にしない。
-       iOS Safariは aspect-ratio + flex-basis:auto の img で intrinsic 幅を採用して縮まず、
-       カードから溢れてレイアウトが崩れる（#iphone15-ios18）。basis 0 + max-width で回避する。 */
-    .search-ms-thumb { flex: 1 1 0; min-width: 0; max-width: 74px; width: 100%; height: auto; aspect-ratio: 1 / 1; border-radius: 8px; border: 1px solid var(--line); object-fit: cover; background: var(--bg); }
+       iOS18以前のSafariは aspect-ratio + flex-basis:74px の img で intrinsic 幅を採用して縮まず、
+       カードから溢れてレイアウトが崩れる（iOS26では修正済み）。basis 0 + max-width で回避する。 */
+    .search-ms-thumb { flex: 1 1 0; min-width: 0; max-width: 74px; height: auto; aspect-ratio: 1 / 1; border-radius: 8px; border: 1px solid var(--line); object-fit: cover; background: var(--bg); }
     .search-ms-thumb-text { display: flex; align-items: center; justify-content: center; text-align: center; padding: 3px; font-size: 0.66em; line-height: 1.2; color: var(--muted); overflow: hidden; }
     /* 公式スプライト win_lose_vs.png(451x138) から VS 部分だけを background-position で切り出す */
     .search-item-vs { flex-shrink: 0; width: 54px; height: 44px;


### PR DESCRIPTION
MS画像サムネイル(.search-ms-thumb)が flex-basis:74px + aspect-ratio:1/1
の組み合わせで、iOS Safari では intrinsic 幅を採用して縮まず、対戦カードが
ビューポート幅を超えてはみ出していた（敵機画像がカード外・画面右端に溢れる）。

フレックス配分(flex:1 1 0)で幅を決め intrinsic サイズを基準にしないよう変更し、
max-width で上限を、親の align-items:center で縦ストレッチを抑止して回避する。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UzgfzKC33uRa4PUof8pWyh