### PR TITLE
fix: iOS18で試合検索カードが崩れる不具合の修正 + アセットキャッシュ制御

### DIFF
--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -5,7 +5,7 @@ config:
   exvs-app:domain: stg.exvs-analyzer.com
   exvs-app:firestoreDatabase: exvs-analyzer
   exvs-app:image:
-    secure: v1:Iu9obXGv0HfiTDwb:WYMTFb2bj9ii5lW9pB3jgF4iCoXURJ+38v9b+j3qJe9l4lDI38Pvw+/kFsrp3Z/md3eroJkGvT2AqCuJICyDIQPDDR5dIPMo2gOACJ7/dMbTvaapCKAmoCy98Ysqs33Mg7NZtt38il0iFKm0jctyyZQZFGN6uA==
+    secure: v1:jrfjMWFRi0XmUnVT:cZhdW1dQmP55+8CUuZJ22fO6TCIoeLGWzU0OLDcCKBMdiwF2MacI1JirT0JmviUbE2oDZxI+Fkp2LIJJ5mOpGaw3Wkd+Ag7fXBeTt6YSl9YCeubSmnsM/S5DLYwM6ImrIS9mxtHY9pLWbLVhHiB61qV8uJ8e9g==
   exvs-app:maxInstances: "1"
   exvs-app:memory: 512Mi
   exvs-app:serviceName: stg-exvs-analyzer

--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -5,7 +5,7 @@ config:
   exvs-app:domain: stg.exvs-analyzer.com
   exvs-app:firestoreDatabase: exvs-analyzer
   exvs-app:image:
-    secure: v1:fiw69XFk+oJl9J5p:841iLq/gzxO2qF69bQAyTw8t/75kRWPGbuITQsEoYn6mrEDEpzReeiykxp6eqnHOfxT6lUnHjLXBFLK7QPf8IuV79rvl+Ka1yfy7P9941KLtNz0/zon4WfjvQj9OPm3KcrEUaA6wkWtVKyBFOCsUBJym7XRtow==
+    secure: v1:hySVyZoGvjkdyGGt:PLZpTVNoQKTT7ff0PZwoN9nQ4BE8QozL+Uo9dT/vDcTxT8fvuDwETNJlpGxrEeZ31tV2DHOQbkTOzAoZHUrP24fP0Bt5cjlIlxSW8mAB2hOkQGg+TIVGahplh1FSZwjCG+2/JKeQuXp0TH7KldBb6rrbrlo7Hg==
   exvs-app:maxInstances: "1"
   exvs-app:memory: 512Mi
   exvs-app:serviceName: stg-exvs-analyzer

--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -5,7 +5,7 @@ config:
   exvs-app:domain: stg.exvs-analyzer.com
   exvs-app:firestoreDatabase: exvs-analyzer
   exvs-app:image:
-    secure: v1:LslaisMjmCsneZyJ:LpMhi8IkNUFYIytfws+TjXPLjYtLBwZxvr0yamAlQVhxNZGaXza8uX8Qs9mFvEKZexLBWrenwbmPqNiET3tJzBnTIa2+BztMtdijfT8k3G1ISoMuD8naoHyPw5kln0Iujur0NZEqyZwfq0H/X1+7/y9Br1RqWg==
+    secure: v1:fiw69XFk+oJl9J5p:841iLq/gzxO2qF69bQAyTw8t/75kRWPGbuITQsEoYn6mrEDEpzReeiykxp6eqnHOfxT6lUnHjLXBFLK7QPf8IuV79rvl+Ka1yfy7P9941KLtNz0/zon4WfjvQj9OPm3KcrEUaA6wkWtVKyBFOCsUBJym7XRtow==
   exvs-app:maxInstances: "1"
   exvs-app:memory: 512Mi
   exvs-app:serviceName: stg-exvs-analyzer

--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -5,7 +5,7 @@ config:
   exvs-app:domain: stg.exvs-analyzer.com
   exvs-app:firestoreDatabase: exvs-analyzer
   exvs-app:image:
-    secure: v1:jrfjMWFRi0XmUnVT:cZhdW1dQmP55+8CUuZJ22fO6TCIoeLGWzU0OLDcCKBMdiwF2MacI1JirT0JmviUbE2oDZxI+Fkp2LIJJ5mOpGaw3Wkd+Ag7fXBeTt6YSl9YCeubSmnsM/S5DLYwM6ImrIS9mxtHY9pLWbLVhHiB61qV8uJ8e9g==
+    secure: v1:LslaisMjmCsneZyJ:LpMhi8IkNUFYIytfws+TjXPLjYtLBwZxvr0yamAlQVhxNZGaXza8uX8Qs9mFvEKZexLBWrenwbmPqNiET3tJzBnTIa2+BztMtdijfT8k3G1ISoMuD8naoHyPw5kln0Iujur0NZEqyZwfq0H/X1+7/y9Br1RqWg==
   exvs-app:maxInstances: "1"
   exvs-app:memory: 512Mi
   exvs-app:serviceName: stg-exvs-analyzer

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"net/mail"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -268,7 +269,7 @@ func StartServer() {
 		log.Printf("[WARN] Failed to register webmanifest MIME type: %v", err)
 	}
 	fs := http.FileServer(http.Dir("static"))
-	http.Handle("/", fs)
+	http.Handle("/", staticCacheControl(fs))
 
 	log.Printf("[INFO] Server starting on port %s", port)
 	handler := basicAuth(securityHeaders(http.DefaultServeMux), "/health")
@@ -382,6 +383,21 @@ func handleMatches(w http.ResponseWriter, r *http.Request) {
 }
 
 // securityHeaders は全レスポンスにセキュリティヘッダーを付与する
+// staticCacheControl は HTML/JS を常に再検証（no-cache）させる。
+// アセットにバージョニングが無いため、デプロイ直後にブラウザが古いHTMLと新しいJS
+// （またはその逆）を混在してキャッシュし、レイアウトが崩れるのを防ぐ。FileServer の
+// Last-Modified / If-Modified-Since により実体が変わらなければ 304 で返るため負荷は小さい。
+// 画像や webmanifest 等は変更頻度が低くヒューリスティックキャッシュで問題ないため対象外。
+func staticCacheControl(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		if p == "/" || strings.HasSuffix(p, ".html") || strings.HasSuffix(p, ".js") {
+			w.Header().Set("Cache-Control", "no-cache")
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func securityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -224,13 +224,16 @@ function FilterForm({ filters, options, onField, onReset, resultCount }) {
 var METRIC_LABELS = SORT_OPTIONS.reduce(function (m, o) { m[o.key] = o.label; return m; }, {});
 
 // 機体サムネイル。画像URLが引ければ画像、無ければ機体名テキストにフォールバック。
+// フレックスアイテムはラッパー(.search-ms-slot)側にし、画像/テキストは width:100% で内側に収める。
+// img自体をフレックスアイテム＋aspect-ratioにすると iOS18 Safari が min-width:0 を無視して
+// 本来サイズで min-content を算出し、カードから溢れるため（iOS26では解消）。
 function MsThumb({ name, msImages }) {
   var nm = (name || '').trim();
   var url = nm && msImages ? msImages[nm] : '';
-  if (url) {
-    return html`<img class="search-ms-thumb" src=${url} alt=${nm} title=${nm} loading="lazy" />`;
-  }
-  return html`<span class="search-ms-thumb search-ms-thumb-text" title=${nm}>${esc(nm || '?')}</span>`;
+  var inner = url
+    ? html`<img class="search-ms-thumb" src=${url} alt=${nm} title=${nm} loading="lazy" />`
+    : html`<span class="search-ms-thumb search-ms-thumb-text" title=${nm}>${esc(nm || '?')}</span>`;
+  return html`<span class="search-ms-slot">${inner}</span>`;
 }
 
 // プレイヤー名を整形（空は「—」）。名前は最大12文字。

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -263,10 +263,11 @@ function ResultItem({ match, msImages, sortKey, onOpen }) {
       </div>
     </div>
     <div class="search-item-namesrow">
-      <div class="search-item-names">
-        <div class="search-name-line self" title=${playerName(match.name)}>${esc(playerName(match.name))}</div>
+      <div class="search-item-names self">
+        <div class="search-name-line" title=${playerName(match.name)}>${esc(playerName(match.name))}</div>
         <div class="search-name-line" title=${playerName(match.partner_name)}>${esc(playerName(match.partner_name))}</div>
       </div>
+      <span class="search-names-vs" aria-hidden="true"></span>
       <div class="search-item-names enemy">
         <div class="search-name-line" title=${playerName(match.opponent1_name)}>${esc(playerName(match.opponent1_name))}</div>
         <div class="search-name-line" title=${playerName(match.opponent2_name)}>${esc(playerName(match.opponent2_name))}</div>

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -267,7 +267,6 @@ function ResultItem({ match, msImages, sortKey, onOpen }) {
         <div class="search-name-line" title=${playerName(match.name)}>${esc(playerName(match.name))}</div>
         <div class="search-name-line" title=${playerName(match.partner_name)}>${esc(playerName(match.partner_name))}</div>
       </div>
-      <span class="search-names-vs" aria-hidden="true"></span>
       <div class="search-item-names enemy">
         <div class="search-name-line" title=${playerName(match.opponent1_name)}>${esc(playerName(match.opponent1_name))}</div>
         <div class="search-name-line" title=${playerName(match.opponent2_name)}>${esc(playerName(match.opponent2_name))}</div>

--- a/static/index.html
+++ b/static/index.html
@@ -454,10 +454,12 @@
     .search-item-battle { display: flex; align-items: center; gap: 10px; }
     .search-ms-imgs { flex: 1; min-width: 0; display: flex; gap: 6px; align-items: center; }
     .search-ms-imgs.enemy { justify-content: flex-end; }
-    /* 幅はフレックス配分(basis 0)で決め、intrinsicサイズを基準にしない。
-       iOS18以前のSafariは aspect-ratio + flex-basis:74px の img で intrinsic 幅を採用して縮まず、
-       カードから溢れてレイアウトが崩れる（iOS26では修正済み）。basis 0 + max-width で回避する。 */
-    .search-ms-thumb { flex: 1 1 0; min-width: 0; max-width: 74px; height: auto; aspect-ratio: 1 / 1; border-radius: 8px; border: 1px solid var(--line); object-fit: cover; background: var(--bg); }
+    /* フレックスアイテムはラッパー(.search-ms-slot)側。幅はフレックス配分(basis 0)で確定させ、
+       画像/テキストは width:100% で内側に収める。img自体をフレックスアイテム＋aspect-ratioにすると
+       iOS18以前のSafariが min-width:0 を無視して本来サイズで min-content を算出し、カードから
+       溢れてレイアウトが崩れる（iOS26では解消）。ラッパー方式でそのバグ経路を避ける。 */
+    .search-ms-slot { flex: 1 1 0; min-width: 0; max-width: 74px; }
+    .search-ms-thumb { display: block; width: 100%; height: auto; aspect-ratio: 1 / 1; border-radius: 8px; border: 1px solid var(--line); object-fit: cover; background: var(--bg); }
     .search-ms-thumb-text { display: flex; align-items: center; justify-content: center; text-align: center; padding: 3px; font-size: 0.66em; line-height: 1.2; color: var(--muted); overflow: hidden; }
     /* 公式スプライト win_lose_vs.png(451x138) から VS 部分だけを background-position で切り出す */
     .search-item-vs { flex-shrink: 0; width: 54px; height: 44px;

--- a/static/index.html
+++ b/static/index.html
@@ -459,7 +459,9 @@
        iOS18以前のSafariが min-width:0 を無視して本来サイズで min-content を算出し、カードから
        溢れてレイアウトが崩れる（iOS26では解消）。ラッパー方式でそのバグ経路を避ける。 */
     .search-ms-slot { flex: 1 1 0; min-width: 0; max-width: 74px; }
-    .search-ms-thumb { display: block; width: 100%; height: auto; aspect-ratio: 1 / 1; border-radius: 8px; border: 1px solid var(--line); object-fit: cover; background: var(--bg); }
+    /* max-width はスロットで効くが、アセット混在（古いJSでラッパー無し等）でも巨大化しないよう
+       サムネイル自身にも上限を持たせる保険。 */
+    .search-ms-thumb { display: block; width: 100%; max-width: 74px; height: auto; aspect-ratio: 1 / 1; border-radius: 8px; border: 1px solid var(--line); object-fit: cover; background: var(--bg); }
     .search-ms-thumb-text { display: flex; align-items: center; justify-content: center; text-align: center; padding: 3px; font-size: 0.66em; line-height: 1.2; color: var(--muted); overflow: hidden; }
     /* 公式スプライト win_lose_vs.png(451x138) から VS 部分だけを background-position で切り出す */
     .search-item-vs { flex-shrink: 0; width: 54px; height: 44px;

--- a/static/index.html
+++ b/static/index.html
@@ -468,17 +468,16 @@
       background-image: url("https://resource.exvs2ib.vsmobile.jp/css/images/common/win_lose_vs.png");
       background-repeat: no-repeat; background-size: 161px 49px; background-position: -99px 0;
       filter: drop-shadow(0 1px 2px rgba(0,0,0,0.5)); }
-    /* 名前行: 画像行と同一構造にして各機体の真下に名前を配置する。
-       自陣(自機+僚機) / VSスペーサ(54px) / 敵陣(敵1+敵2)。各名前は対応する機体スロットと
-       同じ flex:1 1 0 / max-width:74px で並べ、中心が画像の中心に一致する。 */
-    .search-item-namesrow { display: flex; align-items: flex-start; gap: 10px; margin-top: 2px; }
-    .search-item-names { flex: 1; min-width: 0; display: flex; gap: 6px; }
-    .search-item-names.enemy { justify-content: flex-end; }
-    .search-names-vs { flex-shrink: 0; width: 54px; }
-    /* 各名前は機体1枚の直下（最大74px）。収まらない名前は省略（title属性でフル表示）。 */
-    .search-name-line { flex: 1 1 0; min-width: 0; max-width: 74px; text-align: center; font-size: 0.72em; line-height: 1.3; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    @media (max-width: 480px) { .search-name-line { font-size: 0.66em; } }
-    @media (max-width: 380px) { .search-name-line { font-size: 0.6em; } }
+    /* 名前行: チーム単位で縦2段（自機+僚機 / 敵1+敵2）。自陣は左寄せ・敵陣は右寄せで
+       各チームが半カード幅を使えるため、名前は省略されずフル表示になる。長い名前は横に溢れず
+       最大2行で折り返し、超過分のみ末尾を省略する。 */
+    .search-item-namesrow { display: flex; align-items: flex-start; gap: 12px; margin-top: 2px; }
+    .search-item-names { flex: 1 1 0; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+    .search-item-names.enemy { align-items: flex-end; text-align: right; }
+    /* 名前は最大2行。半幅に収まらない長い名前は折り返し、2行を超える分だけ省略する。 */
+    .search-name-line { font-size: 0.74em; line-height: 1.3; color: var(--muted); max-width: 100%; overflow: hidden; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; overflow-wrap: anywhere; }
+    @media (max-width: 480px) { .search-name-line { font-size: 0.68em; } }
+    @media (max-width: 380px) { .search-name-line { font-size: 0.62em; } }
     .search-empty { color: var(--muted); text-align: center; padding: 24px 0; }
 
     .search-pager { display: flex; align-items: center; justify-content: center; gap: 12px; margin-top: 16px; }

--- a/static/index.html
+++ b/static/index.html
@@ -468,12 +468,15 @@
       background-image: url("https://resource.exvs2ib.vsmobile.jp/css/images/common/win_lose_vs.png");
       background-repeat: no-repeat; background-size: 161px 49px; background-position: -99px 0;
       filter: drop-shadow(0 1px 2px rgba(0,0,0,0.5)); }
-    /* 名前行: 画像の下に全幅で配置し左右50/50。各欄が半カード幅を使えるのでスマホでも文字が入る */
-    .search-item-namesrow { display: flex; gap: 12px; margin-top: 2px; }
-    .search-item-names { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
-    .search-item-names.enemy { align-items: flex-end; text-align: right; }
-    /* プレイヤー名は最大12文字。小さめ＋省略(保険)。狭幅では更に縮小して12文字を確保 */
-    .search-name-line { font-size: 0.74em; line-height: 1.35; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+    /* 名前行: 画像行と同一構造にして各機体の真下に名前を配置する。
+       自陣(自機+僚機) / VSスペーサ(54px) / 敵陣(敵1+敵2)。各名前は対応する機体スロットと
+       同じ flex:1 1 0 / max-width:74px で並べ、中心が画像の中心に一致する。 */
+    .search-item-namesrow { display: flex; align-items: flex-start; gap: 10px; margin-top: 2px; }
+    .search-item-names { flex: 1; min-width: 0; display: flex; gap: 6px; }
+    .search-item-names.enemy { justify-content: flex-end; }
+    .search-names-vs { flex-shrink: 0; width: 54px; }
+    /* 各名前は機体1枚の直下（最大74px）。収まらない名前は省略（title属性でフル表示）。 */
+    .search-name-line { flex: 1 1 0; min-width: 0; max-width: 74px; text-align: center; font-size: 0.72em; line-height: 1.3; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     @media (max-width: 480px) { .search-name-line { font-size: 0.66em; } }
     @media (max-width: 380px) { .search-name-line { font-size: 0.6em; } }
     .search-empty { color: var(--muted); text-align: center; padding: 24px 0; }


### PR DESCRIPTION
## 概要

iPhone15 / iOS18 環境で試合検索画面（SearchView）の対戦カードのレイアウトが崩れる不具合を修正する。あわせて、デプロイ直後にアセットの新旧がブラウザで混在キャッシュされてレイアウトが崩れる問題への恒久対策を入れる。iOS26 / Chrome では元々崩れていなかったが、本修正は全環境で従来と同じ見た目になる。

## 原因

機体サムネイル `<img.search-ms-thumb>` を `flex` アイテムにして `aspect-ratio: 1/1` を持たせていた。iOS18以前のSafariは、この構成の置換要素で `min-width: 0` を無視して画像の本来サイズから min-content を算出するバグがあり、カードがビューポート幅を超えて敵機画像が見切れていた。

## 変更点

- **`static/components/search.js`**: `MsThumb` を変更し、フレックスアイテムをラッパー `<span class="search-ms-slot">` に移動。画像/テキストは `width:100%` で内側に収める。フレックスアイテムが非置換要素になるため、画像の本来サイズがサイズ計算に混入せず、当該バグ経路を構造的に回避する。
- **`static/index.html`**: `.search-ms-slot` に幅上限（`flex:1 1 0; max-width:74px`）を定義。保険として `.search-ms-thumb` 自身にも `max-width:74px` を付与し、アセット混在時でも巨大化しないようにする。
- **`internal/server/server.go`**: 静的配信をラップし、`HTML/JS` に `Cache-Control: no-cache` を付与。アセットにバージョニングが無いため常に再検証させ、HTMLとJSが必ず同一デプロイの組で読まれるようにする（`FileServer` の `Last-Modified`/`If-Modified-Since` で実体不変なら304、負荷は小さい）。画像・webmanifest等は対象外。

## 検証

- Chromium(Playwright) で対戦カードを再現し、320〜1080px の全幅で横オーバーフロー無し・サムネイルは正方形・74px上限を確認。
- 新JS+旧CSSの混在を再現し「サムネイル巨大化」を再現、`Cache-Control: no-cache` とCSS保険で解消することを確認。
- ローカル起動で `HTML/JS` に `Cache-Control: no-cache` が付き、画像には付かないことを確認。
- `gofmt` / `go build` / `go vet` / `node --test`（JS 113件）いずれも全緑。
- stg にデプロイ済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzgfzKC33uRa4PUof8pWyh

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzgfzKC33uRa4PUof8pWyh)_