### PR TITLE
UI改善: 勝率以外のパーセント表示を削除

### DIFF
--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -5,7 +5,7 @@ config:
   exvs-app:domain: stg.exvs-analyzer.com
   exvs-app:firestoreDatabase: exvs-analyzer
   exvs-app:image:
-    secure: v1:hySVyZoGvjkdyGGt:PLZpTVNoQKTT7ff0PZwoN9nQ4BE8QozL+Uo9dT/vDcTxT8fvuDwETNJlpGxrEeZ31tV2DHOQbkTOzAoZHUrP24fP0Bt5cjlIlxSW8mAB2hOkQGg+TIVGahplh1FSZwjCG+2/JKeQuXp0TH7KldBb6rrbrlo7Hg==
+    secure: v1:ifloWc4YvtuMMwth:Y/V1DgHnCrTtXovPtzLNzPK9ZAV+Kjtjxseq2d/bueB6LzB4WvNloZRMNTJ8Askjzwi9r1VzDwM6Jy48nfsQ3dzG212XH927tqdrQiQd8VPyrLcr6hFH7Vohmic1dbB/2AWSbKZOw/crmNxvgVjqgl3hybOpTQ==
   exvs-app:maxInstances: "1"
   exvs-app:memory: 512Mi
   exvs-app:serviceName: stg-exvs-analyzer

--- a/static/components/charts.js
+++ b/static/components/charts.js
@@ -605,12 +605,12 @@ export function FallOrderContent({ fallOrder }) {
   var s = fallOrder.second_fall;
   var st = fallOrder.same_time;
   var rows = [
-    ['0落ち', n.count + '戦 (' + n.rate + '%)', colorPct(n.win_rate), colorDmgGiven(n.avg_dmg_given), colorDmgTaken(n.avg_dmg_taken), colorDE(n.dmg_efficiency, 3)],
-    ['先落ち', f.count + '戦 (' + f.rate + '%)', colorPct(f.win_rate), colorDmgGiven(f.avg_dmg_given), colorDmgTaken(f.avg_dmg_taken), colorDE(f.dmg_efficiency, 3)],
-    ['後落ち', s.count + '戦 (' + s.rate + '%)', colorPct(s.win_rate), colorDmgGiven(s.avg_dmg_given), colorDmgTaken(s.avg_dmg_taken), colorDE(s.dmg_efficiency, 3)],
+    ['0落ち', n.count + '戦', colorPct(n.win_rate), colorDmgGiven(n.avg_dmg_given), colorDmgTaken(n.avg_dmg_taken), colorDE(n.dmg_efficiency, 3)],
+    ['先落ち', f.count + '戦', colorPct(f.win_rate), colorDmgGiven(f.avg_dmg_given), colorDmgTaken(f.avg_dmg_taken), colorDE(f.dmg_efficiency, 3)],
+    ['後落ち', s.count + '戦', colorPct(s.win_rate), colorDmgGiven(s.avg_dmg_given), colorDmgTaken(s.avg_dmg_taken), colorDE(s.dmg_efficiency, 3)],
   ];
   if (st.count > 0) {
-    rows.push(['同時落ち', st.count + '戦 (' + st.rate + '%)', colorPct(st.win_rate), colorDmgGiven(st.avg_dmg_given), colorDmgTaken(st.avg_dmg_taken), colorDE(st.dmg_efficiency, 3)]);
+    rows.push(['同時落ち', st.count + '戦', colorPct(st.win_rate), colorDmgGiven(st.avg_dmg_given), colorDmgTaken(st.avg_dmg_taken), colorDE(st.dmg_efficiency, 3)]);
   }
   return html`<div>
     <p>対象: ${fallOrder.total}戦</p>
@@ -622,10 +622,10 @@ export function FallOrderContent({ fallOrder }) {
 export function BurstTimingContent({ timingData }) {
   if (!timingData || !timingData.by_timing || !timingData.by_timing.length) return null;
   var rows = timingData.by_timing.map(function (t) {
-    return [t.label, t.count + '戦 (' + t.rate + '%)', colorPct(t.win_rate)];
+    return [t.label, t.count + '戦', colorPct(t.win_rate)];
   });
   return html`<div>
-    <p>覚醒発動時の被撃墜数で分類（対象: ${timingData.total}戦）<br />1試合で複数のタイミングに覚醒した場合は各タイミングに計上（割合の合計は100%を超えることがあります）</p>
+    <p>覚醒発動時の被撃墜数で分類（対象: ${timingData.total}戦）<br />1試合で複数のタイミングに覚醒した場合は各タイミングに計上</p>
     <${Table} headers=${['タイミング', '試合数', '勝率']} rows=${rows} />
     <${Tips} tips=${timingData.tips} />
   </div>`;
@@ -634,7 +634,7 @@ export function BurstTimingContent({ timingData }) {
 export function BurstTypeContent({ typeData }) {
   if (!typeData || !typeData.by_type || !typeData.by_type.length) return null;
   var rows = typeData.by_type.map(function (t) {
-    return [t.label, t.count + '回 (' + t.rate + '%)', t.matches + '戦', colorPct(t.win_rate)];
+    return [t.label, t.count + '回', t.matches + '戦', colorPct(t.win_rate)];
   });
   return html`<div>
     <p>F/S/E覚醒の使用傾向（対象: ${typeData.total_bursts}回発動）</p>

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -570,7 +570,7 @@ export function SearchView({ matches, msImages }) {
 
     <div class="panel">
       <div class="search-result-head">
-        <h2><span class="dot" /><span class="search-result-label">検索結果 </span><span class="search-result-count">${total}戦（${winRate}%）</span></h2>
+        <h2><span class="dot" /><span class="search-result-label">検索結果 </span><span class="search-result-count">${total}戦（${winRate.toFixed(1)}%）</span></h2>
         <div class="search-result-tools">
           <div class="search-pagesize">
             <${Dropdown} value=${String(pageSize)} noClear=${true}


### PR DESCRIPTION
勝率まわりのパーセント表示に関するUI改善。以下の2点を含む。

## 1. 勝率以外のパーセント表示を削除
立ち回り/覚醒タブのテーブルで、試合数・発動数カウントの横に併記していた非勝率の割合 (NN%) を削除する。対象は「先落ち/後落ち分析」「覚醒タイミング」「覚醒タイプ別傾向」の3テーブル。割合列を消すため、覚醒タイミングの説明文から「割合の合計は100%を超える」の注記も除去した。

勝率・ダメージ貢献率パネル・ヒント文（先落ち率/使用率）は従来どおり残す。

## 2. 試合検索の勝率%を小数第1位で表示
検索結果ヘッダ「NNNN戦（NN.N%）」の勝率が整数のとき末尾の `.0` が落ちて「68%」と表示されていたため、`toFixed(1)` で常に小数第1位（例「68.0%」）まで表示するよう統一した。

## 変更ファイル
- `static/components/charts.js`（1）
- `static/components/search.js`（2）

## テスト
- `node --test 'static/__tests__/*.test.js'`（JSテスト）全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DRCvxcf8K97G1kQCuRgMN