### PR TITLE
試合経過タイムラインの時刻ラベル重なりを解消し点線補助線を追加

### DIFF
--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -5,7 +5,7 @@ config:
   exvs-app:domain: stg.exvs-analyzer.com
   exvs-app:firestoreDatabase: exvs-analyzer
   exvs-app:image:
-    secure: v1:3N1GQWpCtuVM3+IR:XBbsVg0ONKU5qFVc+AjFYR1X6LEmc8yLZedWbFCV3y+8tKXUzyH6KgoJ73ygjF+PTIzSoljj4SjJ7uG5VoXLYJCqaKxYB9djsdcjJ40X2mWpWwoAT5BURmnt3MCdeIAFzqScajdarRomx+SadNMbAI5O+KDwQA==
+    secure: v1:9OtgV35VuOnbXFgd:GXZWK4swEu4k74HWO6YGDwQlm5Yccb1tLfOc7VDWk3p9pM68hB76OqvtkofEm6rYonXfOrVPGkjIBcAFevZj4s5nj97sMLASbd1uq5jOPPh7AzuiQCywWV+q03IUHR2kpilLrherT5ctmv1kPRg+pmCu495R5w==
   exvs-app:maxInstances: "1"
   exvs-app:memory: 512Mi
   exvs-app:serviceName: stg-exvs-analyzer

--- a/infra/app/Pulumi.stg.yaml
+++ b/infra/app/Pulumi.stg.yaml
@@ -5,7 +5,7 @@ config:
   exvs-app:domain: stg.exvs-analyzer.com
   exvs-app:firestoreDatabase: exvs-analyzer
   exvs-app:image:
-    secure: v1:hySVyZoGvjkdyGGt:PLZpTVNoQKTT7ff0PZwoN9nQ4BE8QozL+Uo9dT/vDcTxT8fvuDwETNJlpGxrEeZ31tV2DHOQbkTOzAoZHUrP24fP0Bt5cjlIlxSW8mAB2hOkQGg+TIVGahplh1FSZwjCG+2/JKeQuXp0TH7KldBb6rrbrlo7Hg==
+    secure: v1:3N1GQWpCtuVM3+IR:XBbsVg0ONKU5qFVc+AjFYR1X6LEmc8yLZedWbFCV3y+8tKXUzyH6KgoJ73ygjF+PTIzSoljj4SjJ7uG5VoXLYJCqaKxYB9djsdcjJ40X2mWpWwoAT5BURmnt3MCdeIAFzqScajdarRomx+SadNMbAI5O+KDwQA==
   exvs-app:maxInstances: "1"
   exvs-app:memory: 512Mi
   exvs-app:serviceName: stg-exvs-analyzer

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -30,14 +30,6 @@ var GANTT_LEGEND = [
   ['ov', 'OLスタンバイ'], ['ov-on', 'OL発動'],
 ];
 
-// 秒数を M:SS 形式に整形する。
-function fmtSec(sec) {
-  if (sec == null || isNaN(sec)) return '';
-  var s = Math.max(0, Math.round(sec));
-  var m = Math.floor(s / 60);
-  return m + ':' + String(s % 60).padStart(2, '0');
-}
-
 // 機体/タッグ/コスト編成用の複数選択（OR）。集計結果 [{name, matches}] を渡す。
 // 選択後のトリガーは名前のみ（chip）、ドロップダウン内は「名前（N戦）」を出す。
 function MsMulti({ values, onChange, options }) {
@@ -308,8 +300,8 @@ function Timeline({ match, msImages }) {
     }
     return barEl;
   }
-  // 補助線＋目盛り。30秒ごとに点線の補助線、1分ごと(major)にラベルを付ける。
-  // 以前は10秒刻みでラベルを出しており、隣同士が重なって判読できなかった（公式は分刻み）。
+  // 補助線＋目盛り。30秒ごとに点線の補助線、1分ごと(major)に秒数ラベル(60/120/180)を付ける。
+  // 以前は10秒刻みでラベルを出しており、隣同士が重なって判読できなかった。
   var grid = [];
   for (var t = 30; t < raw; t += 30) grid.push({ sec: t, major: t % 60 === 0 });
   var labels = grid.filter(function (g) { return g.major; });
@@ -342,7 +334,7 @@ function Timeline({ match, msImages }) {
     </div>
     <div class="gantt-axis">
       ${labels.map(function (g) {
-        return html`<span class="gantt-tick" style=${'left:' + pct(g.sec) + '%'}>${fmtSec(g.sec)}</span>`;
+        return html`<span class="gantt-tick" style=${'left:' + pct(g.sec) + '%'}>${g.sec}</span>`;
       })}
     </div>
     <div class="gantt-legend">

--- a/static/components/search.js
+++ b/static/components/search.js
@@ -308,32 +308,41 @@ function Timeline({ match, msImages }) {
     }
     return barEl;
   }
-  // 10秒刻みの目盛り（実終了時刻まで。余白部分には目盛りを出さない）。
-  var ticks = [];
-  for (var t = 0; t <= raw; t += 10) ticks.push(t);
+  // 補助線＋目盛り。30秒ごとに点線の補助線、1分ごと(major)にラベルを付ける。
+  // 以前は10秒刻みでラベルを出しており、隣同士が重なって判読できなかった（公式は分刻み）。
+  var grid = [];
+  for (var t = 30; t < raw; t += 30) grid.push({ sec: t, major: t % 60 === 0 });
+  var labels = grid.filter(function (g) { return g.major; });
 
   return html`<div class="gantt">
-    ${rows.map(function (r) {
-      var acts = r.actions || [];
-      var lane0 = acts.filter(function (a) { return GANTT_BAR[a.action] && GANTT_BAR[a.action].lane === 0; });
-      var lane1 = acts.filter(function (a) { return GANTT_BAR[a.action] && GANTT_BAR[a.action].lane === 1; });
-      var deaths = acts.filter(function (a) { return a.action === 'death'; });
-      return html`<div class="gantt-row">
-        <${DetailThumb} name=${r.ms} msImages=${msImages} />
-        <div class="gantt-track">
-          <div class="gantt-lane">
-            ${lane0.map(bar)}
-            ${deaths.map(function (a) {
-              return html`<span class="gantt-death" style=${'left:' + pct(a.action_start_sec) + '%'}>✕</span>`;
-            })}
+    <div class="gantt-rows">
+      <div class="gantt-grid">
+        ${grid.map(function (g) {
+          return html`<span class=${'gantt-gridline' + (g.major ? ' gantt-gridline-major' : '')} style=${'left:' + pct(g.sec) + '%'}></span>`;
+        })}
+      </div>
+      ${rows.map(function (r) {
+        var acts = r.actions || [];
+        var lane0 = acts.filter(function (a) { return GANTT_BAR[a.action] && GANTT_BAR[a.action].lane === 0; });
+        var lane1 = acts.filter(function (a) { return GANTT_BAR[a.action] && GANTT_BAR[a.action].lane === 1; });
+        var deaths = acts.filter(function (a) { return a.action === 'death'; });
+        return html`<div class="gantt-row">
+          <${DetailThumb} name=${r.ms} msImages=${msImages} />
+          <div class="gantt-track">
+            <div class="gantt-lane">
+              ${lane0.map(bar)}
+              ${deaths.map(function (a) {
+                return html`<span class="gantt-death" style=${'left:' + pct(a.action_start_sec) + '%'}>✕</span>`;
+              })}
+            </div>
+            <div class="gantt-lane">${lane1.map(bar)}</div>
           </div>
-          <div class="gantt-lane">${lane1.map(bar)}</div>
-        </div>
-      </div>`;
-    })}
+        </div>`;
+      })}
+    </div>
     <div class="gantt-axis">
-      ${ticks.map(function (t) {
-        return html`<span class="gantt-tick" style=${'left:' + pct(t) + '%'}>${fmtSec(t)}</span>`;
+      ${labels.map(function (g) {
+        return html`<span class="gantt-tick" style=${'left:' + pct(g.sec) + '%'}>${fmtSec(g.sec)}</span>`;
       })}
     </div>
     <div class="gantt-legend">

--- a/static/index.html
+++ b/static/index.html
@@ -527,6 +527,11 @@
     .search-detail-empty { color: var(--muted); font-size: 0.88em; }
     /* 試合経過ガント（公式風の横棒タイムライン） */
     .gantt { display: flex; flex-direction: column; gap: 6px; }
+    /* 行の重なり領域。縦の補助線（点線）を全行にまたがって重ねる */
+    .gantt-rows { position: relative; display: flex; flex-direction: column; gap: 6px; }
+    .gantt-grid { position: absolute; top: 0; bottom: 0; left: 42px; right: 0; pointer-events: none; z-index: 4; }
+    .gantt-gridline { position: absolute; top: -2px; bottom: -2px; width: 0; border-left: 1px dashed rgba(255,255,255,0.09); }
+    .gantt-gridline-major { border-left-color: rgba(255,255,255,0.20); }
     .gantt-row { display: flex; align-items: center; gap: 8px; }
     .gantt-row .search-detail-thumb { width: 34px; height: 34px; margin: 0; flex-shrink: 0; }
     .gantt-track { position: relative; flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }


### PR DESCRIPTION
## 概要

試合詳細モーダルの「試合経過」ガントタイムラインで、時間軸の目盛りラベルが重なって判読できない不具合を修正する。あわせて時刻を読み取りやすくする縦の点線補助線を追加する。

## 背景 / 問題

時間軸のラベルを **10秒刻み**（`0:10` `0:20` `0:30` …）で描画していたため、隣接するラベル同士が重なり、実質的に読み取れない状態になっていた。

## 変更内容

- **目盛りラベルの間隔を変更**: 10秒刻み → **1分刻み**（60秒ごと）にラベルを表示し、重なりを解消
- **ラベル表記を秒数に変更**: `M:SS` 形式ではなく秒数そのもの（`60` `120` `180`）を表示
- **縦の点線補助線を追加**: 30秒ごとに点線の縦補助線を全4行にまたがって重ね、時刻を読み取りやすくした（1分の線はやや濃く強調）
- 未使用となった `fmtSec` ヘルパーを削除

## 変更ファイル

- `static/components/search.js` — 目盛り/補助線の生成ロジックと描画（`Timeline` コンポーネント）
- `static/index.html` — 補助線オーバーレイ（`.gantt-rows` / `.gantt-grid` / `.gantt-gridline`）のCSS追加

※ `infra/app/Pulumi.stg.yaml` の差分は、stg動作確認のためのデプロイ（`build.yml` 手動実行）で自動追加されたイメージ更新コミットによるもの。

## 検証

- `go vet ./...`: パス
- JSテスト（`node --test 'static/__tests__/*.test.js'`）: 113件全パス
- stg環境へデプロイし、実機で時刻ラベルの重なり解消・点線補助線の表示・秒数表記を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxNZHfTHX8DkhYy72ofgv3)_