### PR TITLE
試合検索でタイムアップ試合を明示表示

### DIFF
--- a/static/__tests__/format.test.js
+++ b/static/__tests__/format.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { esc, pct, num, cellValue, cellDisplay } from '../lib/format.js';
+import { esc, pct, num, cellValue, cellDisplay, isTimeUp, TIMEUP_SEC } from '../lib/format.js';
 
 // --- esc ---
 
@@ -106,5 +106,25 @@ describe('cellDisplay', function () {
 
   it('handles null', function () {
     assert.equal(cellDisplay(null), null);
+  });
+});
+
+// --- isTimeUp ---
+
+describe('isTimeUp', function () {
+  it('returns true when game_end_sec reaches the time limit', function () {
+    assert.equal(isTimeUp({ game_end_sec: TIMEUP_SEC }), true);
+    assert.equal(isTimeUp({ game_end_sec: TIMEUP_SEC + 5 }), true);
+  });
+
+  it('returns false when the match ended before the time limit', function () {
+    assert.equal(isTimeUp({ game_end_sec: 143 }), false);
+    assert.equal(isTimeUp({ game_end_sec: TIMEUP_SEC - 1 }), false);
+  });
+
+  it('returns false when game_end_sec is missing or zero', function () {
+    assert.equal(isTimeUp({ game_end_sec: 0 }), false);
+    assert.equal(isTimeUp({}), false);
+    assert.equal(isTimeUp(null), false);
   });
 });

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -4,7 +4,7 @@ import {
   filterMatches, sortMatches, SORT_OPTIONS,
 } from '../analysis/search.js';
 import {
-  esc, num, cellDisplay,
+  esc, num, cellDisplay, isTimeUp,
   colorKillsInt, colorDeathsInt, colorDmgGiven, colorDmgTaken, colorExDmg,
 } from '../lib/format.js';
 import { CompareRadar } from './charts.js';
@@ -248,6 +248,7 @@ function ResultItem({ match, msImages, sortKey, onOpen }) {
   return html`<button class="search-item" onClick=${function () { onOpen(match); }}>
     <div class="search-item-top">
       <span class=${'badge ' + (match.win ? 'win' : 'lose')}>${match.win ? 'WIN' : 'LOSE'}</span>
+      ${isTimeUp(match) && html`<span class="badge-timeup" title="制限時間切れ（勝敗はスコアで決定）">タイムアップ</span>`}
       <span class="search-item-date">${esc(match.date)}</span>
       ${metricLabel && html`<span class="search-item-metric">${metricLabel} ${num(match[sortKey])}</span>`}
     </div>
@@ -434,6 +435,7 @@ function DetailModal({ match, msImages, onClose }) {
       <div class="search-detail-head">
         <div>
           <span class=${'badge ' + (match.win ? 'win' : 'lose')}>${match.win ? 'WIN' : 'LOSE'}</span>
+          ${isTimeUp(match) && html`<span class="badge-timeup" title="制限時間切れ（勝敗はスコアで決定）">タイムアップ</span>`}
           <span class="search-detail-date">${esc(match.date)}</span>
         </div>
         <button class="search-detail-close" onClick=${onClose} aria-label="閉じる">✕</button>

--- a/static/index.html
+++ b/static/index.html
@@ -160,6 +160,8 @@
     .badge { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: .72em; font-weight: 700; }
     .badge.win { background: rgba(105,240,174,.15); color: var(--great); }
     .badge.lose { background: rgba(239,83,80,.15); color: var(--terrible); }
+    /* タイムアップ（制限時間切れ）試合を示す補助バッジ。勝敗バッジの隣に添える。 */
+    .badge-timeup { display: inline-block; margin-left: 6px; padding: 2px 8px; border-radius: 999px; font-size: .68em; font-weight: 700; background: rgba(255,193,7,.15); color: #ffc107; }
 
     /* ===== Report tables / sections (reused leaf components) ===== */
     .report h1 { font-size: 1.5em; margin: 20px 0 10px; text-align: left; }

--- a/static/lib/format.js
+++ b/static/lib/format.js
@@ -17,6 +17,15 @@ export function boldText(s) {
 export function pct(n) { return n != null ? n.toFixed(1) + '%' : '-'; }
 export function num(n, d) { return n != null ? n.toFixed(d != null ? d : 0) : '-'; }
 
+// 試合の制限時間（秒）。この時間まで経過した試合はタイムアップとなり、勝敗はスコアで決まる。
+export var TIMEUP_SEC = 240;
+
+// タイムアップ（制限時間切れ）で決着した試合か。game_end_secが制限時間に達していれば真。
+// 勝敗自体は既に正しく判定済みで、これは表示用の付加情報。
+export function isTimeUp(match) {
+  return !!(match && match.game_end_sec != null && match.game_end_sec >= TIMEUP_SEC);
+}
+
 function valClass4(n, great, good, bad, terrible, higherIsBetter) {
   if (n == null) return '';
   if (higherIsBetter) {


### PR DESCRIPTION
240秒（制限時間）まで経過した試合はタイムアップとなり勝敗はスコアで決まる。
勝敗判定自体は既に正しいため、WIN/LOSEバッジの隣に「タイムアップ」補助バッジを
添えて視覚的に区別できるようにした。

- format.js に isTimeUp(match) / TIMEUP_SEC(240) を追加（game_end_sec で判定）
- 検索結果カードと詳細モーダルの両方にバッジを表示
- format.test.js に isTimeUp のテストを追加

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017uf9T18buWDsb3Hm84EhHe